### PR TITLE
feat: worktree-as-project refactor with Option B nested UI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -39,7 +39,7 @@ No other files need changes. The provider handles: session discovery, active ses
 Zustand stores (no Redux). Four stores, each owning a specific domain:
 
 - **terminalStore** — Terminal tabs, editor groups, split layout tree. Auto-persists AI session tabs to disk via debounced save. The layout is a recursive `LayoutNode` tree (group | split).
-- **projectStore** — Project list, drag-and-drop ordering, active session polling. Polls every 5s for active sessions across all providers.
+- **projectStore** — Project list, drag-and-drop ordering, active session tracking (event-driven via provider watchers; no polling).
 - **sessionStore** — Session history list (discovered from providers), search/filter.
 - **settingsStore** — App settings with immediate persistence.
 
@@ -72,20 +72,23 @@ AI session tabs are serialized to `sessions.json` in the Electron userData direc
 
 ## Code Review Policy
 
-After every major change (project refactors, new features, architectural changes — not minor styling tweaks or few-line fixes), automatically run a deep dual-model code review before committing:
+After every major change (project refactors, new features, architectural changes — not minor styling tweaks or few-line fixes), automatically run a deep dual-model code review before committing. The same procedure applies whenever the user explicitly asks to "run a code review" (or similar wording).
 
 1. Launch **two parallel code-review agents** using the `task` tool with `agent_type: "code-review"`:
    - One with `model: "claude-opus-4.7"` 
    - One with `model: "gpt-5.4"`
 2. Both reviews must cover **all** of the following:
-   - **Dead code** — unused imports, variables, functions, types, exports
-   - **Memory leaks** — event listener cleanup, subscription management, timer cleanup, React effect cleanup
-   - **Security** — XSS vectors, unsafe eval, prototype pollution, path traversal
+   - **Dead code** — unused imports, variables, functions, classes, types, exports, IPC handlers, and anything else that is no longer referenced
+   - **Duplicate code** — near-identical logic across files that should be extracted into a shared helper/module for reuse
+   - **Memory leaks** — event listener cleanup, subscription management, timer/interval cleanup, React effect cleanup, PTY/watcher disposal
+   - **Security** — XSS vectors, unsafe eval, prototype pollution, path traversal, shell injection, exposure of secrets
    - **Race conditions** — async conflicts, stale closures, missing cancellation
-   - **Performance** — unnecessary re-renders, missing memoization, O(n²) loops
+   - **Performance** — unnecessary re-renders, missing memoization, O(n²) loops, redundant polling mechanisms, irrelevant or duplicated file watching, non-optimized queries/IPC round-trips
+   - **Best practices** — verify established patterns and idioms are followed; call out anti-patterns
+   - **Cross-platform support** — no implementation that only works on one OS. The project must support **macOS, Windows, and Linux**. Flag hardcoded path separators, shell invocations, signals, env vars, or APIs that don't work on all three.
    - **Correctness** — logic errors, edge cases, null/undefined handling, type safety
-   - **Clean code** — consistent patterns, clear naming, appropriate abstractions, reusability
-   - **File size** — no oversized files with too many responsibilities; split when needed
+   - **Clean, reusable, maintainable code** — consistent patterns, clear naming, appropriate abstractions, DRY
+   - **File size & separation of concerns** — no oversized files mixing multiple unrelated areas. Each file should own a single, well-defined area. Split files that handle multiple concerns into isolated, area-specific files/classes.
    - **Design patterns** — proper separation of concerns, DRY, extensibility
 3. Wait for both reviews to complete, then **fix all genuine issues** before committing.
 4. Report a summary of findings and fixes to the user.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,5 +1,7 @@
 import { app, shell, BrowserWindow, ipcMain, dialog, nativeImage } from 'electron'
 import { join } from 'path'
+import * as path from 'path'
+import { randomUUID } from 'crypto'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import * as fs from 'fs'
 import * as os from 'os'
@@ -27,7 +29,18 @@ import {
 } from './services/notifications'
 import * as attentionService from './services/attentionService'
 import { makeCompositeId } from '../preload/attentionTypes'
-import { getBranch, watchBranch, unwatchBranch, stopAllBranchWatchers } from './services/gitService'
+import {
+  getBranch,
+  watchBranch,
+  unwatchBranch,
+  stopAllBranchWatchers,
+  inspectPath
+} from './services/gitService'
+import * as worktreeService from './services/worktrees'
+import type {
+  CreateWorktreeOptions,
+  DeleteWorktreeOptions
+} from './services/worktrees/types'
 
 const providerRegistry = createDefaultRegistry()
 
@@ -397,43 +410,175 @@ function registerIpcHandlers(): void {
     return getBranch(dirPath)
   })
 
-  // Track per-subscription callback references — keyed by dirPath to support
-  // multiple projects in the same repo without overwriting each other
-  const gitWatchCallbacks = new Map<string, {
-    repoRoot: string
-    callback: (repoRoot: string, branch: string | null) => void
-  }>()
-
-  // Single shared callback that forwards to renderer
-  const sendBranchChange = (repoRoot: string, branch: string | null): void => {
-    if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('git:branchChanged', repoRoot, branch)
-    }
-  }
-
-  ipcMain.handle('git:watchBranch', async (_event, dirPath: string) => {
-    // If already watching this exact dirPath, just return the repo root
-    const existing = gitWatchCallbacks.get(dirPath)
-    if (existing) return existing.repoRoot
-
-    const callback = (root: string, branch: string | null): void => {
-      sendBranchChange(root, branch)
-    }
-
-    const repoRoot = await watchBranch(dirPath, callback)
-    if (repoRoot) {
-      gitWatchCallbacks.set(dirPath, { repoRoot, callback })
-    }
-    return repoRoot
+  ipcMain.handle('git:inspectPath', async (_event, dirPath: string) => {
+    return inspectPath(dirPath)
   })
 
-  ipcMain.on('git:unwatchBranch', (_event, repoRoot: string) => {
-    // Find and remove all subscriptions for this repo root
-    for (const [dirPath, entry] of gitWatchCallbacks) {
-      if (entry.repoRoot === repoRoot) {
-        unwatchBranch(repoRoot, entry.callback)
-        gitWatchCallbacks.delete(dirPath)
+  // Track per-subscription callback references — keyed by TOKEN so that
+  // multiple renderer-side consumers can watch the same repoRoot without
+  // tearing each other's subscriptions down on unwatch.
+  const gitWatchCallbacks = new Map<
+    string,
+    { repoRoot: string; callback: (repoRoot: string, branch: string | null) => void }
+  >()
+  // Per-webContents token set so we can tear everything down if the renderer
+  // reloads/crashes before git:unwatchBranch is called.
+  const gitWatchTokensByWebContents = new Map<number, Set<string>>()
+
+  const teardownGitWatchToken = (token: string): void => {
+    const entry = gitWatchCallbacks.get(token)
+    if (!entry) return
+    gitWatchCallbacks.delete(token)
+    unwatchBranch(entry.repoRoot, entry.callback)
+  }
+
+  ipcMain.handle('git:watchBranch', async (event, dirPath: string) => {
+    const sender = event.sender
+    const wcId = sender.id
+
+    // Install destroyed handler BEFORE awaiting so a reload/crash during
+    // watchBranch() still tears everything down.
+    let set = gitWatchTokensByWebContents.get(wcId)
+    if (!set) {
+      set = new Set()
+      gitWatchTokensByWebContents.set(wcId, set)
+      sender.once('destroyed', () => {
+        const tokens = gitWatchTokensByWebContents.get(wcId)
+        gitWatchTokensByWebContents.delete(wcId)
+        if (tokens) for (const t of tokens) teardownGitWatchToken(t)
+      })
+    }
+
+    const callback = (root: string, branch: string | null): void => {
+      if (!sender.isDestroyed()) {
+        sender.send('git:branchChanged', root, branch)
       }
+    }
+    const repoRoot = await watchBranch(dirPath, callback)
+    if (!repoRoot) return null
+    if (sender.isDestroyed()) {
+      unwatchBranch(repoRoot, callback)
+      return null
+    }
+    const token = randomUUID()
+    gitWatchCallbacks.set(token, { repoRoot, callback })
+    set.add(token)
+    return { token, repoRoot }
+  })
+
+  ipcMain.on('git:unwatchBranch', (event, token: string) => {
+    teardownGitWatchToken(token)
+    const set = gitWatchTokensByWebContents.get(event.sender.id)
+    if (set) set.delete(token)
+  })
+
+  // ── Worktrees ──────────────────────────────────────────────────────
+  // Track subscription tokens per webContents so we can clean up on reload/close.
+  const worktreeSubsByWebContents = new Map<number, Set<string>>()
+
+  ipcMain.handle('worktrees:list', (_event, repoRoot: string) => {
+    return worktreeService.list(repoRoot)
+  })
+
+  ipcMain.handle('worktrees:listBranches', (_event, repoRoot: string) => {
+    return worktreeService.listBranches(repoRoot)
+  })
+
+  ipcMain.handle('worktrees:create', (_event, opts: CreateWorktreeOptions) => {
+    return worktreeService.create(opts)
+  })
+
+  ipcMain.handle('worktrees:delete', (_event, opts: DeleteWorktreeOptions) => {
+    return worktreeService.remove(opts)
+  })
+
+  ipcMain.handle('worktrees:watchRepo', async (event, repoRoot: string) => {
+    const sender = event.sender
+    const wcId = sender.id
+
+    // Register the destroyed handler BEFORE awaiting so that if the
+    // webContents dies while watchRepo is resolving, the token we're about
+    // to create is still torn down.
+    let set = worktreeSubsByWebContents.get(wcId)
+    if (!set) {
+      set = new Set()
+      worktreeSubsByWebContents.set(wcId, set)
+      sender.once('destroyed', () => {
+        const tokens = worktreeSubsByWebContents.get(wcId)
+        worktreeSubsByWebContents.delete(wcId)
+        if (tokens) {
+          for (const t of tokens) worktreeService.unwatchRepo(t)
+        }
+      })
+    }
+
+    const result = await worktreeService.watchRepo(repoRoot, (payload) => {
+      if (!sender.isDestroyed()) {
+        sender.send('worktrees:changed', payload)
+      }
+    })
+    if (!result) return null
+
+    // If the webContents died during the await, unwatch immediately.
+    if (sender.isDestroyed()) {
+      worktreeService.unwatchRepo(result.token)
+      return null
+    }
+
+    set.add(result.token)
+    return result
+  })
+
+  ipcMain.on('worktrees:unwatchRepo', (event, token: string) => {
+    worktreeService.unwatchRepo(token)
+    const set = worktreeSubsByWebContents.get(event.sender.id)
+    if (set) set.delete(token)
+  })
+
+  ipcMain.handle('worktrees:refresh', (_event, repoRoot: string) => {
+    return worktreeService.refreshRepo(repoRoot)
+  })
+
+  ipcMain.handle('worktrees:reveal', async (_event, targetPath: string) => {
+    shell.showItemInFolder(targetPath)
+  })
+
+  ipcMain.handle(
+    'worktrees:recordSetupResult',
+    async (_event, repoRoot: string, worktreePath: string, exitCode: number) => {
+      await worktreeService.recordSetupResult(repoRoot, worktreePath, exitCode)
+    }
+  )
+
+  ipcMain.handle('worktrees:prepareSetupScript', async (_event, scriptBody: string) => {
+    const isWindows = process.platform === 'win32'
+    const ext = isWindows ? '.bat' : '.sh'
+    const tempPath = join(os.tmpdir(), `dplex-setup-${randomUUID()}${ext}`)
+    const body = isWindows
+      ? `@echo off\r\n${scriptBody.replace(/\r?\n/g, '\r\n')}\r\n`
+      : `#!/bin/sh\nset -e\n${scriptBody}\n`
+    await fs.promises.writeFile(tempPath, body, { mode: 0o700 })
+    // Windows cmd.exe /C parses outer quotes specially: if both the command
+    // and args are quoted, it strips the outermost pair. Wrap the path in a
+    // second pair so paths with spaces (e.g. C:\Users\John Doe\...) work.
+    const command = isWindows
+      ? `cmd /c ""${tempPath}""`
+      : `sh "${tempPath.replace(/"/g, '\\"')}"`
+    return { command, tempPath }
+  })
+
+  ipcMain.handle('worktrees:cleanupSetupScript', async (_event, tempPath: string) => {
+    try {
+      const tmpRoot = await fs.promises.realpath(os.tmpdir())
+      const resolved = await fs.promises.realpath(tempPath).catch(() => null)
+      if (!resolved) return
+      // Use path.relative for boundary-safe containment check — rejects paths
+      // that only share the tmpdir prefix as a string (e.g. /tmpfoo vs /tmp).
+      const rel = path.relative(tmpRoot, resolved)
+      if (!rel || rel.startsWith('..') || path.isAbsolute(rel)) return
+      await fs.promises.unlink(resolved).catch(() => undefined)
+    } catch {
+      /* ignore */
     }
   })
 }
@@ -482,5 +627,6 @@ app.on('before-quit', () => {
     provider.stopWatching()
   }
   stopAllBranchWatchers()
+  worktreeService.stopAll()
   destroyAllPtys()
 })

--- a/src/main/services/gitService.ts
+++ b/src/main/services/gitService.ts
@@ -47,6 +47,54 @@ export async function getRepoRoot(dirPath: string): Promise<string | null> {
 }
 
 /**
+ * Inspect a path and determine whether it's a git worktree of a larger repo.
+ * Returns the current checkout's top-level, the main repo root (parent of
+ * --git-common-dir), whether the path is a linked worktree, and the branch.
+ * Returns null when the path isn't inside a git repo.
+ */
+export async function inspectPath(dirPath: string): Promise<{
+  topLevel: string
+  mainRepoPath: string
+  isWorktree: boolean
+  branch: string | null
+} | null> {
+  try {
+    const topLevel = await execGit(['rev-parse', '--show-toplevel'], dirPath)
+    if (!topLevel) return null
+    const [gitDirRaw, commonDirRaw] = await Promise.all([
+      execGit(['rev-parse', '--git-dir'], dirPath),
+      execGit(['rev-parse', '--git-common-dir'], dirPath)
+    ])
+    if (!gitDirRaw || !commonDirRaw) return null
+    // Both may be relative to CWD; resolve against the toplevel.
+    const gitDir = path.isAbsolute(gitDirRaw)
+      ? gitDirRaw
+      : path.resolve(topLevel, gitDirRaw)
+    const commonDir = path.isAbsolute(commonDirRaw)
+      ? commonDirRaw
+      : path.resolve(topLevel, commonDirRaw)
+
+    // A linked worktree has a per-worktree gitdir (e.g. `.git/worktrees/foo`)
+    // that differs from the shared common-dir. Comparing these two paths is
+    // the only reliable way to distinguish linked worktrees from main
+    // checkouts (including main checkouts using --separate-git-dir, where
+    // deriving the parent from the common-dir alone is meaningless).
+    const isWorktree = path.resolve(gitDir) !== path.resolve(commonDir)
+
+    // For linked worktrees we best-effort derive the main repo's toplevel
+    // from the common-dir's parent. This is correct for the standard
+    // `<repo>/.git` layout and is only used as a hint (reconciliation
+    // matches by path). For non-worktrees we simply return the toplevel.
+    const mainRepoPath = isWorktree ? path.dirname(path.resolve(commonDir)) : path.resolve(topLevel)
+
+    const branch = await getBranch(dirPath)
+    return { topLevel, mainRepoPath, isWorktree, branch }
+  } catch {
+    return null
+  }
+}
+
+/**
  * Start watching a directory's git branch for changes.
  * Multiple calls with paths in the same repo share one watcher (ref-counted).
  * The callback receives (canonicalRepoRoot, branch).
@@ -155,7 +203,7 @@ function cleanupWatcher(canonical: string): void {
  * Resolve the actual .git directory path.
  * Handles worktrees where .git is a file containing "gitdir: <path>".
  */
-async function resolveGitDir(repoRoot: string): Promise<string | null> {
+export async function resolveGitDir(repoRoot: string): Promise<string | null> {
   const gitPath = path.join(repoRoot, '.git')
 
   try {
@@ -203,4 +251,228 @@ function execGit(args: string[], cwd: string): Promise<string | null> {
       resolve(result || null)
     })
   })
+}
+
+/**
+ * Run a git command and return full result (stdout+stderr+exit code) for callers
+ * that need to distinguish success-empty-output from failure.
+ */
+export function execGitRaw(
+  args: string[],
+  cwd: string,
+  timeoutMs = 10_000
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return new Promise((resolve) => {
+    execFile(
+      'git',
+      args,
+      { cwd, timeout: timeoutMs, maxBuffer: 32 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        if (err) {
+          const maybeCode = (err as NodeJS.ErrnoException & { code?: number | string }).code
+          const code = typeof maybeCode === 'number' ? maybeCode : 1
+          resolve({ code, stdout: String(stdout ?? ''), stderr: String(stderr ?? err.message ?? '') })
+          return
+        }
+        resolve({ code: 0, stdout: String(stdout ?? ''), stderr: String(stderr ?? '') })
+      }
+    )
+  })
+}
+
+/**
+ * Canonicalize a filesystem path — resolves symlinks and normalizes separators.
+ * Falls back to path.resolve if the path does not exist yet.
+ */
+export async function realpath(p: string): Promise<string> {
+  try {
+    return await fsp.realpath(p)
+  } catch {
+    return path.resolve(p)
+  }
+}
+
+export function realpathSync(p: string): string {
+  try {
+    return fs.realpathSync(p)
+  } catch {
+    return path.resolve(p)
+  }
+}
+
+/**
+ * List local branches (short names, no "refs/heads/" prefix).
+ */
+export async function listLocalBranches(repoRoot: string): Promise<string[]> {
+  const result = await execGitRaw(
+    ['for-each-ref', '--format=%(refname:short)', 'refs/heads/'],
+    repoRoot
+  )
+  if (result.code !== 0) return []
+  return result.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+}
+
+/**
+ * List remote-tracking branches as "origin/feat" style names, excluding HEAD aliases.
+ */
+export async function listRemoteBranches(repoRoot: string): Promise<string[]> {
+  const result = await execGitRaw(
+    ['for-each-ref', '--format=%(refname:short)', 'refs/remotes/'],
+    repoRoot
+  )
+  if (result.code !== 0) return []
+  return result.stdout
+    .split('\n')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0 && !s.endsWith('/HEAD'))
+}
+
+/**
+ * Resolve the default base branch for new worktrees.
+ * Priority: origin/HEAD symref → main → master → null.
+ */
+export async function resolveDefaultBaseBranch(repoRoot: string): Promise<string | null> {
+  // Try origin/HEAD first — this is what `git symbolic-ref` returns for the default branch.
+  const headRef = await execGit(['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'], repoRoot)
+  if (headRef) {
+    // Strip "origin/" prefix if present
+    return headRef.startsWith('origin/') ? headRef.slice('origin/'.length) : headRef
+  }
+
+  // Fall back to conventional branch names if they exist locally.
+  const locals = await listLocalBranches(repoRoot)
+  if (locals.includes('main')) return 'main'
+  if (locals.includes('master')) return 'master'
+  return locals[0] ?? null
+}
+
+/**
+ * Count commits in `head` that are not in `base` (i.e. how many commits ahead `head` is).
+ * Returns null on error.
+ */
+export async function revListCount(
+  repoRoot: string,
+  base: string,
+  head: string
+): Promise<number | null> {
+  const result = await execGitRaw(
+    ['rev-list', '--count', `${base}..${head}`],
+    repoRoot
+  )
+  if (result.code !== 0) return null
+  const n = parseInt(result.stdout.trim(), 10)
+  return Number.isFinite(n) ? n : null
+}
+
+/**
+ * Return both "ahead of base" and "behind base" commit counts for a branch/ref.
+ * Returns null for fields that could not be computed.
+ */
+export async function revListAheadBehind(
+  repoRoot: string,
+  base: string,
+  head: string
+): Promise<{ ahead: number | null; behind: number | null }> {
+  const result = await execGitRaw(
+    ['rev-list', '--left-right', '--count', `${base}...${head}`],
+    repoRoot
+  )
+  if (result.code !== 0) return { ahead: null, behind: null }
+  // Output format: "<behind>\t<ahead>" — left side is `base`, right side is `head`.
+  const parts = result.stdout.trim().split(/\s+/)
+  if (parts.length < 2) return { ahead: null, behind: null }
+  const behind = parseInt(parts[0], 10)
+  const ahead = parseInt(parts[1], 10)
+  return {
+    ahead: Number.isFinite(ahead) ? ahead : null,
+    behind: Number.isFinite(behind) ? behind : null
+  }
+}
+
+/**
+ * Return the upstream tracking ref for a branch (e.g. "origin/feature/auth"),
+ * or null if the branch has no upstream set.
+ */
+export async function getUpstream(
+  repoRoot: string,
+  branch: string
+): Promise<string | null> {
+  const result = await execGitRaw(
+    ['rev-parse', '--abbrev-ref', '--symbolic-full-name', `${branch}@{upstream}`],
+    repoRoot
+  )
+  if (result.code !== 0) return null
+  const out = result.stdout.trim()
+  return out.length > 0 ? out : null
+}
+
+/**
+ * Return the common git dir (the .git directory shared by all worktrees of a repo).
+ * For a main checkout this is `<repo>/.git`. For a worktree it's `<main>/.git`.
+ * Returns null if not a git repo.
+ */
+export async function getCommonGitDir(repoRoot: string): Promise<string | null> {
+  const result = await execGitRaw(['rev-parse', '--git-common-dir'], repoRoot)
+  if (result.code !== 0) return null
+  const out = result.stdout.trim()
+  if (!out) return null
+  return path.isAbsolute(out) ? out : path.resolve(repoRoot, out)
+}
+
+/**
+ * True if the given path is the main checkout of its repo (i.e. not a linked worktree).
+ */
+export async function isMainCheckout(repoRoot: string): Promise<boolean> {
+  const canonical = await realpath(repoRoot)
+  const result = await execGitRaw(['rev-parse', '--git-dir'], canonical)
+  if (result.code !== 0) return false
+  const gitDir = result.stdout.trim()
+  if (!gitDir) return false
+  // Linked worktrees have `--git-dir` pointing at `<common>/worktrees/<name>`.
+  // Main checkouts have `--git-dir` equal to their common dir.
+  const abs = path.isAbsolute(gitDir) ? gitDir : path.resolve(canonical, gitDir)
+  const common = await getCommonGitDir(canonical)
+  if (!common) return false
+  return (await realpath(abs)) === (await realpath(common))
+}
+
+/**
+ * Canonical repo identity — stable across main checkout and linked worktrees.
+ *
+ * Strategy:
+ *   1. Resolve the shared `--git-common-dir` (stable per repo; the same for
+ *      main + every linked worktree).
+ *   2. If that common dir is a `.git` directory inside a working tree (the
+ *      standard layout), return its parent — i.e. the main checkout root.
+ *      This is the most useful identity because git commands can be run
+ *      against it.
+ *   3. Otherwise (submodules, `--separate-git-dir`, bare repos, etc.) fall
+ *      back to the realpathed common dir itself. It's a stable string that
+ *      is identical for every worktree of the same repo, which is all we
+ *      actually need for keying sidecar/watchers/queues.
+ *
+ * Returns null when the path is not inside a git repo.
+ */
+export async function getRepoIdentity(repoRoot: string): Promise<string | null> {
+  const commonDir = await getCommonGitDir(repoRoot)
+  if (!commonDir) return null
+  const realCommon = await realpath(commonDir)
+  // Standard layout: `<main>/.git`. Use parent as the identity.
+  if (path.basename(realCommon) === '.git') {
+    const parent = path.dirname(realCommon)
+    // Verify the parent is actually a working tree. For submodules the
+    // common dir lives under `<super>/.git/modules/<name>` whose basename
+    // is `<name>`, not `.git`, so this branch won't run — the fallback does.
+    try {
+      await fsp.access(parent)
+      return await realpath(parent)
+    } catch {
+      /* fall through */
+    }
+  }
+  // Non-standard layout — return the common dir itself as the stable key.
+  return realCommon
 }

--- a/src/main/services/sessionPersistence.ts
+++ b/src/main/services/sessionPersistence.ts
@@ -11,6 +11,9 @@ export interface PersistedTab {
   cwd?: string
   command?: string
   sessionId?: string
+  providerId?: string
+  worktreePath?: string
+  worktreeBranch?: string
 }
 
 export interface PersistedGroup {

--- a/src/main/services/worktrees/gitWorktree.ts
+++ b/src/main/services/worktrees/gitWorktree.ts
@@ -13,7 +13,7 @@ import {
 } from '../gitService'
 import type { WorktreeInfo, WorktreeStatus } from './types'
 import { getEntriesForRepo } from './sidecar'
-import { parsePorcelain as parsePorcelainImpl, type RawWorktreeRecord } from './porcelain'
+import { parsePorcelain as parseGitWorktreePorcelain, type RawWorktreeRecord } from './porcelain'
 
 /**
  * Parse `git worktree list --porcelain` output.
@@ -31,7 +31,7 @@ import { parsePorcelain as parsePorcelainImpl, type RawWorktreeRecord } from './
  * structured records.
  */
 export function parsePorcelain(output: string): RawWorktreeRecord[] {
-  return parsePorcelainImpl(output)
+  return parseGitWorktreePorcelain(output)
 }
 
 export type { RawWorktreeRecord }
@@ -142,7 +142,7 @@ export async function listWorktreesWithStatus(
   if (res.code !== 0) return null
 
   const identity = (await getRepoIdentity(canonicalRoot)) ?? canonicalRoot
-  const raws = parsePorcelainImpl(res.stdout).filter((r) => !r.bare)
+  const raws = parseGitWorktreePorcelain(res.stdout).filter((r) => !r.bare)
   const sidecar = getEntriesForRepo(identity)
   const enriched = await Promise.all(raws.map((r) => enrich(canonicalRoot, r, sidecar)))
 

--- a/src/main/services/worktrees/gitWorktree.ts
+++ b/src/main/services/worktrees/gitWorktree.ts
@@ -13,6 +13,7 @@ import {
 } from '../gitService'
 import type { WorktreeInfo, WorktreeStatus } from './types'
 import { getEntriesForRepo } from './sidecar'
+import { parsePorcelain as parsePorcelainImpl, type RawWorktreeRecord } from './porcelain'
 
 /**
  * Parse `git worktree list --porcelain` output.
@@ -25,63 +26,6 @@ import { getEntriesForRepo } from './sidecar'
  *   [prunable <reason>]
  *   [locked <reason>]
  */
-interface RawWorktreeRecord {
-  path: string
-  head: string
-  branch: string | null
-  detached: boolean
-  bare: boolean
-  prunable: boolean
-}
-
-function parsePorcelainImpl(output: string): RawWorktreeRecord[] {
-  const records: RawWorktreeRecord[] = []
-  let cur: Partial<RawWorktreeRecord> | null = null
-
-  const flush = (): void => {
-    if (cur && cur.path) {
-      records.push({
-        path: cur.path,
-        head: cur.head ?? '',
-        branch: cur.branch ?? null,
-        detached: cur.detached ?? false,
-        bare: cur.bare ?? false,
-        prunable: cur.prunable ?? false
-      })
-    }
-    cur = null
-  }
-
-  for (const line of output.split('\n')) {
-    if (line.length === 0) {
-      flush()
-      continue
-    }
-    if (line.startsWith('worktree ')) {
-      flush()
-      cur = { path: line.slice('worktree '.length) }
-      continue
-    }
-    if (!cur) continue
-    if (line.startsWith('HEAD ')) {
-      cur.head = line.slice('HEAD '.length)
-    } else if (line.startsWith('branch ')) {
-      const ref = line.slice('branch '.length)
-      cur.branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
-      cur.detached = false
-    } else if (line === 'detached') {
-      cur.branch = null
-      cur.detached = true
-    } else if (line === 'bare') {
-      cur.bare = true
-    } else if (line.startsWith('prunable')) {
-      cur.prunable = true
-    }
-  }
-  flush()
-  return records
-}
-
 /**
  * Exported for unit testing. Parses `git worktree list --porcelain` output into
  * structured records.

--- a/src/main/services/worktrees/gitWorktree.ts
+++ b/src/main/services/worktrees/gitWorktree.ts
@@ -1,0 +1,260 @@
+/**
+ * Thin wrappers around `git worktree` + `git status` / `git rev-list` that return
+ * structured data. No caching and no watchers here — those live in `service.ts`.
+ */
+
+import {
+  execGitRaw,
+  realpath,
+  getUpstream,
+  getRepoIdentity,
+  isMainCheckout,
+  revListAheadBehind
+} from '../gitService'
+import type { WorktreeInfo, WorktreeStatus } from './types'
+import { getEntriesForRepo } from './sidecar'
+
+/**
+ * Parse `git worktree list --porcelain` output.
+ *
+ * Porcelain format (one record per worktree, records separated by blank line):
+ *   worktree <path>
+ *   HEAD <sha>
+ *   branch refs/heads/<branch>   (or "detached")
+ *   [bare]                       (top-level bare repo, we skip this in v1)
+ *   [prunable <reason>]
+ *   [locked <reason>]
+ */
+interface RawWorktreeRecord {
+  path: string
+  head: string
+  branch: string | null
+  detached: boolean
+  bare: boolean
+  prunable: boolean
+}
+
+function parsePorcelainImpl(output: string): RawWorktreeRecord[] {
+  const records: RawWorktreeRecord[] = []
+  let cur: Partial<RawWorktreeRecord> | null = null
+
+  const flush = (): void => {
+    if (cur && cur.path) {
+      records.push({
+        path: cur.path,
+        head: cur.head ?? '',
+        branch: cur.branch ?? null,
+        detached: cur.detached ?? false,
+        bare: cur.bare ?? false,
+        prunable: cur.prunable ?? false
+      })
+    }
+    cur = null
+  }
+
+  for (const line of output.split('\n')) {
+    if (line.length === 0) {
+      flush()
+      continue
+    }
+    if (line.startsWith('worktree ')) {
+      flush()
+      cur = { path: line.slice('worktree '.length) }
+      continue
+    }
+    if (!cur) continue
+    if (line.startsWith('HEAD ')) {
+      cur.head = line.slice('HEAD '.length)
+    } else if (line.startsWith('branch ')) {
+      const ref = line.slice('branch '.length)
+      cur.branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+      cur.detached = false
+    } else if (line === 'detached') {
+      cur.branch = null
+      cur.detached = true
+    } else if (line === 'bare') {
+      cur.bare = true
+    } else if (line.startsWith('prunable')) {
+      cur.prunable = true
+    }
+  }
+  flush()
+  return records
+}
+
+/**
+ * Exported for unit testing. Parses `git worktree list --porcelain` output into
+ * structured records.
+ */
+export function parsePorcelain(output: string): RawWorktreeRecord[] {
+  return parsePorcelainImpl(output)
+}
+
+export type { RawWorktreeRecord }
+
+/**
+ * Returns true if the given directory is inside a valid git repo (worktree or main).
+ */
+export async function isGitRepo(dirPath: string): Promise<boolean> {
+  const res = await execGitRaw(['rev-parse', '--is-inside-work-tree'], dirPath, 3000)
+  if (res.code !== 0) return false
+  return res.stdout.trim() === 'true'
+}
+
+/**
+ * Compute dirty/staged/untracked counts from `git status --porcelain=v1`.
+ * Fast: one command per worktree.
+ */
+async function readStatusCounts(
+  worktreePath: string
+): Promise<Pick<WorktreeStatus, 'dirtyCount' | 'untrackedCount' | 'stagedCount'>> {
+  const res = await execGitRaw(['status', '--porcelain=v1'], worktreePath, 5000)
+  if (res.code !== 0) {
+    return { dirtyCount: null, untrackedCount: null, stagedCount: null }
+  }
+  let dirty = 0
+  let staged = 0
+  let untracked = 0
+  for (const line of res.stdout.split('\n')) {
+    if (line.length < 2) continue
+    const x = line[0]
+    const y = line[1]
+    if (x === '?' && y === '?') {
+      untracked++
+      continue
+    }
+    if (x !== ' ' && x !== '?') staged++
+    if (y !== ' ' && y !== '?') dirty++
+  }
+  return { dirtyCount: dirty, untrackedCount: untracked, stagedCount: staged }
+}
+
+/**
+ * Enrich a single raw worktree record with status + sidecar data.
+ * Returns a finalized WorktreeInfo.
+ */
+async function enrich(
+  _repoRoot: string,
+  raw: RawWorktreeRecord,
+  sidecar: Map<string, import('./sidecar').WorktreeSidecarEntry>
+): Promise<WorktreeInfo> {
+  const canonical = await realpath(raw.path)
+
+  const [counts, upstream] = await Promise.all([
+    readStatusCounts(canonical),
+    raw.branch ? getUpstream(canonical, raw.branch) : Promise.resolve(null)
+  ])
+
+  let ahead: number | null = null
+  let behind: number | null = null
+  if (raw.branch && upstream) {
+    const res = await revListAheadBehind(canonical, upstream, raw.branch)
+    ahead = res.ahead
+    behind = res.behind
+  }
+
+  const sc = sidecar.get(canonical)
+  // Use git metadata (not `.git`-is-a-directory heuristic) so that repos
+  // configured with `--separate-git-dir` are classified correctly.
+  const isMain = await isMainCheckout(canonical)
+
+  return {
+    path: canonical,
+    branch: raw.branch,
+    head: raw.head ? raw.head.slice(0, 7) : '',
+    detached: raw.detached,
+    isMain,
+    prunable: raw.prunable,
+    createdByDplex: Boolean(sc?.createdByDplex),
+    createdAt: sc?.createdAt ?? null,
+    baseBranch: sc?.baseBranch ?? null,
+    status: {
+      ...counts,
+      ahead,
+      behind,
+      upstream: upstream ?? null
+    }
+  }
+}
+
+/**
+ * List all worktrees in the repo with enriched status.
+ * Canonicalizes all paths. Skips bare-repo entries in v1.
+ *
+ * Returns `null` when git itself fails (timeout, not-a-repo, permission
+ * issue). The difference matters: callers MUST NOT interpret a transient
+ * failure as "no worktrees" and then reconcile away our sidecar entries.
+ * Callers should retry later and keep the previous snapshot in the meantime.
+ *
+ * Returns `[]` only when git succeeds with no worktrees (vanishingly rare — a
+ * valid repo has at least the main checkout, so the empty list effectively
+ * means "bare repo" in v1 where we skip bare entries).
+ */
+export async function listWorktreesWithStatus(
+  repoRoot: string
+): Promise<WorktreeInfo[] | null> {
+  const canonicalRoot = await realpath(repoRoot)
+  const res = await execGitRaw(['worktree', 'list', '--porcelain'], canonicalRoot, 10_000)
+  if (res.code !== 0) return null
+
+  const identity = (await getRepoIdentity(canonicalRoot)) ?? canonicalRoot
+  const raws = parsePorcelainImpl(res.stdout).filter((r) => !r.bare)
+  const sidecar = getEntriesForRepo(identity)
+  const enriched = await Promise.all(raws.map((r) => enrich(canonicalRoot, r, sidecar)))
+
+  // Order: main checkout first, then by createdAt desc (if known), else by path.
+  enriched.sort((a, b) => {
+    if (a.isMain !== b.isMain) return a.isMain ? -1 : 1
+    const ta = a.createdAt ? Date.parse(a.createdAt) : 0
+    const tb = b.createdAt ? Date.parse(b.createdAt) : 0
+    if (ta !== tb) return tb - ta
+    return a.path.localeCompare(b.path)
+  })
+
+  return enriched
+}
+
+/**
+ * Run `git worktree add` with sensible defaults.
+ * Returns { code, stdout, stderr } — callers map to structured errors.
+ */
+export async function gitWorktreeAdd(
+  repoRoot: string,
+  worktreePath: string,
+  branch: string,
+  options: { newBranch: boolean; baseBranch: string | null }
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const args = ['worktree', 'add']
+  if (options.newBranch) {
+    args.push('-b', branch, worktreePath)
+    if (options.baseBranch) args.push(options.baseBranch)
+  } else {
+    args.push(worktreePath, branch)
+  }
+  return execGitRaw(args, repoRoot, 120_000)
+}
+
+export async function gitWorktreeRemove(
+  repoRoot: string,
+  worktreePath: string,
+  force: boolean
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const args = ['worktree', 'remove']
+  if (force) args.push('--force')
+  args.push(worktreePath)
+  return execGitRaw(args, repoRoot, 30_000)
+}
+
+export async function gitBranchDelete(
+  repoRoot: string,
+  branch: string,
+  force: boolean
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return execGitRaw(['branch', force ? '-D' : '-d', branch], repoRoot, 10_000)
+}
+
+export async function gitWorktreePrune(
+  repoRoot: string
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  return execGitRaw(['worktree', 'prune'], repoRoot, 10_000)
+}

--- a/src/main/services/worktrees/index.ts
+++ b/src/main/services/worktrees/index.ts
@@ -1,0 +1,12 @@
+export * from './types'
+export {
+  list,
+  create,
+  remove,
+  listBranches,
+  watchRepo,
+  unwatchRepo,
+  refreshRepo,
+  recordSetupResult,
+  stopAll
+} from './service'

--- a/src/main/services/worktrees/porcelain.ts
+++ b/src/main/services/worktrees/porcelain.ts
@@ -1,0 +1,56 @@
+export interface RawWorktreeRecord {
+  path: string
+  head: string
+  branch: string | null
+  detached: boolean
+  bare: boolean
+  prunable: boolean
+}
+
+export function parsePorcelain(output: string): RawWorktreeRecord[] {
+  const records: RawWorktreeRecord[] = []
+  let cur: Partial<RawWorktreeRecord> | null = null
+
+  const flush = (): void => {
+    if (cur && cur.path) {
+      records.push({
+        path: cur.path,
+        head: cur.head ?? '',
+        branch: cur.branch ?? null,
+        detached: cur.detached ?? false,
+        bare: cur.bare ?? false,
+        prunable: cur.prunable ?? false
+      })
+    }
+    cur = null
+  }
+
+  for (const line of output.split('\n')) {
+    if (line.length === 0) {
+      flush()
+      continue
+    }
+    if (line.startsWith('worktree ')) {
+      flush()
+      cur = { path: line.slice('worktree '.length) }
+      continue
+    }
+    if (!cur) continue
+    if (line.startsWith('HEAD ')) {
+      cur.head = line.slice('HEAD '.length)
+    } else if (line.startsWith('branch ')) {
+      const ref = line.slice('branch '.length)
+      cur.branch = ref.startsWith('refs/heads/') ? ref.slice('refs/heads/'.length) : ref
+      cur.detached = false
+    } else if (line === 'detached') {
+      cur.branch = null
+      cur.detached = true
+    } else if (line === 'bare') {
+      cur.bare = true
+    } else if (line.startsWith('prunable')) {
+      cur.prunable = true
+    }
+  }
+  flush()
+  return records
+}

--- a/src/main/services/worktrees/service.ts
+++ b/src/main/services/worktrees/service.ts
@@ -1,0 +1,700 @@
+/**
+ * Core worktree service.
+ *
+ * Responsibilities:
+ *  - maintain the ops queue per repo (phase 1 = git mutation + sidecar + env copy)
+ *  - host watchers (ref-counted by subscription token)
+ *  - emit `worktrees:changed` via the injected emitter (main index.ts wires this
+ *    to webContents.send + tracks subscribers per webContents)
+ *  - copy env files
+ *  - list with status (delegates to gitWorktree)
+ *  - structured errors
+ *
+ * Setup script execution is delegated: the renderer requests a PTY tab via the
+ * existing pty IPC; the service only records lastSetupRunAt/ExitCode in sidecar
+ * once the renderer reports completion.
+ */
+
+import * as fs from 'fs'
+import * as fsp from 'fs/promises'
+import * as os from 'os'
+import * as path from 'path'
+import { randomUUID } from 'crypto'
+import {
+  realpath,
+  resolveGitDir,
+  getCommonGitDir,
+  getRepoIdentity,
+  listLocalBranches,
+  listRemoteBranches,
+  resolveDefaultBaseBranch,
+  getUpstream,
+  revListAheadBehind
+} from '../gitService'
+import {
+  listWorktreesWithStatus,
+  gitWorktreeAdd,
+  gitWorktreeRemove,
+  gitBranchDelete,
+  isGitRepo
+} from './gitWorktree'
+import { getEntry, removeEntry, upsertEntry, reconcile } from './sidecar'
+import type {
+  CreateWorktreeOptions,
+  CreateWorktreeResult,
+  DeleteWorktreeOptions,
+  DeleteWorktreeResult,
+  WorktreeError,
+  WorktreeInfo,
+  WorktreesChangedPayload,
+  WorktreeSubscriptionToken
+} from './types'
+import { worktreeError } from './types'
+
+type Emitter = (payload: WorktreesChangedPayload) => void
+
+// ── Subscriptions ─────────────────────────────────────────────────────
+// Subscriptions are keyed by repo *identity* (the main-checkout root), which
+// is stable across a user opening the project from the main checkout or from
+// any linked worktree.
+
+interface SubscriptionEntry {
+  identity: string
+  emit: Emitter
+}
+
+const subscriptions = new Map<WorktreeSubscriptionToken, SubscriptionEntry>()
+
+interface WatcherEntry {
+  identity: string
+  gitDirWatcher: fs.FSWatcher | null
+  worktreeWatchers: Map<string, fs.FSWatcher>
+  debounceTimer: ReturnType<typeof setTimeout> | null
+  lastSnapshot: WorktreeInfo[]
+}
+
+const watchers = new Map<string, WatcherEntry>() // keyed by repo identity
+
+// ── Ops queue ─────────────────────────────────────────────────────────
+// Queued per repo identity so that concurrent ops on the same repo serialize,
+// while unrelated repos run in parallel.
+
+const repoQueues = new Map<string, Promise<unknown>>()
+
+function queue<T>(identity: string, fn: () => Promise<T>): Promise<T> {
+  const prev = repoQueues.get(identity) ?? Promise.resolve()
+  const next = prev.then(fn, fn)
+  const tracked = next.catch(() => undefined)
+  repoQueues.set(identity, tracked)
+  // Reclaim the slot once this queue entry settles AND no newer entry has
+  // chained behind it. This keeps the Map from growing linearly with the
+  // number of distinct repos touched over a long session.
+  void tracked.finally(() => {
+    if (repoQueues.get(identity) === tracked) {
+      repoQueues.delete(identity)
+    }
+  })
+  return next
+}
+
+async function resolveIdentity(repoRoot: string): Promise<string | null> {
+  const id = await getRepoIdentity(repoRoot)
+  if (id) return id
+  // Fallback when the caller passed something that's not a git repo.
+  return null
+}
+
+// ── Public API ────────────────────────────────────────────────────────
+
+export async function listBranches(
+  repoRoot: string
+): Promise<{ local: string[]; remote: string[]; defaultBase: string | null }> {
+  const canonical = await realpath(repoRoot)
+  const [local, remote, defaultBase] = await Promise.all([
+    listLocalBranches(canonical),
+    listRemoteBranches(canonical),
+    resolveDefaultBaseBranch(canonical)
+  ])
+  return { local, remote, defaultBase }
+}
+
+export async function list(repoRoot: string): Promise<WorktreeInfo[]> {
+  const canonical = await realpath(repoRoot)
+  if (!(await isGitRepo(canonical))) return []
+  const identity = (await resolveIdentity(canonical)) ?? canonical
+  const worktrees = await listWorktreesWithStatus(canonical)
+  if (worktrees === null) {
+    // Transient git failure — do NOT reconcile (would wipe sidecar).
+    return watchers.get(identity)?.lastSnapshot ?? []
+  }
+  await reconcile(
+    identity,
+    worktrees.map((w) => w.path)
+  )
+  return worktrees
+}
+
+/**
+ * Validate that a requested worktree location is safe.
+ *
+ * Rules:
+ *   - Must be absolute (caller resolves this before calling).
+ *   - Must not equal the repo root (would clobber main checkout).
+ *   - Must not be inside the main `.git` directory.
+ *   - Must be under the user's home directory OR the parent directory of
+ *     the repo root. This blocks accidental `/etc/...` / `/tmp/...` paths
+ *     created by a buggy pattern expansion while still allowing both
+ *     `~/work/proj-branch` and `<repoParent>/proj-branch` patterns.
+ */
+function validateWorktreePath(
+  desiredPath: string,
+  repoRoot: string
+): WorktreeError | null {
+  if (!path.isAbsolute(desiredPath)) {
+    return worktreeError('INVALID_ARGUMENT', `Worktree path must be absolute: ${desiredPath}`)
+  }
+  if (desiredPath === repoRoot) {
+    return worktreeError(
+      'INVALID_ARGUMENT',
+      'Worktree path cannot be the repository root itself'
+    )
+  }
+  if (desiredPath.includes(`${path.sep}.git${path.sep}`) || desiredPath.endsWith(`${path.sep}.git`)) {
+    return worktreeError(
+      'INVALID_ARGUMENT',
+      'Worktree path cannot be inside a .git directory'
+    )
+  }
+  const home = os.homedir()
+  const repoParent = path.dirname(repoRoot)
+  const isUnderHome = home ? desiredPath === home || desiredPath.startsWith(home + path.sep) : false
+  const isUnderRepoParent =
+    desiredPath === repoParent || desiredPath.startsWith(repoParent + path.sep)
+  if (!isUnderHome && !isUnderRepoParent) {
+    return worktreeError(
+      'INVALID_ARGUMENT',
+      `Worktree path must be under your home directory or the project's parent folder: ${desiredPath}`
+    )
+  }
+  return null
+}
+
+export async function create(
+  opts: CreateWorktreeOptions
+): Promise<CreateWorktreeResult | WorktreeError> {
+  const repoRoot = await realpath(opts.repoRoot)
+  if (!opts.branch || !opts.worktreePath) {
+    return worktreeError('INVALID_ARGUMENT', 'branch and worktreePath are required')
+  }
+  // Reject branch names that git would interpret as command-line options.
+  // Even though we use execFile (no shell), git argv parsing treats e.g.
+  // "-f" as --force, which would change semantics.
+  if (opts.branch.startsWith('-')) {
+    return worktreeError(
+      'INVALID_ARGUMENT',
+      `Branch name cannot start with "-": ${opts.branch}`
+    )
+  }
+  if (opts.baseBranch && opts.baseBranch.startsWith('-')) {
+    return worktreeError(
+      'INVALID_ARGUMENT',
+      `Base branch name cannot start with "-": ${opts.baseBranch}`
+    )
+  }
+  if (!(await isGitRepo(repoRoot))) {
+    return worktreeError('NOT_A_GIT_REPO', `${repoRoot} is not a git repo`)
+  }
+
+  const identity = (await resolveIdentity(repoRoot)) ?? repoRoot
+
+  const desiredPath = path.isAbsolute(opts.worktreePath)
+    ? path.resolve(opts.worktreePath)
+    : path.resolve(repoRoot, opts.worktreePath)
+
+  const pathError = validateWorktreePath(desiredPath, identity)
+  if (pathError) return pathError
+
+  // Pre-flight checks
+  try {
+    await fsp.access(desiredPath)
+    return worktreeError('PATH_EXISTS', `${desiredPath} already exists`)
+  } catch {
+    /* good — does not exist */
+  }
+
+  // Resolve default base branch if caller created a new branch but didn't
+  // specify a base (common with QuickCreate which always passes null).
+  let baseBranch = opts.baseBranch
+  if (opts.newBranch && !baseBranch) {
+    baseBranch = await resolveDefaultBaseBranch(repoRoot)
+    if (!baseBranch) {
+      return worktreeError(
+        'INVALID_ARGUMENT',
+        'Could not resolve a default base branch — please specify one explicitly.'
+      )
+    }
+  }
+
+  const opId = randomUUID()
+
+  return queue(identity, async () => {
+    const addResult = await gitWorktreeAdd(repoRoot, desiredPath, opts.branch, {
+      newBranch: opts.newBranch,
+      baseBranch
+    })
+    if (addResult.code !== 0) {
+      return mapAddError(addResult.stderr || addResult.stdout)
+    }
+
+    // The new worktree path may be a symlink on some filesystems — canonicalize.
+    const canonicalWorktreePath = await realpath(desiredPath)
+
+    if (opts.trackInSidecar !== false) {
+      await upsertEntry(identity, canonicalWorktreePath, {
+        createdByDplex: true,
+        createdAt: new Date().toISOString(),
+        baseBranch,
+        initialBranch: opts.branch
+      })
+    }
+
+    if (opts.envFiles && opts.envFiles.length > 0) {
+      await copyEnvFiles(repoRoot, canonicalWorktreePath, opts.envFiles)
+    }
+
+    // Refresh + emit. listWorktreesWithStatus may return null if git itself
+    // starts failing between add and list (rare) — fall back to a minimal
+    // snapshot built from the values we just committed.
+    const worktrees = (await listWorktreesWithStatus(repoRoot)) ?? []
+    if (worktrees.length > 0) {
+      emitToIdentity(identity, {
+        repoRoot: identity,
+        worktrees,
+        changedPaths: [canonicalWorktreePath]
+      })
+      rebindWorktreeWatchers(identity, worktrees)
+    }
+
+    const created =
+      worktrees.find((w) => w.path === canonicalWorktreePath) ??
+      ({
+        path: canonicalWorktreePath,
+        branch: opts.branch,
+        head: '',
+        detached: false,
+        isMain: false,
+        prunable: false,
+        createdByDplex: true,
+        createdAt: new Date().toISOString(),
+        baseBranch,
+        status: {
+          dirtyCount: 0,
+          untrackedCount: 0,
+          stagedCount: 0,
+          ahead: null,
+          behind: null,
+          upstream: null
+        }
+      } satisfies WorktreeInfo)
+
+    return { worktree: created, opId }
+  })
+}
+
+export async function remove(
+  opts: DeleteWorktreeOptions
+): Promise<DeleteWorktreeResult | WorktreeError> {
+  const repoRoot = await realpath(opts.repoRoot)
+  const worktreePath = await realpath(opts.worktreePath)
+
+  if (!(await isGitRepo(repoRoot))) {
+    return worktreeError('NOT_A_GIT_REPO', `${repoRoot} is not a git repo`)
+  }
+
+  const identity = (await resolveIdentity(repoRoot)) ?? repoRoot
+
+  return queue(identity, async () => {
+    // Capture branch before removal — needed for optional branch delete.
+    const pre = await listWorktreesWithStatus(repoRoot)
+    if (pre === null) {
+      return worktreeError('UNKNOWN', 'Failed to list worktrees')
+    }
+    const target = pre.find((w) => w.path === worktreePath)
+    if (!target) {
+      return worktreeError('WORKTREE_NOT_FOUND', `No worktree at ${worktreePath}`)
+    }
+    if (target.isMain) {
+      return worktreeError('IS_MAIN_CHECKOUT', 'Cannot delete the main checkout')
+    }
+
+    const rmResult = await gitWorktreeRemove(repoRoot, worktreePath, opts.force)
+    if (rmResult.code !== 0) {
+      return mapRemoveError(rmResult.stderr || rmResult.stdout)
+    }
+
+    await removeEntry(identity, worktreePath)
+
+    if (opts.deleteBranch && target.branch) {
+      // Reject branch names that git would interpret as options.
+      if (target.branch.startsWith('-')) {
+        await refreshAndEmit(identity, repoRoot, [worktreePath])
+        return {
+          ok: true as const,
+          warning: worktreeError(
+            'INVALID_ARGUMENT',
+            `Refusing to delete branch with option-like name: ${target.branch}`
+          )
+        }
+      }
+      // Safety: if branch has no upstream OR is ahead of upstream, block unless force.
+      const upstream = await getUpstream(repoRoot, target.branch)
+      if (!upstream && !opts.forceDeleteBranch) {
+        await refreshAndEmit(identity, repoRoot, [worktreePath])
+        return {
+          ok: true as const,
+          warning: worktreeError(
+            'BRANCH_NO_UPSTREAM',
+            `Branch ${target.branch} has no upstream — branch not deleted`
+          )
+        }
+      }
+      if (upstream && !opts.forceDeleteBranch) {
+        const ab = await revListAheadBehind(repoRoot, upstream, target.branch)
+        if ((ab.ahead ?? 0) > 0) {
+          await refreshAndEmit(identity, repoRoot, [worktreePath])
+          return {
+            ok: true as const,
+            warning: worktreeError(
+              'BRANCH_HAS_UNPUSHED_COMMITS',
+              `Branch ${target.branch} has unpushed commits — branch not deleted`
+            )
+          }
+        }
+      }
+      const delResult = await gitBranchDelete(
+        repoRoot,
+        target.branch,
+        Boolean(opts.forceDeleteBranch)
+      )
+      if (delResult.code !== 0) {
+        await refreshAndEmit(identity, repoRoot, [worktreePath])
+        return {
+          ok: true as const,
+          warning: worktreeError('UNKNOWN', delResult.stderr || delResult.stdout)
+        }
+      }
+    }
+
+    await refreshAndEmit(identity, repoRoot, [worktreePath])
+    return { ok: true as const, warning: null }
+  })
+}
+
+// ── Env file copy ────────────────────────────────────────────────────
+
+async function copyEnvFiles(
+  repoRoot: string,
+  worktreePath: string,
+  patterns: string[]
+): Promise<void> {
+  // v1: simple pattern support — exact filenames + one trailing glob (`.env.*.local`).
+  //
+  // Security: env-file patterns come from the renderer (user-provided). Reject
+  // anything that resolves outside `repoRoot` (source) or `worktreePath`
+  // (destination) so a malicious/misconfigured pattern like `../secrets/.env`
+  // can't read or overwrite files elsewhere on disk.
+  const repoRootResolved = path.resolve(repoRoot)
+  const worktreeResolved = path.resolve(worktreePath)
+
+  const isInside = (parent: string, child: string): boolean => {
+    const rel = path.relative(parent, child)
+    return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel)
+  }
+
+  const expanded = new Set<string>()
+  for (const pat of patterns) {
+    if (pat.includes('*')) {
+      const dir = path.resolve(repoRootResolved, path.dirname(pat))
+      if (!isInside(repoRootResolved, dir) && dir !== repoRootResolved) continue
+      const base = path.basename(pat)
+      try {
+        const entries = await fsp.readdir(dir)
+        const re = new RegExp('^' + base.replace(/[.]/g, '\\.').replace(/\*/g, '.*') + '$')
+        for (const e of entries) {
+          if (re.test(e)) {
+            const src = path.join(dir, e)
+            if (isInside(repoRootResolved, src)) expanded.add(src)
+          }
+        }
+      } catch {
+        /* skip missing dir */
+      }
+    } else {
+      const src = path.resolve(repoRootResolved, pat)
+      if (isInside(repoRootResolved, src)) expanded.add(src)
+    }
+  }
+
+  for (const src of expanded) {
+    try {
+      const rel = path.relative(repoRootResolved, src)
+      const dst = path.resolve(worktreeResolved, rel)
+      if (!isInside(worktreeResolved, dst)) continue
+      await fsp.mkdir(path.dirname(dst), { recursive: true })
+      await fsp.copyFile(src, dst)
+    } catch {
+      // Missing source → skip silently (documented behavior).
+    }
+  }
+}
+
+// ── Watchers ─────────────────────────────────────────────────────────
+
+export async function watchRepo(
+  repoRoot: string,
+  emit: Emitter
+): Promise<{ token: WorktreeSubscriptionToken; repoRoot: string } | null> {
+  const canonical = await realpath(repoRoot)
+  if (!(await isGitRepo(canonical))) return null
+
+  const identity = (await resolveIdentity(canonical)) ?? canonical
+
+  const token = randomUUID()
+  subscriptions.set(token, { identity, emit })
+
+  let entry = watchers.get(identity)
+  if (!entry) {
+    entry = {
+      identity,
+      gitDirWatcher: null,
+      worktreeWatchers: new Map(),
+      debounceTimer: null,
+      lastSnapshot: []
+    }
+    watchers.set(identity, entry)
+
+    const commonDir = await getCommonGitDir(canonical)
+    const gitDir = commonDir ?? (await resolveGitDir(canonical))
+    if (gitDir) {
+      try {
+        entry.gitDirWatcher = fs.watch(
+          gitDir,
+          { persistent: false, recursive: false },
+          () => scheduleRefresh(identity)
+        )
+        entry.gitDirWatcher.on('error', () => {
+          /* ignore — falls back to manual refresh */
+        })
+      } catch {
+        /* ignore */
+      }
+    }
+
+    // Seed snapshot + worktree-level watchers. If git is transiently failing,
+    // start with an empty snapshot rather than tearing down sidecar state.
+    const snapshot = await listWorktreesWithStatus(canonical)
+    if (snapshot !== null) {
+      entry.lastSnapshot = snapshot
+      rebindWorktreeWatchers(identity, snapshot)
+      emit({ repoRoot: identity, worktrees: snapshot })
+    } else {
+      emit({ repoRoot: identity, worktrees: [] })
+    }
+  } else {
+    // Emit cached snapshot to the newcomer without rescanning.
+    emit({ repoRoot: identity, worktrees: entry.lastSnapshot })
+  }
+
+  return { token, repoRoot: identity }
+}
+
+export function unwatchRepo(token: WorktreeSubscriptionToken): void {
+  const sub = subscriptions.get(token)
+  if (!sub) return
+  subscriptions.delete(token)
+
+  // If no subscribers remain for this repo, tear down watchers.
+  const stillSubscribed = [...subscriptions.values()].some((s) => s.identity === sub.identity)
+  if (stillSubscribed) return
+
+  const entry = watchers.get(sub.identity)
+  if (!entry) return
+  if (entry.debounceTimer) clearTimeout(entry.debounceTimer)
+  try {
+    entry.gitDirWatcher?.close()
+  } catch {
+    /* ignore */
+  }
+  for (const w of entry.worktreeWatchers.values()) {
+    try {
+      w.close()
+    } catch {
+      /* ignore */
+    }
+  }
+  watchers.delete(sub.identity)
+}
+
+/** Manual refresh — used by "refresh on window focus" fallback. */
+export async function refreshRepo(repoRoot: string): Promise<void> {
+  const canonical = await realpath(repoRoot)
+  const identity = (await resolveIdentity(canonical)) ?? canonical
+  await refreshAndEmit(identity, canonical)
+}
+
+/** Stop everything — call on app shutdown. */
+export function stopAll(): void {
+  for (const entry of watchers.values()) {
+    if (entry.debounceTimer) clearTimeout(entry.debounceTimer)
+    try {
+      entry.gitDirWatcher?.close()
+    } catch {
+      /* ignore */
+    }
+    for (const w of entry.worktreeWatchers.values()) {
+      try {
+        w.close()
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  watchers.clear()
+  subscriptions.clear()
+  repoQueues.clear()
+}
+
+// ── Internals ────────────────────────────────────────────────────────
+
+function rebindWorktreeWatchers(identity: string, worktrees: WorktreeInfo[]): void {
+  const entry = watchers.get(identity)
+  if (!entry) return
+  const needed = new Set(worktrees.map((w) => w.path))
+
+  // Close watchers for worktrees that no longer exist.
+  for (const [p, w] of entry.worktreeWatchers) {
+    if (!needed.has(p)) {
+      try {
+        w.close()
+      } catch {
+        /* ignore */
+      }
+      entry.worktreeWatchers.delete(p)
+    }
+  }
+
+  // Add watchers for new worktrees.
+  //
+  // Note: `recursive: true` works on macOS and Windows, but Node's fs.watch
+  // does NOT support recursive on Linux (it's silently ignored). On Linux we
+  // fall back to a shallow watch + the window-focus manual refresh path
+  // (refreshRepo) to catch nested edits. Watching the whole tree recursively
+  // on Linux would require a third-party native watcher (chokidar etc.) and
+  // was deemed out of scope.
+  const recursive = process.platform === 'darwin' || process.platform === 'win32'
+  for (const w of worktrees) {
+    if (entry.worktreeWatchers.has(w.path)) continue
+    try {
+      const watcher = fs.watch(
+        w.path,
+        { persistent: false, recursive },
+        () => scheduleRefresh(identity)
+      )
+      watcher.on('error', () => {
+        /* ignore */
+      })
+      entry.worktreeWatchers.set(w.path, watcher)
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function scheduleRefresh(identity: string): void {
+  const entry = watchers.get(identity)
+  if (!entry) return
+  if (entry.debounceTimer) clearTimeout(entry.debounceTimer)
+  entry.debounceTimer = setTimeout(() => {
+    entry.debounceTimer = null
+    // Use the identity itself as the git command cwd — it is the main
+    // checkout root, which `git worktree list` accepts.
+    void refreshAndEmit(identity, identity)
+  }, 250)
+}
+
+async function refreshAndEmit(
+  identity: string,
+  gitCwd: string,
+  changedPaths?: string[]
+): Promise<WorktreeInfo[]> {
+  const worktrees = await listWorktreesWithStatus(gitCwd)
+  if (worktrees === null) {
+    // Transient git failure — keep last snapshot intact, don't reconcile,
+    // don't emit (nothing changed from the subscriber's POV).
+    return watchers.get(identity)?.lastSnapshot ?? []
+  }
+  await reconcile(
+    identity,
+    worktrees.map((w) => w.path)
+  )
+  const entry = watchers.get(identity)
+  if (entry) {
+    entry.lastSnapshot = worktrees
+    rebindWorktreeWatchers(identity, worktrees)
+  }
+  emitToIdentity(identity, { repoRoot: identity, worktrees, changedPaths })
+  return worktrees
+}
+
+function emitToIdentity(identity: string, payload: WorktreesChangedPayload): void {
+  for (const sub of subscriptions.values()) {
+    if (sub.identity === identity) {
+      try {
+        sub.emit(payload)
+      } catch {
+        /* subscriber threw — isolate */
+      }
+    }
+  }
+}
+
+// ── Error mapping ────────────────────────────────────────────────────
+
+function mapAddError(stderr: string): WorktreeError {
+  const s = stderr.toLowerCase()
+  if (s.includes('already exists')) return worktreeError('PATH_EXISTS', stderr.trim())
+  if (s.includes('already checked out') || s.includes('is already used by worktree')) {
+    return worktreeError('BRANCH_ALREADY_CHECKED_OUT', stderr.trim())
+  }
+  if (s.includes('permission denied')) return worktreeError('PERMISSION_DENIED', stderr.trim())
+  if (s.includes('read-only') || s.includes('readonly'))
+    return worktreeError('READ_ONLY_FS', stderr.trim())
+  return worktreeError('UNKNOWN', stderr.trim() || 'git worktree add failed')
+}
+
+function mapRemoveError(stderr: string): WorktreeError {
+  const s = stderr.toLowerCase()
+  if (s.includes('not a working tree')) return worktreeError('WORKTREE_NOT_FOUND', stderr.trim())
+  if (s.includes('permission denied')) return worktreeError('PERMISSION_DENIED', stderr.trim())
+  return worktreeError('UNKNOWN', stderr.trim() || 'git worktree remove failed')
+}
+
+/**
+ * Record setup-script completion for a worktree. Resolves the repo identity
+ * internally so callers don't need to know the main-checkout path.
+ */
+export async function recordSetupResult(
+  repoRoot: string,
+  worktreePath: string,
+  exitCode: number
+): Promise<void> {
+  const identity = (await resolveIdentity(repoRoot)) ?? (await realpath(repoRoot))
+  const canonical = await realpath(worktreePath)
+  const existing = getEntry(identity, canonical)
+  if (!existing) return
+  await upsertEntry(identity, canonical, {
+    ...existing,
+    lastSetupRunAt: new Date().toISOString(),
+    lastSetupExitCode: exitCode
+  })
+}

--- a/src/main/services/worktrees/sidecar.ts
+++ b/src/main/services/worktrees/sidecar.ts
@@ -1,0 +1,204 @@
+/**
+ * DPlex-owned worktree sidecar.
+ *
+ * Git itself is the source of truth for which worktrees exist. This sidecar only
+ * stores provenance we can't derive from git:
+ *   - did DPlex create this worktree? (enables safer auto-cleanup later)
+ *   - when, and from which base branch?
+ *   - last setup script run result (informational)
+ *
+ * Storage: userData/worktrees.json
+ * Schema (v1):
+ *   {
+ *     "schemaVersion": 1,
+ *     "entries": {
+ *       "<repoIdentity>::<canonicalWorktreePath>": {
+ *         "createdByDplex": true,
+ *         "createdAt": "<iso>",
+ *         "baseBranch": "main",
+ *         "initialBranch": "feature/auth",
+ *         "lastSetupRunAt": "<iso>?",
+ *         "lastSetupExitCode": 0
+ *       }
+ *     }
+ *   }
+ *
+ * The repo-identity component is the canonical main-checkout path as returned
+ * by `gitService.getRepoIdentity`. Callers in this module never synthesize the
+ * key themselves — they pass whichever path they have and we resolve it first.
+ *
+ * Concurrency model:
+ *   - An in-memory cache holds the parsed file. It is loaded on first use.
+ *   - All reads and writes go through a single module-level promise chain so
+ *     that concurrent upserts/removes/reconciles never race the file on disk.
+ *   - Writes are atomic (write-to-tmp + rename).
+ */
+
+import * as fs from 'fs'
+import * as fsp from 'fs/promises'
+import * as path from 'path'
+import { app } from 'electron'
+
+export interface WorktreeSidecarEntry {
+  createdByDplex: boolean
+  createdAt: string
+  baseBranch: string | null
+  initialBranch: string | null
+  lastSetupRunAt?: string
+  lastSetupExitCode?: number
+}
+
+interface SidecarFile {
+  schemaVersion: number
+  entries: Record<string, WorktreeSidecarEntry>
+}
+
+const SCHEMA_VERSION = 1
+
+let cache: SidecarFile | null = null
+let opChain: Promise<unknown> = Promise.resolve()
+
+function sidecarPath(): string {
+  return path.join(app.getPath('userData'), 'worktrees.json')
+}
+
+function keyOf(repoIdentity: string, worktreePath: string): string {
+  return `${repoIdentity}::${worktreePath}`
+}
+
+function loadFromDisk(): SidecarFile {
+  try {
+    const p = sidecarPath()
+    if (!fs.existsSync(p)) return { schemaVersion: SCHEMA_VERSION, entries: {} }
+    const raw = fs.readFileSync(p, 'utf-8')
+    const parsed = JSON.parse(raw) as Partial<SidecarFile>
+    if (
+      parsed &&
+      typeof parsed === 'object' &&
+      parsed.entries &&
+      typeof parsed.entries === 'object'
+    ) {
+      return {
+        schemaVersion:
+          typeof parsed.schemaVersion === 'number' ? parsed.schemaVersion : SCHEMA_VERSION,
+        entries: parsed.entries as Record<string, WorktreeSidecarEntry>
+      }
+    }
+  } catch {
+    // Corrupted file — start fresh
+  }
+  return { schemaVersion: SCHEMA_VERSION, entries: {} }
+}
+
+function ensureCache(): SidecarFile {
+  if (cache === null) cache = loadFromDisk()
+  return cache
+}
+
+async function persist(): Promise<void> {
+  if (cache === null) return
+  try {
+    const p = sidecarPath()
+    const tmp = p + '.tmp'
+    await fsp.writeFile(tmp, JSON.stringify(cache, null, 2))
+    await fsp.rename(tmp, p)
+  } catch {
+    // Best-effort — sidecar loss downgrades features but doesn't break the app.
+  }
+}
+
+/**
+ * Serialize a sidecar operation. Returns a promise that resolves when the
+ * operation has completed (including disk flush for mutations).
+ *
+ * All sidecar exports are convenience wrappers around this so that no two
+ * writes ever interleave, even across different repos.
+ */
+function enqueue<T>(fn: () => T | Promise<T>): Promise<T> {
+  const next = opChain.then(fn, fn)
+  opChain = next.catch(() => undefined)
+  return next
+}
+
+export function getEntry(
+  repoIdentity: string,
+  worktreePath: string
+): WorktreeSidecarEntry | null {
+  const file = ensureCache()
+  return file.entries[keyOf(repoIdentity, worktreePath)] ?? null
+}
+
+export function upsertEntry(
+  repoIdentity: string,
+  worktreePath: string,
+  entry: WorktreeSidecarEntry
+): Promise<void> {
+  return enqueue(async () => {
+    const file = ensureCache()
+    file.entries[keyOf(repoIdentity, worktreePath)] = entry
+    await persist()
+  })
+}
+
+export function removeEntry(repoIdentity: string, worktreePath: string): Promise<void> {
+  return enqueue(async () => {
+    const file = ensureCache()
+    const key = keyOf(repoIdentity, worktreePath)
+    if (file.entries[key]) {
+      delete file.entries[key]
+      await persist()
+    }
+  })
+}
+
+/**
+ * Prune sidecar entries whose worktree path is not in `livePaths` for the given repo.
+ * Called after every successful list refresh so stale metadata never accumulates.
+ *
+ * NOTE: Callers MUST only invoke this when they have an authoritative list from
+ * git. Passing an empty `livePaths` after a transient git failure would wipe
+ * every entry for the repo.
+ */
+export function reconcile(repoIdentity: string, livePaths: string[]): Promise<void> {
+  return enqueue(async () => {
+    const file = ensureCache()
+    const live = new Set(livePaths)
+    const prefix = `${repoIdentity}::`
+    let mutated = false
+    for (const key of Object.keys(file.entries)) {
+      if (!key.startsWith(prefix)) continue
+      const p = key.slice(prefix.length)
+      if (!live.has(p)) {
+        delete file.entries[key]
+        mutated = true
+      }
+    }
+    if (mutated) await persist()
+  })
+}
+
+/**
+ * Read all entries for a repo — used by the list layer to enrich each worktree
+ * without N individual disk reads.
+ */
+export function getEntriesForRepo(
+  repoIdentity: string
+): Map<string, WorktreeSidecarEntry> {
+  const file = ensureCache()
+  const out = new Map<string, WorktreeSidecarEntry>()
+  const prefix = `${repoIdentity}::`
+  for (const [key, value] of Object.entries(file.entries)) {
+    if (key.startsWith(prefix)) {
+      out.set(key.slice(prefix.length), value)
+    }
+  }
+  return out
+}
+
+/**
+ * Test-only hook. Resets the in-memory cache so subsequent calls reload from
+ * disk. Safe to call at any time — the next op will trigger a fresh read.
+ */
+export function __resetCacheForTests(): void {
+  cache = null
+}

--- a/src/main/services/worktrees/types.ts
+++ b/src/main/services/worktrees/types.ts
@@ -1,0 +1,146 @@
+/**
+ * Shared types for the worktree service.
+ *
+ * Naming convention: all paths stored in these structures are canonical
+ * (realpath-resolved + path.resolve'd). Callers receiving these values can
+ * safely compare them by string equality.
+ */
+
+export type WorktreeErrorCode =
+  | 'NOT_A_GIT_REPO'
+  | 'BRANCH_ALREADY_CHECKED_OUT'
+  | 'PATH_EXISTS'
+  | 'WORKTREE_NOT_FOUND'
+  | 'BRANCH_HAS_UNPUSHED_COMMITS'
+  | 'BRANCH_NO_UPSTREAM'
+  | 'BRANCH_IS_CHECKED_OUT'
+  | 'READ_ONLY_FS'
+  | 'PERMISSION_DENIED'
+  | 'SETUP_CANCELLED'
+  | 'OPERATION_SUPERSEDED'
+  | 'IS_MAIN_CHECKOUT'
+  | 'INVALID_ARGUMENT'
+  | 'UNKNOWN'
+
+export interface WorktreeError {
+  code: WorktreeErrorCode
+  message: string
+  details?: unknown
+}
+
+export function isWorktreeError(value: unknown): value is WorktreeError {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as WorktreeError).code === 'string' &&
+    typeof (value as WorktreeError).message === 'string'
+  )
+}
+
+export function worktreeError(
+  code: WorktreeErrorCode,
+  message: string,
+  details?: unknown
+): WorktreeError {
+  return { code, message, details }
+}
+
+/**
+ * Status of a single worktree, composed from git + filesystem probes.
+ * All numeric fields default to 0; null indicates the value could not be computed.
+ */
+export interface WorktreeStatus {
+  dirtyCount: number | null
+  untrackedCount: number | null
+  stagedCount: number | null
+  ahead: number | null
+  behind: number | null
+  upstream: string | null
+}
+
+export interface WorktreeInfo {
+  /** Canonical absolute path (realpath + resolve). */
+  path: string
+  /** Short branch name (without refs/heads/), or null for detached HEAD. */
+  branch: string | null
+  /** Short commit SHA (7 chars) — always present. */
+  head: string
+  /** True if the worktree is in detached-HEAD state. */
+  detached: boolean
+  /** True if the worktree is the main checkout of its repo. */
+  isMain: boolean
+  /** True if git reports this worktree as prunable (path no longer exists / locked removal). */
+  prunable: boolean
+  /** True if we created this worktree via DPlex (from sidecar). */
+  createdByDplex: boolean
+  /** ISO timestamp when DPlex created the worktree (from sidecar). */
+  createdAt: string | null
+  /** Base branch DPlex used at creation time (from sidecar). */
+  baseBranch: string | null
+  /** Enriched status. */
+  status: WorktreeStatus
+}
+
+/**
+ * Options for creating a new worktree.
+ */
+export interface CreateWorktreeOptions {
+  /** Canonical path of the git repo root (main checkout). */
+  repoRoot: string
+  /** Desired branch name for the worktree. */
+  branch: string
+  /** If true, create a new branch from `baseBranch`; if false, check out an existing branch. */
+  newBranch: boolean
+  /** Base branch for new-branch mode (ignored when newBranch is false). */
+  baseBranch: string | null
+  /** Absolute (or repo-relative) path where the worktree should live. */
+  worktreePath: string
+  /**
+   * Optional list of env file patterns (relative to repoRoot) to copy into the
+   * new worktree. Globs are expanded simply (trailing `*` only).
+   */
+  envFiles?: string[]
+  /** Track this worktree in the DPlex sidecar as "created by DPlex". */
+  trackInSidecar?: boolean
+}
+
+export interface CreateWorktreeResult {
+  worktree: WorktreeInfo
+  opId: string
+}
+
+export interface DeleteWorktreeOptions {
+  /** Canonical repo root. */
+  repoRoot: string
+  /** Canonical worktree path to delete. */
+  worktreePath: string
+  /** Pass --force to `git worktree remove` (required if worktree is dirty). */
+  force: boolean
+  /** Also run `git branch -d/-D` on the worktree's branch after removal. */
+  deleteBranch: boolean
+  /** If set, force-delete the branch (skip the "not merged" safety check). */
+  forceDeleteBranch?: boolean
+}
+
+/**
+ * Successful delete. `warning` is non-null when the worktree was removed but
+ * an optional follow-up step (e.g. branch deletion) was skipped or failed.
+ */
+export interface DeleteWorktreeResult {
+  ok: true
+  warning: WorktreeError | null
+}
+
+/**
+ * Subscription token returned by watchRepo. Callers must pass this same token
+ * to unwatchRepo so multiple consumers can coexist without tearing down each
+ * other's subscriptions.
+ */
+export type WorktreeSubscriptionToken = string
+
+export interface WorktreesChangedPayload {
+  repoRoot: string
+  worktrees: WorktreeInfo[]
+  /** Paths of worktrees whose data changed in this update (optional hint). */
+  changedPaths?: string[]
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,6 +1,26 @@
 import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import type { AttentionSnapshot } from './attentionTypes'
+import type {
+  CreateWorktreeOptions,
+  CreateWorktreeResult,
+  DeleteWorktreeOptions,
+  DeleteWorktreeResult,
+  WorktreeError,
+  WorktreeInfo,
+  WorktreesChangedPayload
+} from '../main/services/worktrees/types'
+
+export type {
+  CreateWorktreeOptions,
+  CreateWorktreeResult,
+  DeleteWorktreeOptions,
+  DeleteWorktreeResult,
+  WorktreeError,
+  WorktreeInfo,
+  WorktreesChangedPayload
+} from '../main/services/worktrees/types'
+
 
 export interface DplexAPI {
   pty: {
@@ -59,8 +79,18 @@ export interface DplexAPI {
   }
   git: {
     getBranch: (dirPath: string) => Promise<string | null>
-    watchBranch: (dirPath: string) => Promise<string | null>
-    unwatchBranch: (repoRoot: string) => void
+    inspectPath: (
+      dirPath: string
+    ) => Promise<{
+      topLevel: string
+      mainRepoPath: string
+      isWorktree: boolean
+      branch: string | null
+    } | null>
+    watchBranch: (
+      dirPath: string
+    ) => Promise<{ token: string; repoRoot: string } | null>
+    unwatchBranch: (token: string) => void
     onBranchChanged: (callback: (repoRoot: string, branch: string | null) => void) => () => void
   }
   attention: {
@@ -71,6 +101,35 @@ export interface DplexAPI {
     setActiveTab: (compositeId: string | null) => void
     onUpdated: (callback: (snapshot: AttentionSnapshot) => void) => () => void
     onFocusSession: (callback: (compositeId: string) => void) => () => void
+  }
+  worktrees: {
+    list: (repoRoot: string) => Promise<WorktreeInfo[]>
+    listBranches: (
+      repoRoot: string
+    ) => Promise<{ local: string[]; remote: string[]; defaultBase: string | null }>
+    create: (
+      opts: CreateWorktreeOptions
+    ) => Promise<CreateWorktreeResult | WorktreeError>
+    delete: (opts: DeleteWorktreeOptions) => Promise<DeleteWorktreeResult | WorktreeError>
+    watchRepo: (repoRoot: string) => Promise<{ token: string; repoRoot: string } | null>
+    unwatchRepo: (token: string) => void
+    refresh: (repoRoot: string) => Promise<void>
+    reveal: (path: string) => Promise<void>
+    recordSetupResult: (
+      repoRoot: string,
+      worktreePath: string,
+      exitCode: number
+    ) => Promise<void>
+    /**
+     * Write the given script body to a temporary file and return a shell
+     * command that executes it. Caller should create a PTY tab with that
+     * command. A follow-up `worktrees:cleanupSetupScript` removes the tmp file.
+     */
+    prepareSetupScript: (
+      scriptBody: string
+    ) => Promise<{ command: string; tempPath: string }>
+    cleanupSetupScript: (tempPath: string) => Promise<void>
+    onChanged: (callback: (payload: WorktreesChangedPayload) => void) => () => void
   }
 }
 
@@ -148,8 +207,9 @@ const dplexAPI: DplexAPI = {
   },
   git: {
     getBranch: (dirPath: string) => ipcRenderer.invoke('git:getBranch', dirPath),
+    inspectPath: (dirPath: string) => ipcRenderer.invoke('git:inspectPath', dirPath),
     watchBranch: (dirPath: string) => ipcRenderer.invoke('git:watchBranch', dirPath),
-    unwatchBranch: (repoRoot: string) => ipcRenderer.send('git:unwatchBranch', repoRoot),
+    unwatchBranch: (token: string) => ipcRenderer.send('git:unwatchBranch', token),
     onBranchChanged: (callback: (repoRoot: string, branch: string | null) => void) => {
       const handler = (
         _event: Electron.IpcRendererEvent,
@@ -177,6 +237,30 @@ const dplexAPI: DplexAPI = {
         callback(compositeId)
       ipcRenderer.on('attention:focusSession', handler)
       return () => ipcRenderer.removeListener('attention:focusSession', handler)
+    }
+  },
+  worktrees: {
+    list: (repoRoot) => ipcRenderer.invoke('worktrees:list', repoRoot),
+    listBranches: (repoRoot) => ipcRenderer.invoke('worktrees:listBranches', repoRoot),
+    create: (opts) => ipcRenderer.invoke('worktrees:create', opts),
+    delete: (opts) => ipcRenderer.invoke('worktrees:delete', opts),
+    watchRepo: (repoRoot) => ipcRenderer.invoke('worktrees:watchRepo', repoRoot),
+    unwatchRepo: (token) => ipcRenderer.send('worktrees:unwatchRepo', token),
+    refresh: (repoRoot) => ipcRenderer.invoke('worktrees:refresh', repoRoot),
+    reveal: (path) => ipcRenderer.invoke('worktrees:reveal', path),
+    recordSetupResult: (repoRoot, worktreePath, exitCode) =>
+      ipcRenderer.invoke('worktrees:recordSetupResult', repoRoot, worktreePath, exitCode),
+    prepareSetupScript: (scriptBody) =>
+      ipcRenderer.invoke('worktrees:prepareSetupScript', scriptBody),
+    cleanupSetupScript: (tempPath) =>
+      ipcRenderer.invoke('worktrees:cleanupSetupScript', tempPath),
+    onChanged: (callback) => {
+      const handler = (
+        _event: Electron.IpcRendererEvent,
+        payload: WorktreesChangedPayload
+      ): void => callback(payload)
+      ipcRenderer.on('worktrees:changed', handler)
+      return () => ipcRenderer.removeListener('worktrees:changed', handler)
     }
   }
 }

--- a/src/renderer/src/components/common/PopoverMenu.tsx
+++ b/src/renderer/src/components/common/PopoverMenu.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
+import { createPortal } from 'react-dom'
+
+interface PopoverMenuProps {
+  anchorRef: RefObject<HTMLElement | null>
+  open: boolean
+  onClose: () => void
+  align?: 'left' | 'right'
+  /** Minimum gap from viewport edges in px. */
+  edgePadding?: number
+  className?: string
+  children: React.ReactNode
+}
+
+/**
+ * A dropdown/context menu that portals to document.body so it cannot be
+ * clipped by scrollable/overflow ancestors, and automatically flips above
+ * the anchor if there is not enough space below.
+ */
+export function PopoverMenu({
+  anchorRef,
+  open,
+  onClose,
+  align = 'right',
+  edgePadding = 8,
+  className = '',
+  children
+}: PopoverMenuProps): React.JSX.Element | null {
+  const menuRef = useRef<HTMLDivElement | null>(null)
+  const [pos, setPos] = useState<{ top: number; left: number; visibility: 'hidden' | 'visible' }>({
+    top: 0,
+    left: 0,
+    visibility: 'hidden'
+  })
+
+  useLayoutEffect(() => {
+    if (!open) return
+    const anchor = anchorRef.current
+    const menu = menuRef.current
+    if (!anchor || !menu) return
+
+    const compute = (): void => {
+      const a = anchor.getBoundingClientRect()
+      const m = menu.getBoundingClientRect()
+      const vw = window.innerWidth
+      const vh = window.innerHeight
+
+      // Vertical: prefer below; flip above if not enough room and more room above.
+      const spaceBelow = vh - a.bottom
+      const spaceAbove = a.top
+      let top: number
+      if (spaceBelow >= m.height + edgePadding || spaceBelow >= spaceAbove) {
+        top = a.bottom + 4
+        if (top + m.height + edgePadding > vh) {
+          top = Math.max(edgePadding, vh - m.height - edgePadding)
+        }
+      } else {
+        top = a.top - m.height - 4
+        if (top < edgePadding) top = edgePadding
+      }
+
+      // Horizontal: prefer requested align; clamp to viewport.
+      let left: number
+      if (align === 'right') {
+        left = a.right - m.width
+      } else {
+        left = a.left
+      }
+      if (left + m.width + edgePadding > vw) left = vw - m.width - edgePadding
+      if (left < edgePadding) left = edgePadding
+
+      setPos({ top, left, visibility: 'visible' })
+    }
+
+    compute()
+    const onScrollOrResize = (): void => compute()
+    window.addEventListener('resize', onScrollOrResize)
+    window.addEventListener('scroll', onScrollOrResize, true)
+    return () => {
+      window.removeEventListener('resize', onScrollOrResize)
+      window.removeEventListener('scroll', onScrollOrResize, true)
+    }
+  }, [open, align, edgePadding, anchorRef])
+
+  useEffect(() => {
+    if (!open) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return createPortal(
+    <>
+      <div
+        className="fixed inset-0 z-[1000]"
+        onMouseDown={(e) => {
+          e.stopPropagation()
+          onClose()
+        }}
+        onContextMenu={(e) => {
+          e.preventDefault()
+          onClose()
+        }}
+      />
+      <div
+        ref={menuRef}
+        className={`fixed z-[1001] rounded-md shadow-xl py-1 ${className}`}
+        style={{
+          top: pos.top,
+          left: pos.left,
+          visibility: pos.visibility,
+          backgroundColor: 'var(--dplex-bg)',
+          border: '1px solid var(--dplex-border)'
+        }}
+        onClick={(e) => e.stopPropagation()}
+        onMouseDown={(e) => e.stopPropagation()}
+      >
+        {children}
+      </div>
+    </>,
+    document.body
+  )
+}

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -91,6 +91,12 @@ export function AppLayout(): React.JSX.Element {
   const themeId = useSettingsStore((s) => s.settings.theme)
   const [settingsOpen, setSettingsOpen] = useState(false)
 
+  useEffect(() => {
+    const handler = (): void => setSettingsOpen(true)
+    window.addEventListener('dplex:open-settings', handler)
+    return () => window.removeEventListener('dplex:open-settings', handler)
+  }, [])
+
   const theme = getTheme(themeId)
 
   // Apply theme CSS variables (including status colors)

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -8,17 +8,29 @@ import {
   MoreVertical,
   Terminal,
   Copy,
-  Trash2
+  Trash2,
+  GitFork,
+  Settings2,
+  FolderOpen
 } from 'lucide-react'
-import type { Project, AISession, ProviderInfo } from '../../types'
+import type { Project, AISession, ProviderInfo, WorktreeDefaults } from '../../types'
 import { useProjectStore } from '../../stores/projectStore'
 import { useTerminalStore } from '../../stores/terminalStore'
 import { useSessionStore } from '../../stores/sessionStore'
+import { useSettingsStore } from '../../stores/settingsStore'
 import { useGitBranch } from '../../hooks/useGitBranch'
+import { useWorktrees } from '../../hooks/useWorktrees'
 import { STATUS_ACTIVE_COLOR, STATUS_ACTIVE_BG } from '../../utils/statusColors'
 import { SessionItem } from '../sessions/SessionItem'
 import { PromptsDialog } from '../sessions/PromptsDialog'
 import type { ProjectActivity } from '../../hooks/useProjectSessions'
+import { normalizePath } from '../../hooks/useProjectSessions'
+import { PopoverMenu } from '../common/PopoverMenu'
+import { NewWorktreeModal } from '../worktrees/NewWorktreeModal'
+import { ManageWorktreesModal } from '../worktrees/ManageWorktreesModal'
+import { RemoveWorktreeProjectModal } from '../worktrees/RemoveWorktreeProjectModal'
+import { ProjectWorktreeDefaultsModal } from '../worktrees/ProjectWorktreeDefaultsModal'
+import { handleWorktreeCreated } from '../../services/worktreePostCreate'
 
 interface ProjectItemProps {
   project: Project
@@ -26,6 +38,14 @@ interface ProjectItemProps {
   providers: ProviderInfo[]
   isDragging: boolean
   dragOverPosition: 'above' | 'below' | null
+  /** Nesting depth (0 = origin, 1 = worktree-project). Drives the indent. */
+  indent?: number
+  /** Parent project record — used by "Open origin". */
+  parentProject?: Project
+  /** Worktree-child projects to render inline within this project's expanded body. */
+  childProjects?: Project[]
+  /** Resolves activity for a child project path. */
+  getActivity?: (path: string) => ProjectActivity
   onDragStart: (id: string) => void
   onDragOver: (id: string, e: React.DragEvent) => void
   onDrop: (id: string) => void
@@ -53,7 +73,11 @@ export function ProjectItem({
   onDragStart,
   onDragOver,
   onDrop,
-  onDragEnd
+  onDragEnd,
+  indent = 0,
+  parentProject,
+  childProjects,
+  getActivity
 }: ProjectItemProps): React.JSX.Element {
   const expandedIds = useProjectStore((s) => s.expandedProjectIds)
   const toggleExpanded = useProjectStore((s) => s.toggleExpanded)
@@ -63,26 +87,94 @@ export function ProjectItem({
   const setActiveTerminalInGroup = useTerminalStore((s) => s.setActiveTerminalInGroup)
   const createTerminal = useTerminalStore((s) => s.createTerminal)
   const deleteSession = useSessionStore((s) => s.deleteSession)
+  const globalDefaults = useSettingsStore((s) => s.settings.worktreeDefaults)
   const [canDrag, setCanDrag] = useState(false)
   const [showMenu, setShowMenu] = useState(false)
   const [promptsSession, setPromptsSession] = useState<AISession | null>(null)
+  const [newWtOpen, setNewWtOpen] = useState(false)
+  const [manageOpen, setManageOpen] = useState(false)
+  const [defaultsOpen, setDefaultsOpen] = useState(false)
+  const [removeWtOpen, setRemoveWtOpen] = useState(false)
   const dragHandleRef = useRef<HTMLSpanElement>(null)
+  const menuAnchorRef = useRef<HTMLButtonElement>(null)
+
+  const isWorktreeProject = Boolean(project.parentProjectId || project.parentRepoPath)
+  // Only subscribe to worktree info when we actually need it (for the modal
+  // or for disk-deletion) — avoids a watcher for every worktree-project.
+  const needWtWatch = newWtOpen || manageOpen || removeWtOpen
+  const watchPath = isWorktreeProject ? (parentProject?.path ?? project.parentRepoPath ?? project.path) : project.path
+  const { repoRoot } = useWorktrees(needWtWatch ? watchPath : undefined)
 
   const isExpanded = expandedIds.has(project.id)
   const branch = useGitBranch(project.path)
   const { sessions, openTabs, activeCount, hasActive, lastActivity } = activity
+  // Worktree children render compactly: a single-line row with a left thread
+  // line connecting them to the origin project. Sessions hang off that thread.
+  const isCompact = isWorktreeProject && indent > 0
+
+  const defaults: WorktreeDefaults = (() => {
+    const override = project.worktreeOverrides
+    if (!override) return globalDefaults
+    return {
+      locationPattern: override.locationPattern ?? globalDefaults.locationPattern,
+      envFiles:
+        override.envFiles === null || override.envFiles === undefined
+          ? globalDefaults.envFiles
+          : override.envFiles,
+      setupScript: override.setupScript ?? globalDefaults.setupScript,
+      afterCreate: override.afterCreate ?? globalDefaults.afterCreate
+    }
+  })()
 
   const handleFocusTab = (tabId: string, groupId: string): void => {
     setActiveGroup(groupId)
     setActiveTerminalInGroup(groupId, tabId)
   }
 
+  const focusOrigin = (): void => {
+    if (!parentProject) return
+    // Scroll the origin project into view and flash-highlight it.
+    const el = document.querySelector(`[data-project-id="${parentProject.id}"]`)
+    el?.scrollIntoView({ block: 'center', behavior: 'smooth' })
+  }
+
   return (
     <div
       data-reorderable-id={project.id}
-      className="mb-2"
-      style={{ opacity: isDragging ? 0.4 : 1 }}
+      className={isCompact ? 'relative' : 'mb-2 rounded-sm overflow-hidden'}
+      style={{
+        opacity: isDragging ? 0.4 : 1,
+        marginLeft: indent ? indent * 16 : undefined,
+        backgroundColor: isCompact ? undefined : 'var(--dplex-bg-alt)',
+        border: isCompact ? undefined : '1px solid var(--dplex-border)'
+      }}
     >
+      {/* Thread line connecting the worktree row to the parent project. */}
+      {isCompact && (
+        <>
+          <div
+            aria-hidden
+            className="absolute pointer-events-none"
+            style={{
+              left: 6,
+              top: 0,
+              bottom: isExpanded ? 0 : '50%',
+              borderLeft: '1px solid var(--dplex-border)'
+            }}
+          />
+          <div
+            aria-hidden
+            className="absolute pointer-events-none"
+            style={{
+              left: 6,
+              top: 14,
+              width: 8,
+              borderTop: '1px solid var(--dplex-border)'
+            }}
+          />
+        </>
+      )}
+
       {/* Drop indicator above */}
       {dragOverPosition === 'above' && (
         <div className="mx-2 h-0.5 rounded" style={{ backgroundColor: 'var(--dplex-accent)' }} />
@@ -91,11 +183,14 @@ export function ProjectItem({
       {/* Project section header */}
       <div
         data-project-id={project.id}
-        className="group flex items-center gap-1.5 px-2 py-1.5 cursor-pointer relative"
-        style={{
-          backgroundColor: 'var(--dplex-bg-alt)',
-          borderBottom: '1px solid var(--dplex-border)'
-        }}
+        className={
+          isCompact
+            ? 'group flex items-center gap-1.5 pl-4 pr-2 py-1 cursor-pointer relative rounded-sm hover:bg-[var(--dplex-hover)]'
+            : 'group flex items-center gap-1.5 px-2 py-1.5 cursor-pointer relative'
+        }
+        style={
+          isCompact || !isExpanded ? undefined : { borderBottom: '1px solid var(--dplex-border)' }
+        }
         draggable={canDrag}
         onDragStart={(e) => {
           e.dataTransfer.effectAllowed = 'move'
@@ -116,28 +211,49 @@ export function ProjectItem({
         }}
         onClick={() => toggleExpanded(project.id)}
       >
-        {/* Drag handle */}
-        <span
-          ref={dragHandleRef}
-          className="flex-shrink-0 cursor-grab opacity-0 group-hover:opacity-40 hover:!opacity-80 transition-opacity"
-          style={{ color: 'var(--dplex-text-muted)' }}
-          onMouseDown={() => setCanDrag(true)}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <GripVertical size={11} />
-        </span>
+        {/* Drag handle — hidden for worktree children (they stay with parent). */}
+        {!isCompact && (
+          <span
+            ref={dragHandleRef}
+            className="flex-shrink-0 cursor-grab opacity-0 group-hover:opacity-40 hover:!opacity-80 transition-opacity"
+            style={{ color: 'var(--dplex-text-muted)' }}
+            onMouseDown={() => setCanDrag(true)}
+            onClick={(e) => e.stopPropagation()}
+          >
+            <GripVertical size={11} />
+          </span>
+        )}
 
         {/* Chevron */}
         <span style={{ color: 'var(--dplex-accent)' }} className="flex-shrink-0">
           {isExpanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
         </span>
 
+        {/* Branch icon — only for worktree children, where the name IS the branch. */}
+        {isCompact && (
+          <GitBranch
+            size={10}
+            className="flex-shrink-0"
+            style={{ color: 'var(--dplex-text-muted)' }}
+          />
+        )}
+
         {/* Name + count */}
         <span
-          className="text-[11px] font-semibold truncate"
+          className={
+            isCompact ? 'text-[11px] font-medium truncate' : 'text-[11px] font-semibold truncate'
+          }
           style={{ color: 'var(--dplex-text)' }}
         >
           {project.name}
+          {isWorktreeProject && !parentProject && project.parentRepoName && (
+            <span
+              className="ml-1 font-normal"
+              style={{ color: 'var(--dplex-text-muted)', opacity: 0.7 }}
+            >
+              ({project.parentRepoName})
+            </span>
+          )}
         </span>
         {activeCount > 0 && (
           <span
@@ -168,6 +284,7 @@ export function ProjectItem({
             </button>
           ))}
           <button
+            ref={menuAnchorRef}
             onClick={(e) => {
               e.stopPropagation()
               setShowMenu(!showMenu)
@@ -181,88 +298,154 @@ export function ProjectItem({
         </div>
 
         {/* Context menu */}
-        {showMenu && (
-          <>
-            <div className="fixed inset-0 z-[55]" onClick={(e) => { e.stopPropagation(); setShowMenu(false) }} />
-            <div
-              className="absolute right-2 top-full mt-1 z-[60] rounded-md shadow-xl py-1 min-w-[160px]"
-              style={{ backgroundColor: 'var(--dplex-bg)', border: '1px solid var(--dplex-border)' }}
+        <PopoverMenu
+          anchorRef={menuAnchorRef}
+          open={showMenu}
+          onClose={() => setShowMenu(false)}
+          className="min-w-[160px]"
+        >
+          {providers.map((p) => (
+            <button
+              key={p.id}
+              onClick={(e) => {
+                e.stopPropagation()
+                startAISession(project, p.id)
+                setShowMenu(false)
+              }}
+              className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+              style={{ color: 'var(--dplex-text)' }}
             >
-              {providers.map((p) => (
-                <button
-                  key={p.id}
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    startAISession(project, p.id)
-                    setShowMenu(false)
-                  }}
-                  className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-                  style={{ color: 'var(--dplex-text)' }}
-                >
-                  <Play size={11} /> Start {p.name}
-                </button>
-              ))}
+              <Play size={11} /> Start {p.name}
+            </button>
+          ))}
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              createTerminal(undefined, project.name, undefined, undefined, project.path)
+              setShowMenu(false)
+            }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            <Terminal size={11} /> Open Terminal
+          </button>
+
+          <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+
+          {/* Worktree operations — differ by origin vs worktree-project. */}
+          {!isWorktreeProject && (
+            <>
               <button
                 onClick={(e) => {
                   e.stopPropagation()
-                  createTerminal(undefined, project.name, undefined, undefined, project.path)
+                  setNewWtOpen(true)
                   setShowMenu(false)
                 }}
                 className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
                 style={{ color: 'var(--dplex-text)' }}
               >
-                <Terminal size={11} /> Open Terminal
+                <GitFork size={11} /> New worktree…
               </button>
-
-              <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
-
               <button
                 onClick={(e) => {
                   e.stopPropagation()
-                  navigator.clipboard.writeText(project.path)
+                  setManageOpen(true)
                   setShowMenu(false)
                 }}
                 className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
                 style={{ color: 'var(--dplex-text)' }}
               >
-                <Copy size={11} /> Copy Path
+                <Settings2 size={11} /> Manage worktrees…
               </button>
-              {branch && (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    navigator.clipboard.writeText(branch)
-                    setShowMenu(false)
-                  }}
-                  className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-                  style={{ color: 'var(--dplex-text)' }}
-                >
-                  <GitBranch size={11} /> Copy Branch
-                </button>
-              )}
-
-              <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
-
               <button
                 onClick={(e) => {
                   e.stopPropagation()
-                  removeProject(project.id)
+                  setDefaultsOpen(true)
                   setShowMenu(false)
                 }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-red-400 hover:bg-[var(--dplex-hover)]"
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+                style={{ color: 'var(--dplex-text)' }}
               >
-                <Trash2 size={11} /> Remove Project
+                <Settings2 size={11} /> Worktree defaults…
               </button>
-            </div>
-          </>
-        )}
+              <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+            </>
+          )}
+          {isWorktreeProject && parentProject && (
+            <>
+              <button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  focusOrigin()
+                  setShowMenu(false)
+                }}
+                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+                style={{ color: 'var(--dplex-text)' }}
+              >
+                <FolderOpen size={11} /> Open origin project
+              </button>
+              <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+            </>
+          )}
+
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              navigator.clipboard.writeText(project.path)
+              setShowMenu(false)
+            }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            <Copy size={11} /> Copy Path
+          </button>
+          {branch && (
+            <button
+              onClick={(e) => {
+                e.stopPropagation()
+                navigator.clipboard.writeText(branch)
+                setShowMenu(false)
+              }}
+              className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+              style={{ color: 'var(--dplex-text)' }}
+            >
+              <GitBranch size={11} /> Copy Branch
+            </button>
+          )}
+
+          <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              if (isWorktreeProject) {
+                setRemoveWtOpen(true)
+              } else {
+                removeProject(project.id)
+              }
+              setShowMenu(false)
+            }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-red-400 hover:bg-[var(--dplex-hover)]"
+          >
+            <Trash2 size={11} /> {isWorktreeProject ? 'Remove worktree…' : 'Remove Project'}
+          </button>
+        </PopoverMenu>
       </div>
 
       {/* Expanded: sessions */}
       {isExpanded && (
-        <div style={{ backgroundColor: 'var(--dplex-bg)' }}>
-          {/* Branch + last activity info */}
-          {(branch || lastActivity) && (
+        <div
+          style={{
+            backgroundColor: 'transparent',
+            // Indent the compact body so sessions align under the worktree
+            // name; the outer thread line (rendered on the row container) is
+            // the single vertical rule — no second borderLeft here.
+            marginLeft: isCompact ? 18 : undefined
+          }}
+        >
+          {/* Branch + last activity info — origin only. For worktree children
+              the branch IS the name and the time sits on the collapsed row. */}
+          {!isCompact && (branch || lastActivity) && (
             <div
               className="flex items-center gap-1.5 px-3 py-1 text-[10px]"
               style={{ color: 'var(--dplex-text-muted)' }}
@@ -284,68 +467,96 @@ export function ProjectItem({
 
           {!hasActive && openTabs.length === 0 ? (
             <div
-              className="px-3 py-2 text-[10px]"
-              style={{ color: 'var(--dplex-text-muted)' }}
+              className="px-3 py-1.5 text-[10px]"
+              style={{ color: 'var(--dplex-text-muted)', opacity: 0.7 }}
             >
               No active sessions.
             </div>
           ) : (
-            <>
-              {/* Sessions from open tabs (matched to discovered sessions) */}
-              {openTabs.map((tab) => {
-                const matchedSession = sessions.find((s) => s.id === tab.sessionId)
-                if (matchedSession) {
-                  return (
+            (() => {
+              // Pair each open tab to an AI session. First by explicit sessionId,
+              // then fall back to CWD + provider when the resolver hasn't caught
+              // up yet (avoids rendering a placeholder + the session separately).
+              const claimed = new Set<string>()
+              const pairs = openTabs.map((tab) => {
+                let match = tab.sessionId ? sessions.find((s) => s.id === tab.sessionId) : undefined
+                if (!match) {
+                  match = sessions.find((s) => {
+                    if (claimed.has(s.id)) return false
+                    if (s.status !== 'active') return false
+                    if (!s.cwd || !tab.cwd) return false
+                    if (normalizePath(s.cwd) !== normalizePath(tab.cwd)) return false
+                    const cmd = tab.command?.toLowerCase() ?? ''
+                    return cmd.length === 0 || cmd.includes(s.aiTool.toLowerCase())
+                  })
+                }
+                if (match) claimed.add(match.id)
+                return { tab, match }
+              })
+              const unpaired = sessions.filter((s) => s.status === 'active' && !claimed.has(s.id))
+              return (
+                <>
+                  {pairs.map(({ tab, match }) =>
+                    match ? (
+                      <SessionItem
+                        key={tab.id}
+                        session={match}
+                        onDelete={deleteSession}
+                        onShowPrompts={setPromptsSession}
+                        compact
+                        onClick={() => handleFocusTab(tab.id, tab.groupId)}
+                      />
+                    ) : (
+                      <div
+                        key={tab.id}
+                        className="flex items-center gap-2 px-3 py-2 hover:bg-[var(--dplex-hover)] cursor-pointer rounded-sm mx-1"
+                        onClick={() => handleFocusTab(tab.id, tab.groupId)}
+                      >
+                        <span
+                          className="w-2 h-2 rounded-full flex-shrink-0"
+                          style={{ backgroundColor: STATUS_ACTIVE_COLOR }}
+                        />
+                        <span className="text-xs truncate" style={{ color: 'var(--dplex-text)' }}>
+                          {tab.title}
+                        </span>
+                      </div>
+                    )
+                  )}
+                  {unpaired.map((session) => (
                     <SessionItem
-                      key={tab.id}
-                      session={matchedSession}
+                      key={session.id}
+                      session={session}
                       onDelete={deleteSession}
                       onShowPrompts={setPromptsSession}
                       compact
-                      onClick={() => handleFocusTab(tab.id, tab.groupId)}
                     />
-                  )
-                }
-                // Tab without a resolved session yet — simple placeholder row
-                return (
-                  <div
-                    key={tab.id}
-                    className="flex items-center gap-2 px-3 py-2 hover:bg-[var(--dplex-hover)] cursor-pointer rounded-sm mx-1"
-                    onClick={() => handleFocusTab(tab.id, tab.groupId)}
-                  >
-                    <span
-                      className="w-2 h-2 rounded-full flex-shrink-0"
-                      style={{ backgroundColor: STATUS_ACTIVE_COLOR }}
-                    />
-                    <span
-                      className="text-xs truncate"
-                      style={{ color: 'var(--dplex-text)' }}
-                    >
-                      {tab.title}
-                    </span>
-                  </div>
-                )
-              })}
+                  ))}
+                </>
+              )
+            })()
+          )}
 
-              {/* Active sessions not yet open in a tab */}
-              {sessions
-                .filter((s) =>
-                  s.status === 'active' &&
-                  !openTabs.some((t) =>
-                    t.sessionId === s.id ||
-                    (t.command && t.command.includes(s.id))
-                  )
-                )
-                .map((session) => (
-                  <SessionItem
-                    key={session.id}
-                    session={session}
-                    onDelete={deleteSession}
-                    onShowPrompts={setPromptsSession}
-                    compact
-                  />
-                ))}
-            </>
+          {/* Worktree children — rendered inline inside this project's card so
+              they visually belong to it (origin only). */}
+          {!isCompact && childProjects && childProjects.length > 0 && getActivity && (
+            <div className="pb-1">
+              {childProjects.map((child) => (
+                <ProjectItem
+                  key={child.id}
+                  project={child}
+                  parentProject={project}
+                  indent={1}
+                  activity={getActivity(child.path)}
+                  providers={providers}
+                  isDragging={false}
+                  dragOverPosition={null}
+                  onDragStart={onDragStart}
+                  onDragOver={onDragOver}
+                  onDrop={onDrop}
+                  onDragEnd={onDragEnd}
+                />
+              ))}
+            </div>
           )}
         </div>
       )}
@@ -357,6 +568,53 @@ export function ProjectItem({
           sessionName={promptsSession.displayName}
           providerId={promptsSession.aiTool}
           onClose={() => setPromptsSession(null)}
+        />
+      )}
+
+      {/* Worktree creation modal (origin only). */}
+      {newWtOpen && repoRoot && (
+        <NewWorktreeModal
+          project={project}
+          repoRoot={repoRoot}
+          defaults={defaults}
+          providers={providers}
+          onClose={() => setNewWtOpen(false)}
+          onCreated={(result) => {
+            setNewWtOpen(false)
+            void handleWorktreeCreated({
+              originProject: project,
+              worktreePath: result.worktreePath,
+              branch: result.branch,
+              afterCreate: result.afterCreate,
+              providerId: result.providerId,
+              setupScript: result.setupScript,
+              createdByDplexWorktree: true
+            })
+          }}
+        />
+      )}
+
+      {manageOpen && (
+        <ManageWorktreesModal
+          originProject={project}
+          providers={providers}
+          onClose={() => setManageOpen(false)}
+        />
+      )}
+
+      {defaultsOpen && (
+        <ProjectWorktreeDefaultsModal
+          project={project}
+          onClose={() => setDefaultsOpen(false)}
+        />
+      )}
+
+      {removeWtOpen && (
+        <RemoveWorktreeProjectModal
+          project={project}
+          repoRoot={repoRoot}
+          onClose={() => setRemoveWtOpen(false)}
+          onRemoved={() => setRemoveWtOpen(false)}
         />
       )}
 

--- a/src/renderer/src/components/projects/ProjectList.tsx
+++ b/src/renderer/src/components/projects/ProjectList.tsx
@@ -6,7 +6,7 @@ import { ProjectItem } from './ProjectItem'
 import { FolderPlus } from 'lucide-react'
 import { useReorderable } from '../../hooks/useReorderable'
 import { buildProjectSessionIndex } from '../../hooks/useProjectSessions'
-import type { ProviderInfo } from '../../types'
+import type { Project, ProviderInfo } from '../../types'
 
 interface ProjectListProps {
   searchQuery?: string
@@ -28,36 +28,70 @@ export function ProjectList({ searchQuery, activeOnly }: ProjectListProps): Reac
     }
   }, [loaded])
 
-  // Load providers once
   useEffect(() => {
     window.dplex.sessions.getProviders().then(setProviders)
   }, [])
 
-  // Build session index once for all projects
   const projectPaths = useMemo(() => projects.map((p) => p.path), [projects])
   const sessionIndex = useMemo(
     () => buildProjectSessionIndex(sessions, groups, projectPaths),
     [sessions, groups, projectPaths]
   )
 
-  // Filter projects
-  const filteredProjects = useMemo(() => {
-    let result = projects
+  // Build parentId→children map keyed by project id. Orphan children (whose
+  // parent was removed) fall back to being rendered as top-level projects.
+  const childrenByParent = useMemo(() => {
+    const idSet = new Set(projects.map((p) => p.id))
+    const m = new Map<string, Project[]>()
+    for (const p of projects) {
+      if (p.parentProjectId && idSet.has(p.parentProjectId)) {
+        const arr = m.get(p.parentProjectId) ?? []
+        arr.push(p)
+        m.set(p.parentProjectId, arr)
+      }
+    }
+    return m
+  }, [projects])
 
-    if (searchQuery) {
-      const q = searchQuery.toLowerCase()
-      result = result.filter((p) => p.name.toLowerCase().includes(q))
+  // Render-order projects. Only top-level origins render directly here — their
+  // worktree children render INSIDE the parent's expanded body (so they share
+  // the parent's contrasted background container). Orphans whose parent was
+  // removed still get surfaced at top level.
+  const filtered = useMemo(() => {
+    const q = searchQuery?.toLowerCase() ?? ''
+    const matchesFilter = (p: Project): boolean => {
+      if (q && !p.name.toLowerCase().includes(q)) return false
+      if (activeOnly && !sessionIndex.get(p.path)?.hasActive) return false
+      return true
     }
 
-    if (activeOnly) {
-      result = result.filter((p) => {
-        const activity = sessionIndex.get(p.path)
-        return activity?.hasActive
-      })
-    }
+    const idSet = new Set(projects.map((p) => p.id))
+    const isOrphan = (p: Project): boolean =>
+      Boolean(p.parentProjectId) && !idSet.has(p.parentProjectId!)
+    const isTopLevel = (p: Project): boolean => !p.parentProjectId || isOrphan(p)
 
+    const hasFilter = Boolean(q) || Boolean(activeOnly)
+    const result: { project: Project; children?: Project[] }[] = []
+
+    for (const p of projects) {
+      if (!isTopLevel(p)) continue
+
+      const kids = childrenByParent.get(p.id) ?? []
+      const visibleKids = kids.filter(matchesFilter)
+      const parentMatches = matchesFilter(p)
+
+      if (hasFilter) {
+        // When filtering, surface any matching item at top level (flat) so
+        // matches aren't hidden by a collapsed parent. Parent gets no children
+        // in filter mode — matching children appear as their own top-level rows.
+        if (parentMatches) result.push({ project: p })
+        for (const kid of visibleKids) result.push({ project: kid })
+      } else {
+        result.push({ project: p, children: kids })
+      }
+    }
     return result
-  }, [projects, searchQuery, activeOnly, sessionIndex])
+  }, [projects, childrenByParent, searchQuery, activeOnly, sessionIndex])
 
   const handleReorder = useCallback(
     (draggedId: string, targetId: string, position: 'above' | 'below') => {
@@ -71,10 +105,15 @@ export function ProjectList({ searchQuery, activeOnly }: ProjectListProps): Reac
   return (
     <div
       className="flex flex-col min-h-full pt-1"
-      onDragOver={(e) => handlers.onContainerDragOver(e, filteredProjects)}
+      onDragOver={(e) =>
+        handlers.onContainerDragOver(
+          e,
+          filtered.map((r) => r.project)
+        )
+      }
       onDrop={(e) => handlers.onContainerDrop(e)}
     >
-      {filteredProjects.length === 0 && (
+      {filtered.length === 0 && (
         <div className="px-4 py-8 text-center" style={{ color: 'var(--dplex-text-muted)' }}>
           {projects.length === 0 ? (
             <div className="flex flex-col items-center gap-2">
@@ -92,17 +131,29 @@ export function ProjectList({ searchQuery, activeOnly }: ProjectListProps): Reac
         </div>
       )}
 
-      {filteredProjects.map((project) => (
+      {filtered.map(({ project, children }) => (
         <ProjectItem
           key={project.id}
           project={project}
-          activity={sessionIndex.get(project.path) ?? {
-            sessions: [],
-            openTabs: [],
-            activeCount: 0,
-            hasActive: false,
-            lastActivity: undefined
-          }}
+          childProjects={children}
+          getActivity={(path) =>
+            sessionIndex.get(path) ?? {
+              sessions: [],
+              openTabs: [],
+              activeCount: 0,
+              hasActive: false,
+              lastActivity: undefined
+            }
+          }
+          activity={
+            sessionIndex.get(project.path) ?? {
+              sessions: [],
+              openTabs: [],
+              activeCount: 0,
+              hasActive: false,
+              lastActivity: undefined
+            }
+          }
           providers={providers}
           isDragging={isDragging(project.id)}
           dragOverPosition={dragOverPosition(project.id)}

--- a/src/renderer/src/components/sessions/SessionItem.tsx
+++ b/src/renderer/src/components/sessions/SessionItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import {
   MoreVertical,
   Play,
@@ -16,6 +16,7 @@ import type { AISession, SessionStatus } from '../../types'
 import { useTerminalStore } from '../../stores/terminalStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useProjectStore } from '../../stores/projectStore'
+import { PopoverMenu } from '../common/PopoverMenu'
 
 interface SessionItemProps {
   session: AISession
@@ -97,6 +98,7 @@ export function SessionItem({ session, onDelete, onShowPrompts, compact, onClick
   const createTerminal = useTerminalStore((s) => s.createTerminal)
   const closeSession = useSessionStore((s) => s.closeSession)
   const [showMenu, setShowMenu] = useState(false)
+  const menuAnchorRef = useRef<HTMLButtonElement>(null)
 
   const status = session.detailedStatus ?? (session.status === 'active' ? 'thinking' : 'idle')
   const config = STATUS_CONFIG[status]
@@ -239,6 +241,7 @@ export function SessionItem({ session, onDelete, onShowPrompts, compact, onClick
 
       {/* Three-dot menu button */}
       <button
+        ref={menuAnchorRef}
         onClick={(e) => {
           e.stopPropagation()
           setShowMenu(!showMenu)
@@ -249,113 +252,107 @@ export function SessionItem({ session, onDelete, onShowPrompts, compact, onClick
       </button>
 
       {/* Context menu */}
-      {showMenu && (
-        <>
-          <div className="fixed inset-0 z-40" onClick={(e) => { e.stopPropagation(); setShowMenu(false) }} />
-          <div
-            className="absolute right-2 top-8 z-50 rounded shadow-xl py-1 min-w-[160px]"
-            style={{
-              backgroundColor: 'var(--dplex-bg)',
-              border: '1px solid var(--dplex-border)'
+      <PopoverMenu
+        anchorRef={menuAnchorRef}
+        open={showMenu}
+        onClose={() => setShowMenu(false)}
+        className="min-w-[160px]"
+      >
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            handleResume()
+          }}
+          className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+          style={{ color: 'var(--dplex-text)' }}
+        >
+          <Play size={11} /> Resume
+        </button>
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onShowPrompts?.(session)
+            setShowMenu(false)
+          }}
+          className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+          style={{ color: 'var(--dplex-text)' }}
+        >
+          <MessagesSquare size={11} /> Show Prompts
+        </button>
+        {session.status === 'active' && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              closeSession(session.id)
+              setShowMenu(false)
             }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
           >
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                handleResume()
-              }}
-              className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-              style={{ color: 'var(--dplex-text)' }}
-            >
-              <Play size={11} /> Resume
-            </button>
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onShowPrompts?.(session)
-                setShowMenu(false)
-              }}
-              className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-              style={{ color: 'var(--dplex-text)' }}
-            >
-              <MessagesSquare size={11} /> Show Prompts
-            </button>
-            {session.status === 'active' && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  closeSession(session.id)
-                  setShowMenu(false)
-                }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-                style={{ color: 'var(--dplex-text)' }}
-              >
-                <Square size={11} /> Close
-              </button>
-            )}
-            <div style={{ borderTop: '1px solid var(--dplex-border)' }} className="my-1" />
-            {session.cwd && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  handleCopyCwd()
-                }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-                style={{ color: 'var(--dplex-text)' }}
-              >
-                <FolderOpen size={11} /> Copy Path
-              </button>
-            )}
-            {session.branch && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  navigator.clipboard.writeText(session.branch!)
-                  setShowMenu(false)
-                }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-                style={{ color: 'var(--dplex-text)' }}
-              >
-                <GitBranch size={11} /> Copy Branch
-              </button>
-            )}
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                handleCopyId()
-              }}
-              className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-              style={{ color: 'var(--dplex-text)' }}
-            >
-              <Copy size={11} /> Copy Session ID
-            </button>
-            {!compact && session.cwd && (
-              <button
-                onClick={(e) => {
-                  e.stopPropagation()
-                  useProjectStore.getState().addProject(session.cwd)
-                  setShowMenu(false)
-                }}
-                className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
-                style={{ color: 'var(--dplex-text)' }}
-              >
-                <FolderPlus size={11} /> Pin as Project
-              </button>
-            )}
-            <div style={{ borderTop: '1px solid var(--dplex-border)' }} className="my-1" />
-            <button
-              onClick={(e) => {
-                e.stopPropagation()
-                onDelete(session.id)
-                setShowMenu(false)
-              }}
-              className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-red-400 hover:bg-[var(--dplex-hover)]"
-            >
-              <Trash2 size={11} /> Delete
-            </button>
-          </div>
-        </>
-      )}
+            <Square size={11} /> Close
+          </button>
+        )}
+        <div style={{ borderTop: '1px solid var(--dplex-border)' }} className="my-1" />
+        {session.cwd && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              handleCopyCwd()
+            }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            <FolderOpen size={11} /> Copy Path
+          </button>
+        )}
+        {session.branch && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              navigator.clipboard.writeText(session.branch!)
+              setShowMenu(false)
+            }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            <GitBranch size={11} /> Copy Branch
+          </button>
+        )}
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            handleCopyId()
+          }}
+          className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+          style={{ color: 'var(--dplex-text)' }}
+        >
+          <Copy size={11} /> Copy Session ID
+        </button>
+        {!compact && session.cwd && (
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              useProjectStore.getState().addProject(session.cwd)
+              setShowMenu(false)
+            }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            <FolderPlus size={11} /> Pin as Project
+          </button>
+        )}
+        <div style={{ borderTop: '1px solid var(--dplex-border)' }} className="my-1" />
+        <button
+          onClick={(e) => {
+            e.stopPropagation()
+            onDelete(session.id)
+            setShowMenu(false)
+          }}
+          className="flex items-center gap-2 w-full px-3 py-1.5 text-xs text-red-400 hover:bg-[var(--dplex-hover)]"
+        >
+          <Trash2 size={11} /> Delete
+        </button>
+      </PopoverMenu>
     </div>
   )
 }

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
-import { X, Settings, Palette, Terminal, Bot, Keyboard, BellRing } from 'lucide-react'
+import { X, Settings, Palette, Terminal, Bot, Keyboard, BellRing, GitBranch } from 'lucide-react'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { getThemesByVariant, getTheme } from '../../services/themes'
@@ -12,7 +12,7 @@ interface SettingsModalProps {
   onClose: () => void
 }
 
-type SettingsTab = 'appearance' | 'terminal' | 'ai-tools' | 'notifications' | 'shortcuts'
+type SettingsTab = 'appearance' | 'terminal' | 'ai-tools' | 'notifications' | 'worktrees' | 'shortcuts'
 
 const SHORTCUTS: { category: string; items: { keys: string; description: string }[] }[] = [
   {
@@ -46,6 +46,7 @@ const TABS: { id: SettingsTab; label: string; icon: typeof Palette }[] = [
   { id: 'terminal', label: 'Terminal', icon: Terminal },
   { id: 'ai-tools', label: 'AI Tools', icon: Bot },
   { id: 'notifications', label: 'Notifications', icon: BellRing },
+  { id: 'worktrees', label: 'Worktrees', icon: GitBranch },
   { id: 'shortcuts', label: 'Shortcuts', icon: Keyboard }
 ]
 
@@ -90,6 +91,17 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
     window.addEventListener('keydown', handleKey)
     return () => window.removeEventListener('keydown', handleKey)
   }, [isOpen, onClose])
+
+  useEffect(() => {
+    const handler = (e: Event): void => {
+      const detail = (e as CustomEvent<{ section?: string }>).detail
+      if (detail?.section === 'worktrees') {
+        setActiveTab('worktrees')
+      }
+    }
+    window.addEventListener('dplex:open-settings', handler)
+    return () => window.removeEventListener('dplex:open-settings', handler)
+  }, [])
 
   // Clear debounce timer on unmount to prevent stale writes
   useEffect(() => {
@@ -519,6 +531,116 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                     </span>
                   </div>
                 </SettingItem>
+              </>
+            )}
+
+            {activeTab === 'worktrees' && (
+              <>
+                <SettingItem
+                  label="Location pattern"
+                  description="Where new worktrees are created. Supports {project} and {branch} placeholders."
+                >
+                  <input
+                    type="text"
+                    value={settings.worktreeDefaults.locationPattern}
+                    onChange={(e) =>
+                      applyDebounced({
+                        worktreeDefaults: {
+                          ...settings.worktreeDefaults,
+                          locationPattern: e.target.value
+                        }
+                      })
+                    }
+                    placeholder="../{project}-worktrees/{branch}"
+                    className="w-full rounded px-2 py-1 text-xs font-mono outline-none"
+                    style={{
+                      backgroundColor: 'var(--dplex-bg-alt)',
+                      border: '1px solid var(--dplex-border)',
+                      color: 'var(--dplex-text)'
+                    }}
+                  />
+                </SettingItem>
+
+                <SettingItem
+                  label="Env files to copy"
+                  description="Comma-separated relative paths (supports trailing wildcards like .env.*.local)."
+                >
+                  <input
+                    type="text"
+                    value={settings.worktreeDefaults.envFiles.join(', ')}
+                    onChange={(e) =>
+                      applyDebounced({
+                        worktreeDefaults: {
+                          ...settings.worktreeDefaults,
+                          envFiles: e.target.value
+                            .split(',')
+                            .map((s) => s.trim())
+                            .filter(Boolean)
+                        }
+                      })
+                    }
+                    placeholder=".env.local, .env.*.local"
+                    className="w-full rounded px-2 py-1 text-xs font-mono outline-none"
+                    style={{
+                      backgroundColor: 'var(--dplex-bg-alt)',
+                      border: '1px solid var(--dplex-border)',
+                      color: 'var(--dplex-text)'
+                    }}
+                  />
+                </SettingItem>
+
+                <SettingItem
+                  label="Setup script"
+                  description="Shell script to run after creating a worktree (e.g. npm install)."
+                >
+                  <textarea
+                    value={settings.worktreeDefaults.setupScript}
+                    onChange={(e) =>
+                      applyDebounced({
+                        worktreeDefaults: {
+                          ...settings.worktreeDefaults,
+                          setupScript: e.target.value
+                        }
+                      })
+                    }
+                    rows={3}
+                    placeholder="npm install"
+                    className="w-full rounded px-2 py-1 text-xs font-mono outline-none resize-y"
+                    style={{
+                      backgroundColor: 'var(--dplex-bg-alt)',
+                      border: '1px solid var(--dplex-border)',
+                      color: 'var(--dplex-text)'
+                    }}
+                  />
+                </SettingItem>
+
+                <SettingItem
+                  label="After creation"
+                  description="What to do once a worktree is ready."
+                >
+                  <select
+                    value={settings.worktreeDefaults.afterCreate}
+                    onChange={(e) =>
+                      applyNow({
+                        worktreeDefaults: {
+                          ...settings.worktreeDefaults,
+                          afterCreate: e.target.value as 'session' | 'terminal' | 'none'
+                        }
+                      })
+                    }
+                    className="w-full rounded px-2 py-1 text-xs outline-none"
+                    style={{
+                      backgroundColor: 'var(--dplex-bg-alt)',
+                      border: '1px solid var(--dplex-border)',
+                      color: 'var(--dplex-text)'
+                    }}
+                  >
+                    <option value="session">Start AI session</option>
+                    <option value="terminal">Open terminal</option>
+                    <option value="none">Do nothing</option>
+                  </select>
+                </SettingItem>
+
               </>
             )}
 

--- a/src/renderer/src/components/worktrees/DeleteWorktreeModal.tsx
+++ b/src/renderer/src/components/worktrees/DeleteWorktreeModal.tsx
@@ -1,0 +1,273 @@
+import { useState } from 'react'
+import { X, AlertTriangle } from 'lucide-react'
+import type { WorktreeInfo } from '../../../../preload'
+import { useTerminalStore } from '../../stores/terminalStore'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+import { normalizePath } from '../../hooks/useProjectSessions'
+
+interface DeleteWorktreeModalProps {
+  repoRoot: string
+  worktree: WorktreeInfo
+  onClose: () => void
+  onDeleted: () => void
+}
+
+export function DeleteWorktreeModal({
+  repoRoot,
+  worktree,
+  onClose,
+  onDeleted
+}: DeleteWorktreeModalProps): React.JSX.Element {
+  const dirty =
+    (worktree.status.dirtyCount ?? 0) +
+      (worktree.status.untrackedCount ?? 0) +
+      (worktree.status.stagedCount ?? 0) >
+    0
+  const unpushed = (worktree.status.ahead ?? 0) > 0
+  const hasUpstream = Boolean(worktree.status.upstream)
+
+  // Match tabs whose worktree metadata points at this worktree OR whose cwd
+  // falls under the worktree path — normal project launches from a worktree
+  // project don't stamp `worktreePath` metadata, so the prefix check catches
+  // those too. Keeps the dirty/close-session warning in sync with what
+  // `RemoveWorktreeProjectModal` does.
+  const normalizedWorktreePath = normalizePath(worktree.path)
+  const openTabs = useTerminalStore((s) => s.groups).flatMap((g) =>
+    g.tabs.filter((t) => {
+      if (t.worktreePath && normalizePath(t.worktreePath) === normalizedWorktreePath) {
+        return true
+      }
+      if (t.cwd) {
+        const cwd = normalizePath(t.cwd)
+        return cwd === normalizedWorktreePath || cwd.startsWith(normalizedWorktreePath + '/')
+      }
+      return false
+    })
+  )
+  const closeTerminal = useTerminalStore((s) => s.closeTerminal)
+  const activeSessions = openTabs.length
+
+  const [forceDelete, setForceDelete] = useState(dirty)
+  const [deleteBranch, setDeleteBranch] = useState(false)
+  const [forceDeleteBranch, setForceDeleteBranch] = useState(false)
+  const [closeSessions, setCloseSessions] = useState(activeSessions > 0)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEscapeKey(onClose, !submitting)
+
+  // Branch deletion is allowed in two cases:
+  //   (a) safe: has upstream and not ahead — a plain `git branch -d` will succeed
+  //   (b) unsafe but explicit: user ticks "Force delete branch" which passes `-D`.
+  // We only truly DISABLE when the worktree is detached (no branch at all).
+  const hasBranch = Boolean(worktree.branch) && !worktree.detached
+  const safeBranchDelete = hasUpstream && !unpushed
+  const requiresForceBranch = !safeBranchDelete
+  const canDeleteBranch = hasBranch && (safeBranchDelete || forceDeleteBranch)
+
+  const canSubmit = dirty ? forceDelete : true
+
+  const submit = async (): Promise<void> => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      const resp = await window.dplex.worktrees.delete({
+        repoRoot,
+        worktreePath: worktree.path,
+        force: forceDelete,
+        deleteBranch: deleteBranch && canDeleteBranch,
+        forceDeleteBranch: deleteBranch && canDeleteBranch && forceDeleteBranch
+      })
+      if ('code' in resp) {
+        setError(resp.message)
+        setSubmitting(false)
+        return
+      }
+      // Delete succeeded — close related tabs now.
+      if (closeSessions) {
+        for (const tab of openTabs) {
+          closeTerminal(tab.id)
+        }
+      }
+      // Surface any soft-warning (worktree was removed, but the branch
+      // deletion step was skipped/failed). Keep the modal open so the user
+      // can read it; they can close manually.
+      if (resp.warning) {
+        setError(`Worktree deleted. ${resp.warning.message}`)
+        setSubmitting(false)
+        onDeleted()
+        return
+      }
+      onDeleted()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-[480px] rounded-lg shadow-2xl"
+        style={{ backgroundColor: 'var(--dplex-bg)', border: '1px solid var(--dplex-border)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3"
+          style={{ borderBottom: '1px solid var(--dplex-border)' }}
+        >
+          <h2 className="text-sm font-semibold" style={{ color: 'var(--dplex-text)' }}>
+            Delete {worktree.branch ?? worktree.path}?
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-[var(--dplex-hover)] rounded"
+            style={{ color: 'var(--dplex-text-muted)' }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-3 text-[12px]" style={{ color: 'var(--dplex-text)' }}>
+          <div className="space-y-1">
+            {dirty && (() => {
+              const total =
+                (worktree.status.dirtyCount ?? 0) +
+                (worktree.status.untrackedCount ?? 0) +
+                (worktree.status.stagedCount ?? 0)
+              return (
+                <Warning>
+                  {total} uncommitted change{total === 1 ? '' : 's'}
+                </Warning>
+              )
+            })()}
+            {activeSessions > 0 && (
+              <Warning>
+                {activeSessions} running DPlex session{activeSessions === 1 ? '' : 's'}
+              </Warning>
+            )}
+            {unpushed && worktree.branch && (
+              <Warning>
+                {worktree.status.ahead} commit
+                {worktree.status.ahead === 1 ? '' : 's'} not pushed to{' '}
+                {worktree.status.upstream ?? 'remote'}
+              </Warning>
+            )}
+          </div>
+
+          <div
+            className="text-[11px] font-mono px-2 py-1 rounded"
+            style={{ backgroundColor: 'var(--dplex-bg-alt)', color: 'var(--dplex-text-muted)' }}
+          >
+            {worktree.path}
+          </div>
+
+          <label className="flex items-start gap-2 text-[11px]">
+            <input
+              type="checkbox"
+              checked={forceDelete}
+              disabled={dirty}
+              onChange={(e) => setForceDelete(e.target.checked)}
+              className="mt-0.5"
+            />
+            <span>
+              Force delete{dirty ? ' (required — worktree has changes)' : ''}
+            </span>
+          </label>
+
+          {hasBranch && (
+            <div className="space-y-1">
+              <label className="flex items-start gap-2 text-[11px]">
+                <input
+                  type="checkbox"
+                  checked={deleteBranch}
+                  onChange={(e) => {
+                    setDeleteBranch(e.target.checked)
+                    if (!e.target.checked) setForceDeleteBranch(false)
+                  }}
+                  className="mt-0.5"
+                />
+                <span>Also delete branch {worktree.branch}</span>
+              </label>
+              {deleteBranch && requiresForceBranch && (
+                <label
+                  className="flex items-start gap-2 text-[11px] pl-5"
+                  title={
+                    !hasUpstream
+                      ? 'No upstream — branch state cannot be verified against remote'
+                      : `Branch has ${worktree.status.ahead} unpushed commit(s)`
+                  }
+                >
+                  <input
+                    type="checkbox"
+                    checked={forceDeleteBranch}
+                    onChange={(e) => setForceDeleteBranch(e.target.checked)}
+                    className="mt-0.5"
+                  />
+                  <span style={{ color: 'var(--dplex-status-executing)' }}>
+                    Force delete branch (unmerged / no upstream)
+                  </span>
+                </label>
+              )}
+            </div>
+          )}
+
+          {activeSessions > 0 && (
+            <label className="flex items-start gap-2 text-[11px]">
+              <input
+                type="checkbox"
+                checked={closeSessions}
+                onChange={(e) => setCloseSessions(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>Close related DPlex sessions</span>
+            </label>
+          )}
+
+          {error && (
+            <div className="text-[11px] text-red-400" role="alert">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div
+          className="flex items-center justify-end gap-2 px-4 py-3"
+          style={{ borderTop: '1px solid var(--dplex-border)' }}
+        >
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="px-3 py-1 text-[11px] rounded hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void submit()}
+            disabled={submitting || !canSubmit}
+            className="px-3 py-1 text-[11px] rounded disabled:opacity-40"
+            style={{ backgroundColor: '#dc2626', color: 'white' }}
+          >
+            {submitting ? 'Deleting…' : 'Delete'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Warning({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <div
+      className="flex items-center gap-1.5 text-[11px]"
+      style={{ color: 'var(--dplex-status-executing)' }}
+    >
+      <AlertTriangle size={11} /> {children}
+    </div>
+  )
+}

--- a/src/renderer/src/components/worktrees/ManageWorktreesModal.tsx
+++ b/src/renderer/src/components/worktrees/ManageWorktreesModal.tsx
@@ -1,0 +1,284 @@
+import { useMemo, useState } from 'react'
+import { X, GitBranch, Plus, Trash2, FolderOpen, AlertCircle } from 'lucide-react'
+import type { Project, ProviderInfo, WorktreeDefaults } from '../../types'
+import type { WorktreeInfo } from '../../../../preload'
+import { useWorktrees } from '../../hooks/useWorktrees'
+import { useProjectStore } from '../../stores/projectStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+import { normalizePath } from '../../hooks/useProjectSessions'
+import { NewWorktreeModal } from './NewWorktreeModal'
+import { DeleteWorktreeModal } from './DeleteWorktreeModal'
+import { handleWorktreeCreated } from '../../services/worktreePostCreate'
+
+interface ManageWorktreesModalProps {
+  originProject: Project
+  providers: ProviderInfo[]
+  onClose: () => void
+}
+
+/**
+ * Reconciles `git worktree list` for the origin repo against DPlex projects.
+ * Each row shows whether a worktree is backed by a project, with actions to
+ * add/remove/delete.
+ */
+export function ManageWorktreesModal({
+  originProject,
+  providers,
+  onClose
+}: ManageWorktreesModalProps): React.JSX.Element {
+  useEscapeKey(onClose)
+  const { worktrees, loading, error, repoRoot, refresh } = useWorktrees(originProject.path)
+  const projects = useProjectStore((s) => s.projects)
+  const addWorktreeProject = useProjectStore((s) => s.addWorktreeProject)
+  const globalDefaults = useSettingsStore((s) => s.settings.worktreeDefaults)
+
+  const [creating, setCreating] = useState(false)
+  const [toDelete, setToDelete] = useState<WorktreeInfo | null>(null)
+
+  const defaults: WorktreeDefaults = useMemo(() => {
+    const override = originProject.worktreeOverrides
+    if (!override) return globalDefaults
+    return {
+      locationPattern: override.locationPattern ?? globalDefaults.locationPattern,
+      envFiles:
+        override.envFiles === null || override.envFiles === undefined
+          ? globalDefaults.envFiles
+          : override.envFiles,
+      setupScript: override.setupScript ?? globalDefaults.setupScript,
+      afterCreate: override.afterCreate ?? globalDefaults.afterCreate
+    }
+  }, [originProject.worktreeOverrides, globalDefaults])
+
+  // Quickly test "is this worktree backed by a project?"
+  const projectByPath = useMemo(() => {
+    const m = new Map<string, Project>()
+    for (const p of projects) {
+      m.set(normalizePath(p.path), p)
+    }
+    return m
+  }, [projects])
+
+  const findBackingProject = (path: string): Project | undefined => {
+    return projectByPath.get(normalizePath(path))
+  }
+
+  const addAsProject = (wt: WorktreeInfo): void => {
+    addWorktreeProject({
+      parentProjectId: originProject.id,
+      path: wt.path,
+      branch: wt.branch ?? wt.head.slice(0, 7),
+      createdByDplexWorktree: wt.createdByDplex ?? false
+    })
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-[640px] max-h-[85vh] flex flex-col rounded-lg shadow-2xl"
+        style={{ backgroundColor: 'var(--dplex-bg)', border: '1px solid var(--dplex-border)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3"
+          style={{ borderBottom: '1px solid var(--dplex-border)' }}
+        >
+          <h2 className="text-sm font-semibold" style={{ color: 'var(--dplex-text)' }}>
+            Worktrees — {originProject.name}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-[var(--dplex-hover)] rounded"
+            style={{ color: 'var(--dplex-text-muted)' }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-auto">
+          {loading && worktrees.length === 0 && (
+            <div
+              className="px-4 py-6 text-center text-[11px]"
+              style={{ color: 'var(--dplex-text-muted)' }}
+            >
+              Loading worktrees…
+            </div>
+          )}
+          {error && (
+            <div className="px-4 py-2 text-[11px] text-red-400">{error}</div>
+          )}
+          {!loading && worktrees.length === 0 && !error && (
+            <div
+              className="px-4 py-6 text-center text-[11px]"
+              style={{ color: 'var(--dplex-text-muted)' }}
+            >
+              No worktrees yet.
+            </div>
+          )}
+          {worktrees.map((wt) => {
+            const backing = findBackingProject(wt.path)
+            const dirty =
+              (wt.status.dirtyCount ?? 0) + (wt.status.untrackedCount ?? 0) > 0
+            const isOrphan = !wt.isMain && !backing
+            return (
+              <div
+                key={wt.path}
+                className="flex items-center gap-2 px-4 py-2 border-b"
+                style={{ borderColor: 'var(--dplex-border)' }}
+              >
+                <GitBranch
+                  size={12}
+                  style={{
+                    color: wt.detached
+                      ? 'var(--dplex-text-muted)'
+                      : dirty
+                        ? 'var(--dplex-status-executing)'
+                        : 'var(--dplex-text)'
+                  }}
+                  className="flex-shrink-0"
+                />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className="text-[12px] truncate font-medium"
+                      style={{ color: 'var(--dplex-text)' }}
+                    >
+                      {wt.detached ? `(detached @ ${wt.head.slice(0, 7)})` : wt.branch}
+                    </span>
+                    {wt.isMain && (
+                      <span
+                        className="text-[9px] uppercase px-1 rounded"
+                        style={{
+                          color: 'var(--dplex-text-muted)',
+                          border: '1px solid var(--dplex-border)'
+                        }}
+                      >
+                        main
+                      </span>
+                    )}
+                    {isOrphan && (
+                      <span
+                        className="text-[9px] uppercase px-1 rounded"
+                        style={{
+                          color: 'var(--dplex-status-executing)',
+                          border: '1px solid var(--dplex-status-executing)'
+                        }}
+                      >
+                        orphan
+                      </span>
+                    )}
+                    {dirty && (
+                      <AlertCircle
+                        size={10}
+                        style={{ color: 'var(--dplex-status-executing)' }}
+                      />
+                    )}
+                  </div>
+                  <div
+                    className="text-[10px] font-mono truncate"
+                    style={{ color: 'var(--dplex-text-muted)' }}
+                    title={wt.path}
+                  >
+                    {wt.path}
+                  </div>
+                </div>
+
+                <div className="flex items-center gap-1 flex-shrink-0">
+                  {isOrphan && (
+                    <button
+                      onClick={() => addAsProject(wt)}
+                      className="px-2 py-1 text-[10px] rounded hover:bg-[var(--dplex-hover)]"
+                      style={{ color: 'var(--dplex-accent)' }}
+                      title="Add as DPlex project"
+                    >
+                      <Plus size={11} className="inline" /> Add as project
+                    </button>
+                  )}
+                  <button
+                    onClick={() => void window.dplex.worktrees.reveal(wt.path)}
+                    className="p-1 hover:bg-[var(--dplex-hover)] rounded"
+                    style={{ color: 'var(--dplex-text-muted)' }}
+                    title="Reveal in Finder"
+                  >
+                    <FolderOpen size={11} />
+                  </button>
+                  {!wt.isMain && (
+                    <button
+                      onClick={() => setToDelete(wt)}
+                      className="p-1 hover:bg-[var(--dplex-hover)] rounded text-red-400"
+                      title="Delete worktree"
+                    >
+                      <Trash2 size={11} />
+                    </button>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+
+        <div
+          className="flex items-center justify-between gap-2 px-4 py-3"
+          style={{ borderTop: '1px solid var(--dplex-border)' }}
+        >
+          <button
+            onClick={() => setCreating(true)}
+            className="px-3 py-1 text-[11px] rounded flex items-center gap-1"
+            style={{ backgroundColor: 'var(--dplex-accent)', color: 'white' }}
+          >
+            <Plus size={11} /> New worktree
+          </button>
+          <button
+            onClick={onClose}
+            className="px-3 py-1 text-[11px] rounded hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            Close
+          </button>
+        </div>
+      </div>
+
+      {creating && repoRoot && (
+        <NewWorktreeModal
+          project={originProject}
+          repoRoot={repoRoot}
+          defaults={defaults}
+          providers={providers}
+          onClose={() => setCreating(false)}
+          onCreated={(result) => {
+            setCreating(false)
+            void handleWorktreeCreated({
+              originProject,
+              worktreePath: result.worktreePath,
+              branch: result.branch,
+              afterCreate: result.afterCreate,
+              providerId: result.providerId,
+              setupScript: result.setupScript,
+              createdByDplexWorktree: true
+            })
+            void refresh()
+          }}
+        />
+      )}
+
+      {toDelete && repoRoot && (
+        <DeleteWorktreeModal
+          repoRoot={repoRoot}
+          worktree={toDelete}
+          onClose={() => setToDelete(null)}
+          onDeleted={() => {
+            // If a DPlex project backed this worktree, remove it too.
+            const backing = findBackingProject(toDelete.path)
+            if (backing) useProjectStore.getState().removeProject(backing.id)
+            setToDelete(null)
+            void refresh()
+          }}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/worktrees/NewWorktreeModal.tsx
+++ b/src/renderer/src/components/worktrees/NewWorktreeModal.tsx
@@ -1,0 +1,391 @@
+import { useEffect, useState } from 'react'
+import { X } from 'lucide-react'
+import type { Project, ProviderInfo, WorktreeDefaults } from '../../types'
+import { expandPattern } from '../../utils/worktreePath'
+import { useProjectStore } from '../../stores/projectStore'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+
+interface NewWorktreeModalProps {
+  project: Project
+  repoRoot: string
+  defaults: WorktreeDefaults
+  providers: ProviderInfo[]
+  initialBranch?: string
+  onClose: () => void
+  onCreated: (result: {
+    worktreePath: string
+    afterCreate: 'session' | 'terminal' | 'none'
+    providerId: string | null
+    branch: string
+    setupScript: string
+  }) => void
+}
+
+export function NewWorktreeModal({
+  project,
+  repoRoot,
+  defaults,
+  providers,
+  initialBranch,
+  onClose,
+  onCreated
+}: NewWorktreeModalProps): React.JSX.Element {
+  const [localBranches, setLocalBranches] = useState<string[]>([])
+  const [remoteBranches, setRemoteBranches] = useState<string[]>([])
+  const [defaultBase, setDefaultBase] = useState<string | null>(null)
+  const [mode, setMode] = useState<'new' | 'existing'>('new')
+  const [branch, setBranch] = useState(initialBranch ?? '')
+  const [baseBranch, setBaseBranch] = useState<string>('')
+  const [location, setLocation] = useState<string>('')
+  const [locationDirty, setLocationDirty] = useState<boolean>(false)
+  const [afterCreate, setAfterCreate] = useState<'session' | 'terminal' | 'none'>(
+    defaults.afterCreate
+  )
+  const [envFiles, setEnvFiles] = useState<string>(defaults.envFiles.join(', '))
+  const [setupScript, setSetupScript] = useState<string>(defaults.setupScript)
+  const [saveDefaults, setSaveDefaults] = useState(false)
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Load branches + default base.
+  useEffect(() => {
+    let cancelled = false
+    void window.dplex.worktrees.listBranches(repoRoot).then((result) => {
+      if (cancelled) return
+      setLocalBranches(result.local)
+      setRemoteBranches(result.remote)
+      setDefaultBase(result.defaultBase)
+      setBaseBranch(result.defaultBase ?? result.local[0] ?? '')
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [repoRoot])
+
+  // Recompute location when branch changes. Show the configured pattern as a live
+  // preview (with a placeholder for branch) before the user types anything. Stop
+  // auto-updating once the user has edited the field manually.
+  useEffect(() => {
+    if (locationDirty) return
+    if (branch) {
+      setLocation(expandPattern(defaults.locationPattern, project.name, branch))
+    } else {
+      setLocation(
+        defaults.locationPattern
+          .replace(/\{project\}/g, project.name)
+          .replace(/\{branch\}/g, '<branch>')
+      )
+    }
+  }, [branch, defaults.locationPattern, project.name, locationDirty])
+
+  // Auto-flip to "existing" only when the typed branch matches a known local branch.
+  // Never auto-revert based on `mode` itself, so manually clicking "Check out existing"
+  // (with a yet-unknown name) is respected.
+  useEffect(() => {
+    if (!branch) return
+    if (localBranches.includes(branch)) setMode('existing')
+  }, [branch, localBranches])
+
+  useEscapeKey(onClose)
+
+  const allBranchSuggestions = [
+    ...localBranches,
+    ...remoteBranches.map((r) => r.replace(/^origin\//, ''))
+  ]
+
+  const submit = async (): Promise<void> => {
+    const trimmedBranch = branch.trim()
+    if (!trimmedBranch || !location.trim()) return
+    setSubmitting(true)
+    setError(null)
+    try {
+      const resp = await window.dplex.worktrees.create({
+        repoRoot,
+        branch: trimmedBranch,
+        newBranch: mode === 'new',
+        baseBranch: mode === 'new' ? baseBranch || defaultBase : null,
+        worktreePath: location.trim(),
+        envFiles: envFiles
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean),
+        trackInSidecar: true
+      })
+      if ('code' in resp) {
+        setError(resp.message)
+        setSubmitting(false)
+        return
+      }
+      if (saveDefaults) {
+        const parsedEnvFiles = envFiles
+          .split(',')
+          .map((s) => s.trim())
+          .filter(Boolean)
+        useProjectStore.getState().updateProjectWorktreeOverrides(project.id, {
+          ...(project.worktreeOverrides ?? {}),
+          envFiles: parsedEnvFiles,
+          setupScript,
+          afterCreate
+        })
+      }
+      onCreated({
+        worktreePath: resp.worktree.path,
+        afterCreate,
+        providerId: null,
+        branch: trimmedBranch,
+        setupScript
+      })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-[520px] max-h-[85vh] overflow-auto rounded-lg shadow-2xl"
+        style={{ backgroundColor: 'var(--dplex-bg)', border: '1px solid var(--dplex-border)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3"
+          style={{ borderBottom: '1px solid var(--dplex-border)' }}
+        >
+          <h2 className="text-sm font-semibold" style={{ color: 'var(--dplex-text)' }}>
+            New worktree — {project.name}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-[var(--dplex-hover)] rounded"
+            style={{ color: 'var(--dplex-text-muted)' }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-3 text-[12px]" style={{ color: 'var(--dplex-text)' }}>
+          <div className="flex gap-2 text-[11px]">
+            <label className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="mode"
+                checked={mode === 'new'}
+                onChange={() => setMode('new')}
+              />
+              New branch
+            </label>
+            <label className="flex items-center gap-1">
+              <input
+                type="radio"
+                name="mode"
+                checked={mode === 'existing'}
+                onChange={() => setMode('existing')}
+              />
+              Check out existing
+            </label>
+          </div>
+
+          <Field label="Branch">
+            <input
+              type="text"
+              list="dplex-wt-branches"
+              value={branch}
+              onChange={(e) => setBranch(e.target.value)}
+              placeholder="feature/auth"
+              className="w-full px-2 py-1 rounded"
+              style={{
+                backgroundColor: 'var(--dplex-bg-alt)',
+                border: '1px solid var(--dplex-border)',
+                color: 'var(--dplex-text)'
+              }}
+            />
+            <datalist id="dplex-wt-branches">
+              {allBranchSuggestions.map((b) => (
+                <option key={b} value={b} />
+              ))}
+            </datalist>
+          </Field>
+
+          {mode === 'new' && (
+            <Field label="Base branch">
+              <input
+                type="text"
+                list="dplex-wt-bases"
+                value={baseBranch}
+                onChange={(e) => setBaseBranch(e.target.value)}
+                className="w-full px-2 py-1 rounded"
+                style={{
+                  backgroundColor: 'var(--dplex-bg-alt)',
+                  border: '1px solid var(--dplex-border)',
+                  color: 'var(--dplex-text)'
+                }}
+              />
+              <datalist id="dplex-wt-bases">
+                {localBranches.map((b) => (
+                  <option key={b} value={b} />
+                ))}
+                {remoteBranches.map((b) => (
+                  <option key={b} value={b} />
+                ))}
+              </datalist>
+            </Field>
+          )}
+
+          <Field label="Location">
+            <input
+              type="text"
+              value={location}
+              onChange={(e) => {
+                setLocation(e.target.value)
+                setLocationDirty(true)
+              }}
+              className="w-full px-2 py-1 rounded font-mono text-[11px]"
+              style={{
+                backgroundColor: 'var(--dplex-bg-alt)',
+                border: '1px solid var(--dplex-border)',
+                color: 'var(--dplex-text)'
+              }}
+            />
+          </Field>
+
+          <Field label="After create">
+            <div className="flex gap-3 text-[11px]">
+              {(['session', 'terminal', 'none'] as const).map((v) => (
+                <label key={v} className="flex items-center gap-1">
+                  <input
+                    type="radio"
+                    name="after"
+                    checked={afterCreate === v}
+                    onChange={() => setAfterCreate(v)}
+                  />
+                  {v === 'session'
+                    ? 'Start AI session'
+                    : v === 'terminal'
+                      ? 'Open terminal'
+                      : 'None'}
+                </label>
+              ))}
+            </div>
+          </Field>
+
+          {afterCreate === 'session' && providers.length > 0 && (
+            <div
+              className="text-[10px] px-2 py-1 rounded"
+              style={{
+                color: 'var(--dplex-text-muted)',
+                backgroundColor: 'var(--dplex-bg-alt)'
+              }}
+            >
+              Uses the default AI provider from settings.
+            </div>
+          )}
+
+          <button
+            onClick={() => setShowAdvanced((v) => !v)}
+            className="text-[11px]"
+            style={{ color: 'var(--dplex-accent)' }}
+          >
+            {showAdvanced ? '− Advanced' : '+ Advanced'}
+          </button>
+
+          {showAdvanced && (
+            <>
+              <Field label="Setup script">
+                <textarea
+                  value={setupScript}
+                  onChange={(e) => setSetupScript(e.target.value)}
+                  rows={3}
+                  placeholder="npm install"
+                  className="w-full px-2 py-1 rounded font-mono text-[11px]"
+                  style={{
+                    backgroundColor: 'var(--dplex-bg-alt)',
+                    border: '1px solid var(--dplex-border)',
+                    color: 'var(--dplex-text)'
+                  }}
+                />
+              </Field>
+              <Field label="Env files (comma-separated)">
+                <input
+                  type="text"
+                  value={envFiles}
+                  onChange={(e) => setEnvFiles(e.target.value)}
+                  className="w-full px-2 py-1 rounded font-mono text-[11px]"
+                  style={{
+                    backgroundColor: 'var(--dplex-bg-alt)',
+                    border: '1px solid var(--dplex-border)',
+                    color: 'var(--dplex-text)'
+                  }}
+                />
+              </Field>
+              <label className="flex items-center gap-2 text-[11px]">
+                <input
+                  type="checkbox"
+                  checked={saveDefaults}
+                  onChange={(e) => setSaveDefaults(e.target.checked)}
+                />
+                Save these as project defaults
+              </label>
+            </>
+          )}
+
+          {error && (
+            <div className="text-[11px] text-red-400" role="alert">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div
+          className="flex items-center justify-end gap-2 px-4 py-3"
+          style={{ borderTop: '1px solid var(--dplex-border)' }}
+        >
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="px-3 py-1 text-[11px] rounded hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void submit()}
+            disabled={submitting || !branch.trim() || !location.trim()}
+            className="px-3 py-1 text-[11px] rounded disabled:opacity-40"
+            style={{
+              backgroundColor: 'var(--dplex-accent)',
+              color: 'white'
+            }}
+          >
+            {submitting ? 'Creating…' : 'Create'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Field({
+  label,
+  children
+}: {
+  label: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <div>
+      <label
+        className="block text-[10px] uppercase mb-1"
+        style={{ color: 'var(--dplex-text-muted)' }}
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  )
+}

--- a/src/renderer/src/components/worktrees/ProjectWorktreeDefaultsModal.tsx
+++ b/src/renderer/src/components/worktrees/ProjectWorktreeDefaultsModal.tsx
@@ -1,0 +1,251 @@
+import { useState } from 'react'
+import { X } from 'lucide-react'
+import type { Project, ProjectWorktreeOverrides } from '../../types'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { useProjectStore } from '../../stores/projectStore'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+
+interface ProjectWorktreeDefaultsModalProps {
+  project: Project
+  onClose: () => void
+}
+
+export function ProjectWorktreeDefaultsModal({
+  project,
+  onClose
+}: ProjectWorktreeDefaultsModalProps): React.JSX.Element {
+  const globalDefaults = useSettingsStore((s) => s.settings.worktreeDefaults)
+  const updateOverrides = useProjectStore((s) => s.updateProjectWorktreeOverrides)
+
+  const existing = project.worktreeOverrides ?? {}
+  const [locationPattern, setLocationPattern] = useState<string | undefined>(
+    existing.locationPattern
+  )
+  const [envFiles, setEnvFiles] = useState<string | undefined>(
+    existing.envFiles == null ? undefined : existing.envFiles.join(', ')
+  )
+  const [setupScript, setSetupScript] = useState<string | undefined>(existing.setupScript)
+  const [afterCreate, setAfterCreate] = useState<
+    'session' | 'terminal' | 'none' | undefined
+  >(existing.afterCreate)
+  useEscapeKey(onClose)
+
+  const save = (): void => {
+    const overrides: ProjectWorktreeOverrides = {}
+    if (locationPattern !== undefined) overrides.locationPattern = locationPattern
+    if (envFiles !== undefined) {
+      overrides.envFiles = envFiles
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean)
+    }
+    if (setupScript !== undefined) overrides.setupScript = setupScript
+    if (afterCreate !== undefined) overrides.afterCreate = afterCreate
+    const isEmpty = Object.keys(overrides).length === 0
+    updateOverrides(project.id, isEmpty ? null : overrides)
+    onClose()
+  }
+
+  const reset = (): void => {
+    updateOverrides(project.id, null)
+    onClose()
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-[520px] max-h-[85vh] overflow-auto rounded-lg shadow-2xl"
+        style={{ backgroundColor: 'var(--dplex-bg)', border: '1px solid var(--dplex-border)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3"
+          style={{ borderBottom: '1px solid var(--dplex-border)' }}
+        >
+          <h2 className="text-sm font-semibold" style={{ color: 'var(--dplex-text)' }}>
+            Worktree defaults — {project.name}
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-[var(--dplex-hover)] rounded"
+            style={{ color: 'var(--dplex-text-muted)' }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-4 text-[12px]" style={{ color: 'var(--dplex-text)' }}>
+          <p className="text-[11px]" style={{ color: 'var(--dplex-text-muted)' }}>
+            Leave a field unchecked to inherit the global default.
+          </p>
+
+          <OverrideField
+            label="Location pattern"
+            globalValue={globalDefaults.locationPattern}
+            value={locationPattern}
+            onChange={setLocationPattern}
+            render={(value, setValue) => (
+              <input
+                type="text"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                className="w-full px-2 py-1 rounded font-mono text-[11px]"
+                style={{
+                  backgroundColor: 'var(--dplex-bg-alt)',
+                  border: '1px solid var(--dplex-border)',
+                  color: 'var(--dplex-text)'
+                }}
+              />
+            )}
+            defaultOverrideValue={globalDefaults.locationPattern}
+          />
+
+          <OverrideField
+            label="Env files"
+            globalValue={globalDefaults.envFiles.join(', ')}
+            value={envFiles}
+            onChange={setEnvFiles}
+            render={(value, setValue) => (
+              <input
+                type="text"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                className="w-full px-2 py-1 rounded font-mono text-[11px]"
+                style={{
+                  backgroundColor: 'var(--dplex-bg-alt)',
+                  border: '1px solid var(--dplex-border)',
+                  color: 'var(--dplex-text)'
+                }}
+              />
+            )}
+            defaultOverrideValue={globalDefaults.envFiles.join(', ')}
+          />
+
+          <OverrideField
+            label="Setup script"
+            globalValue={globalDefaults.setupScript || '(none)'}
+            value={setupScript}
+            onChange={setSetupScript}
+            render={(value, setValue) => (
+              <textarea
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                rows={3}
+                className="w-full px-2 py-1 rounded font-mono text-[11px]"
+                style={{
+                  backgroundColor: 'var(--dplex-bg-alt)',
+                  border: '1px solid var(--dplex-border)',
+                  color: 'var(--dplex-text)'
+                }}
+              />
+            )}
+            defaultOverrideValue={globalDefaults.setupScript}
+          />
+
+          <OverrideField
+            label="After creation"
+            globalValue={globalDefaults.afterCreate}
+            value={afterCreate}
+            onChange={setAfterCreate}
+            render={(value, setValue) => (
+              <select
+                value={value}
+                onChange={(e) =>
+                  setValue(e.target.value as 'session' | 'terminal' | 'none')
+                }
+                className="w-full px-2 py-1 rounded text-[11px]"
+                style={{
+                  backgroundColor: 'var(--dplex-bg-alt)',
+                  border: '1px solid var(--dplex-border)',
+                  color: 'var(--dplex-text)'
+                }}
+              >
+                <option value="session">Start AI session</option>
+                <option value="terminal">Open terminal</option>
+                <option value="none">Do nothing</option>
+              </select>
+            )}
+            defaultOverrideValue={globalDefaults.afterCreate}
+          />
+        </div>
+
+        <div
+          className="flex items-center justify-between gap-2 px-4 py-3"
+          style={{ borderTop: '1px solid var(--dplex-border)' }}
+        >
+          <button
+            onClick={reset}
+            className="px-3 py-1 text-[11px] rounded hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text-muted)' }}
+          >
+            Reset to global defaults
+          </button>
+          <div className="flex items-center gap-2">
+            <button
+              onClick={onClose}
+              className="px-3 py-1 text-[11px] rounded hover:bg-[var(--dplex-hover)]"
+              style={{ color: 'var(--dplex-text)' }}
+            >
+              Cancel
+            </button>
+            <button
+              onClick={save}
+              className="px-3 py-1 text-[11px] rounded"
+              style={{ backgroundColor: 'var(--dplex-accent)', color: 'white' }}
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface OverrideFieldProps<T> {
+  label: string
+  globalValue: string
+  value: T | undefined
+  onChange: (v: T | undefined) => void
+  render: (value: T, setValue: (v: T) => void) => React.ReactNode
+  defaultOverrideValue?: T
+}
+
+function OverrideField<T>({
+  label,
+  globalValue,
+  value,
+  onChange,
+  render,
+  defaultOverrideValue
+}: OverrideFieldProps<T>): React.JSX.Element {
+  const overridden = value !== undefined
+  return (
+    <div>
+      <label className="flex items-center gap-2 text-[10px] uppercase mb-1" style={{ color: 'var(--dplex-text-muted)' }}>
+        <input
+          type="checkbox"
+          checked={overridden}
+          onChange={(e) => {
+            if (e.target.checked) {
+              onChange((defaultOverrideValue ?? ('' as unknown as T)))
+            } else {
+              onChange(undefined)
+            }
+          }}
+        />
+        {label}
+        {!overridden && (
+          <span className="normal-case ml-1" style={{ color: 'var(--dplex-text-muted)' }}>
+            inheriting: <span className="font-mono">{globalValue || '(empty)'}</span>
+          </span>
+        )}
+      </label>
+      {overridden && render(value as T, (v) => onChange(v))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/worktrees/RemoveWorktreeProjectModal.tsx
+++ b/src/renderer/src/components/worktrees/RemoveWorktreeProjectModal.tsx
@@ -1,0 +1,216 @@
+import { useState } from 'react'
+import { X, AlertTriangle } from 'lucide-react'
+import type { Project } from '../../types'
+import { useProjectStore } from '../../stores/projectStore'
+import { useTerminalStore } from '../../stores/terminalStore'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+import { normalizePath } from '../../hooks/useProjectSessions'
+
+interface RemoveWorktreeProjectModalProps {
+  project: Project
+  /**
+   * Repo root passed from the caller. May be null while the IPC watcher is
+   * still resolving, or when the origin project has been removed (orphan
+   * worktree-project). In the orphan case `project.path` itself is the
+   * worktree path and git worktree remove resolves .git/worktrees from it.
+   */
+  repoRoot: string | null
+  onClose: () => void
+  onRemoved: () => void
+}
+
+/**
+ * Removes a worktree-project from DPlex, optionally deleting the
+ * worktree on disk too. Mirrors DeleteWorktreeModal's behaviour but
+ * is driven off the Project record rather than WorktreeInfo.
+ */
+export function RemoveWorktreeProjectModal({
+  project,
+  repoRoot,
+  onClose,
+  onRemoved
+}: RemoveWorktreeProjectModalProps): React.JSX.Element {
+  const removeProject = useProjectStore((s) => s.removeProject)
+  // Match open tabs by longest-prefix — consistent with how sessions/terminals
+  // are attributed elsewhere. Strict equality missed terminals launched in
+  // subdirectories of the worktree (the common case).
+  const projectPath = normalizePath(project.path)
+  const openTabs = useTerminalStore((s) => s.groups).flatMap((g) =>
+    g.tabs.filter((t) => {
+      if (t.worktreePath && normalizePath(t.worktreePath) === projectPath) return true
+      if (!t.cwd) return false
+      const cwd = normalizePath(t.cwd)
+      return cwd === projectPath || cwd.startsWith(projectPath + '/')
+    })
+  )
+  const closeTerminal = useTerminalStore((s) => s.closeTerminal)
+
+  const [deleteFromDisk, setDeleteFromDisk] = useState<boolean>(
+    project.createdByDplexWorktree ?? false
+  )
+  const [forceDelete, setForceDelete] = useState(false)
+  const [closeSessions, setCloseSessions] = useState(openTabs.length > 0)
+  const [submitting, setSubmitting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEscapeKey(onClose, !submitting)
+
+  const submit = async (): Promise<void> => {
+    setSubmitting(true)
+    setError(null)
+    try {
+      if (deleteFromDisk) {
+        // Fall back to the worktree path itself when we don't know the repo
+        // root yet (watcher race) or when the origin project is gone
+        // (orphan). `git worktree remove` can resolve either one.
+        const effectiveRepoRoot = repoRoot ?? project.path
+        const resp = await window.dplex.worktrees.delete({
+          repoRoot: effectiveRepoRoot,
+          worktreePath: project.path,
+          force: forceDelete,
+          deleteBranch: false,
+          forceDeleteBranch: false
+        })
+        if ('code' in resp) {
+          setError(resp.message)
+          setSubmitting(false)
+          return
+        }
+      }
+      if (closeSessions) {
+        for (const tab of openTabs) closeTerminal(tab.id)
+      }
+      removeProject(project.id)
+      onRemoved()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      setSubmitting(false)
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-[100] flex items-center justify-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.5)' }}
+      onClick={onClose}
+    >
+      <div
+        className="w-[480px] rounded-lg shadow-2xl"
+        style={{ backgroundColor: 'var(--dplex-bg)', border: '1px solid var(--dplex-border)' }}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className="flex items-center justify-between px-4 py-3"
+          style={{ borderBottom: '1px solid var(--dplex-border)' }}
+        >
+          <h2 className="text-sm font-semibold" style={{ color: 'var(--dplex-text)' }}>
+            Remove {project.name}?
+          </h2>
+          <button
+            onClick={onClose}
+            className="p-1 hover:bg-[var(--dplex-hover)] rounded"
+            style={{ color: 'var(--dplex-text-muted)' }}
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="p-4 space-y-3 text-[12px]" style={{ color: 'var(--dplex-text)' }}>
+          {openTabs.length > 0 && (
+            <div
+              className="flex items-center gap-1.5 text-[11px]"
+              style={{ color: 'var(--dplex-status-executing)' }}
+            >
+              <AlertTriangle size={11} /> {openTabs.length} open tab
+              {openTabs.length === 1 ? '' : 's'} in this project
+            </div>
+          )}
+
+          <div
+            className="text-[11px] font-mono px-2 py-1 rounded"
+            style={{ backgroundColor: 'var(--dplex-bg-alt)', color: 'var(--dplex-text-muted)' }}
+          >
+            {project.path}
+          </div>
+
+          <label className="flex items-start gap-2 text-[11px]">
+            <input
+              type="checkbox"
+              checked={deleteFromDisk}
+              onChange={(e) => {
+                setDeleteFromDisk(e.target.checked)
+                if (!e.target.checked) setForceDelete(false)
+              }}
+              className="mt-0.5"
+            />
+            <span>
+              Also delete worktree from disk (<code>git worktree remove</code>)
+              {project.createdByDplexWorktree && (
+                <span
+                  className="ml-1 text-[10px]"
+                  style={{ color: 'var(--dplex-text-muted)' }}
+                >
+                  — created by DPlex
+                </span>
+              )}
+            </span>
+          </label>
+
+          {deleteFromDisk && (
+            <label className="flex items-start gap-2 text-[11px] pl-5">
+              <input
+                type="checkbox"
+                checked={forceDelete}
+                onChange={(e) => setForceDelete(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span style={{ color: 'var(--dplex-status-executing)' }}>
+                Force (discard uncommitted changes)
+              </span>
+            </label>
+          )}
+
+          {openTabs.length > 0 && (
+            <label className="flex items-start gap-2 text-[11px]">
+              <input
+                type="checkbox"
+                checked={closeSessions}
+                onChange={(e) => setCloseSessions(e.target.checked)}
+                className="mt-0.5"
+              />
+              <span>Close related DPlex tabs</span>
+            </label>
+          )}
+
+          {error && (
+            <div className="text-[11px] text-red-400" role="alert">
+              {error}
+            </div>
+          )}
+        </div>
+
+        <div
+          className="flex items-center justify-end gap-2 px-4 py-3"
+          style={{ borderTop: '1px solid var(--dplex-border)' }}
+        >
+          <button
+            onClick={onClose}
+            disabled={submitting}
+            className="px-3 py-1 text-[11px] rounded hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={() => void submit()}
+            disabled={submitting}
+            className="px-3 py-1 text-[11px] rounded disabled:opacity-40"
+            style={{ backgroundColor: '#dc2626', color: 'white' }}
+          >
+            {submitting ? 'Removing…' : 'Remove'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/hooks/useEscapeKey.ts
+++ b/src/renderer/src/hooks/useEscapeKey.ts
@@ -1,0 +1,22 @@
+import { useEffect, useRef } from 'react'
+
+/**
+ * Invoke `handler` when the user presses Escape anywhere in the document.
+ * Pass `enabled = false` to suspend the listener (e.g. when the modal is closed).
+ *
+ * The handler is stored in a ref so callers can pass fresh closures without
+ * re-registering the `keydown` listener on every render.
+ */
+export function useEscapeKey(handler: () => void, enabled = true): void {
+  const handlerRef = useRef(handler)
+  handlerRef.current = handler
+
+  useEffect(() => {
+    if (!enabled) return
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') handlerRef.current()
+    }
+    document.addEventListener('keydown', onKey)
+    return () => document.removeEventListener('keydown', onKey)
+  }, [enabled])
+}

--- a/src/renderer/src/hooks/useGitBranch.ts
+++ b/src/renderer/src/hooks/useGitBranch.ts
@@ -8,14 +8,15 @@ export function useGitBranch(dirPath: string | undefined): string | null {
   const [branch, setBranch] = useState<string | null>(null)
 
   useEffect(() => {
-    if (!dirPath) {
-      setBranch(null)
-      return
-    }
+    // Clear any prior value immediately so the UI doesn't show a stale
+    // branch during the async switch to a new path.
+    setBranch(null)
+
+    if (!dirPath) return
 
     let cancelled = false
     let cleanupListener: (() => void) | null = null
-    let watchedRepoRoot: string | null = null
+    let watchToken: string | null = null
 
     // Initial fetch
     window.dplex.git.getBranch(dirPath).then((b) => {
@@ -23,17 +24,17 @@ export function useGitBranch(dirPath: string | undefined): string | null {
     })
 
     // Subscribe to push updates
-    window.dplex.git.watchBranch(dirPath).then((repoRoot) => {
+    window.dplex.git.watchBranch(dirPath).then((result) => {
       if (cancelled) {
         // Effect already cleaned up — tear down immediately
-        if (repoRoot) window.dplex.git.unwatchBranch(repoRoot)
+        if (result) window.dplex.git.unwatchBranch(result.token)
         return
       }
-      if (!repoRoot) return
-      watchedRepoRoot = repoRoot
+      if (!result) return
+      watchToken = result.token
 
       cleanupListener = window.dplex.git.onBranchChanged((changedRoot, newBranch) => {
-        if (!cancelled && changedRoot === repoRoot) {
+        if (!cancelled && changedRoot === result.repoRoot) {
           setBranch(newBranch)
         }
       })
@@ -42,8 +43,8 @@ export function useGitBranch(dirPath: string | undefined): string | null {
     return () => {
       cancelled = true
       cleanupListener?.()
-      if (watchedRepoRoot) {
-        window.dplex.git.unwatchBranch(watchedRepoRoot)
+      if (watchToken) {
+        window.dplex.git.unwatchBranch(watchToken)
       }
     }
   }, [dirPath])

--- a/src/renderer/src/hooks/useProjectSessions.ts
+++ b/src/renderer/src/hooks/useProjectSessions.ts
@@ -1,15 +1,18 @@
 import { useMemo } from 'react'
 import { useSessionStore } from '../stores/sessionStore'
 import { useTerminalStore } from '../stores/terminalStore'
+import { useProjectStore } from '../stores/projectStore'
 import type { AISession, TerminalTab } from '../types'
 
 /**
  * Normalize a path for comparison: resolve separators, trim trailing slashes.
  * Case-fold only on case-insensitive platforms (macOS, Windows).
+ *
+ * Exported so that every code path that decides "is this the same project path"
+ * uses identical rules (dedup, orphan detection, session attribution).
  */
-function normalizePath(p: string): string {
+export function normalizePath(p: string): string {
   let normalized = p.replace(/\\/g, '/').replace(/\/+$/, '')
-  // Case-insensitive on macOS (darwin) and Windows (win32)
   if (typeof navigator !== 'undefined') {
     const platform = navigator.platform?.toLowerCase() ?? ''
     if (platform.includes('mac') || platform.includes('win')) {
@@ -19,11 +22,19 @@ function normalizePath(p: string): string {
   return normalized
 }
 
-/** Check if a CWD belongs to a project path (exact match or subdirectory). */
-function cwdMatchesProject(cwd: string, projectPath: string): boolean {
-  const normCwd = normalizePath(cwd)
-  const normProject = normalizePath(projectPath)
-  return normCwd === normProject || normCwd.startsWith(normProject + '/')
+/**
+ * Pick the registered project whose path is the longest prefix of cwd.
+ * Each worktree is registered as its own project in the new model, so
+ * we no longer need a worktree-aware remap layer — a plain path-prefix
+ * match is both sufficient and more predictable.
+ */
+function findMatchingProject(cwd: string, sortedProjects: string[]): string | null {
+  const norm = normalizePath(cwd)
+  for (const pp of sortedProjects) {
+    const n = normalizePath(pp)
+    if (norm === n || norm.startsWith(n + '/')) return pp
+  }
+  return null
 }
 
 export interface ProjectActivity {
@@ -41,7 +52,6 @@ export interface ProjectActivity {
 
 /**
  * Derives project activity from sessionStore + terminalStore.
- * Merges discovered sessions with open DPlex tabs, deduping by sessionId.
  *
  * NOTE: For O(1) per-project lookups, prefer getProjectSessionsFromIndex()
  * when rendering a list of projects. This hook is for individual project use.
@@ -49,10 +59,12 @@ export interface ProjectActivity {
 export function useProjectSessions(projectPath: string): ProjectActivity {
   const sessions = useSessionStore((s) => s.sessions)
   const groups = useTerminalStore((s) => s.groups)
+  const projects = useProjectStore((s) => s.projects)
+  const allProjectPaths = useMemo(() => projects.map((p) => p.path), [projects])
 
   return useMemo(() => {
-    return computeProjectActivity(sessions, groups, projectPath)
-  }, [sessions, groups, projectPath])
+    return computeProjectActivity(sessions, groups, projectPath, allProjectPaths)
+  }, [sessions, groups, projectPath, allProjectPaths])
 }
 
 /**
@@ -62,27 +74,30 @@ export function useProjectSessions(projectPath: string): ProjectActivity {
 export function computeProjectActivity(
   sessions: AISession[],
   groups: { id: string; tabs: TerminalTab[] }[],
-  projectPath: string
+  projectPath: string,
+  allProjectPaths: string[] = [projectPath]
 ): ProjectActivity {
-  // 1. Find discovered sessions matching this project
-  const matchedSessions = sessions.filter(
-    (s) => s.cwd && cwdMatchesProject(s.cwd, projectPath)
+  const sortedProjects = [...allProjectPaths].sort(
+    (a, b) => normalizePath(b).length - normalizePath(a).length
   )
+  const matchesThisProject = (cwd: string): boolean => {
+    return findMatchingProject(cwd, sortedProjects) === projectPath
+  }
 
-  // 2. Find open DPlex tabs matching this project
+  const matchedSessions = sessions.filter((s) => s.cwd && matchesThisProject(s.cwd))
+
+  // Any tab with a cwd that falls under the project counts — including plain
+  // terminals (no command) launched from inside the checkout.
   const matchedTabs = groups.flatMap((g) =>
     g.tabs
-      .filter((t) => t.command && t.cwd && cwdMatchesProject(t.cwd, projectPath))
+      .filter((t) => t.cwd && matchesThisProject(t.cwd))
       .map((t) => ({ ...t, groupId: g.id }))
   )
 
-  // 4. Compute activity metrics
   const activeSessions = matchedSessions.filter((s) => s.status === 'active')
-  // activeCount reflects sessions with known active status (not unresolved tabs)
   const activeCount = activeSessions.length
   const hasActive = activeCount > 0
 
-  // 5. Most recent activity across all matched sessions
   const lastActivity = matchedSessions.reduce<Date | undefined>((latest, s) => {
     const time = s.lastActivityTime ? new Date(s.lastActivityTime) : s.updatedAt
     return !latest || time > latest ? time : latest
@@ -107,12 +122,10 @@ export function buildProjectSessionIndex(
   groups: { id: string; tabs: TerminalTab[] }[],
   projectPaths: string[]
 ): Map<string, ProjectActivity> {
-  // Sort project paths by length descending — longest match wins
-  const sorted = [...projectPaths].sort((a, b) =>
-    normalizePath(b).length - normalizePath(a).length
+  const sorted = [...projectPaths].sort(
+    (a, b) => normalizePath(b).length - normalizePath(a).length
   )
 
-  // Assign each session to the longest matching project
   const sessionsByProject = new Map<string, AISession[]>()
   const tabsByProject = new Map<string, (TerminalTab & { groupId: string })[]>()
   for (const pp of projectPaths) {
@@ -120,36 +133,21 @@ export function buildProjectSessionIndex(
     tabsByProject.set(pp, [])
   }
 
-  const assignedSessionIds = new Set<string>()
   for (const s of sessions) {
-    if (!s.cwd || assignedSessionIds.has(s.id)) continue
-    for (const pp of sorted) {
-      if (cwdMatchesProject(s.cwd, pp)) {
-        sessionsByProject.get(pp)!.push(s)
-        assignedSessionIds.add(s.id)
-        break
-      }
-    }
+    if (!s.cwd) continue
+    const matched = findMatchingProject(s.cwd, sorted)
+    if (matched) sessionsByProject.get(matched)!.push(s)
   }
 
-  const assignedTabIds = new Set<string>()
   const allTabs = groups.flatMap((g) =>
-    g.tabs
-      .filter((t) => t.command && t.cwd)
-      .map((t) => ({ ...t, groupId: g.id }))
+    g.tabs.filter((t) => t.cwd).map((t) => ({ ...t, groupId: g.id }))
   )
   for (const tab of allTabs) {
-    if (!tab.cwd || assignedTabIds.has(tab.id)) continue
-    for (const pp of sorted) {
-      if (cwdMatchesProject(tab.cwd, pp)) {
-        tabsByProject.get(pp)!.push(tab)
-        assignedTabIds.add(tab.id)
-        break
-      }
-    }
+    if (!tab.cwd) continue
+    const matched = findMatchingProject(tab.cwd, sorted)
+    if (matched) tabsByProject.get(matched)!.push(tab)
   }
 
-  // Build activity for each project from its assigned sessions/tabs
   const index = new Map<string, ProjectActivity>()
   for (const pp of projectPaths) {
     const matchedSessions = sessionsByProject.get(pp)!

--- a/src/renderer/src/hooks/useTerminal.ts
+++ b/src/renderer/src/hooks/useTerminal.ts
@@ -5,6 +5,7 @@ import {
   getOrCreateTerminal,
   updateTerminalFont,
   applyThemeToAll,
+  fireExitHandler,
   type TerminalEntry
 } from '../services/terminalRegistry'
 
@@ -95,9 +96,13 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
         }
       })
 
-      const removeExitListener = window.dplex.pty.onExit((id, _exitCode) => {
+      const removeExitListener = window.dplex.pty.onExit((id, exitCode) => {
         if (id === ptyIdResolved) {
           entry.term.write('\r\n\x1b[90m[Process exited]\x1b[0m\r\n')
+          // Notify any callers that registered a pending exit handler for
+          // this terminal (e.g. worktree setup-script flow) so they can
+          // record results and clean up resources without polling.
+          fireExitHandler(terminalId, exitCode)
         }
       })
 

--- a/src/renderer/src/hooks/useWorktrees.ts
+++ b/src/renderer/src/hooks/useWorktrees.ts
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react'
+import { useWorktreeStore } from '../stores/worktreeStore'
+import type { WorktreeInfo } from '../../../preload'
+
+// Module-level ref counting so multiple components can subscribe to the same
+// repo without tearing each other's watchers down.
+interface RefCountEntry {
+  count: number
+  // Pending/resolved subscription. Concurrent callers await this same promise
+  // so StrictMode double-invoke doesn't abort the second mount before the
+  // first watchRepo has resolved.
+  promise: Promise<{ token: string; repoRoot: string } | null>
+}
+const refCounts = new Map<string, RefCountEntry>()
+
+export function ensureWorktreeSubscription(
+  repoPath: string
+): Promise<{ token: string; repoRoot: string } | null> {
+  return ensureSubscription(repoPath)
+}
+
+export function releaseWorktreeSubscription(repoPath: string): void {
+  releaseSubscription(repoPath)
+}
+
+function ensureSubscription(
+  repoPath: string
+): Promise<{ token: string; repoRoot: string } | null> {
+  const existing = refCounts.get(repoPath)
+  if (existing) {
+    existing.count += 1
+    return existing.promise
+  }
+  const promise = (async () => {
+    const result = await window.dplex.worktrees.watchRepo(repoPath)
+    if (!result) {
+      // Subscription failed — remove entry so a later attempt can retry.
+      refCounts.delete(repoPath)
+      return null
+    }
+    return { token: result.token, repoRoot: result.repoRoot }
+  })()
+  refCounts.set(repoPath, { count: 1, promise })
+  return promise
+}
+
+function releaseSubscription(repoPath: string): void {
+  const existing = refCounts.get(repoPath)
+  if (!existing) return
+  existing.count -= 1
+  if (existing.count <= 0) {
+    // Wait for the subscription to resolve before unwatching — otherwise we
+    // might try to unwatch a token we haven't received yet.
+    const pending = existing.promise
+    refCounts.delete(repoPath)
+    void pending.then((sub) => {
+      if (sub) window.dplex.worktrees.unwatchRepo(sub.token)
+    })
+  }
+}
+
+/**
+ * Subscribe to worktree updates for a given project path. Automatically
+ * resolves the repo root on the main side, manages watcher subscription,
+ * and returns the current snapshot + helpers.
+ */
+export function useWorktrees(projectPath: string | undefined): {
+  worktrees: WorktreeInfo[]
+  loading: boolean
+  error: string | null
+  refresh: () => Promise<void>
+  isGitRepo: boolean
+  repoRoot: string | null
+} {
+  const [isGitRepo, setIsGitRepo] = useState<boolean>(false)
+  const setLoading = useWorktreeStore((s) => s.setLoading)
+
+  const [canonicalRoot, setCanonicalRoot] = useState<string | null>(null)
+
+  // Subscribe only to this repo's slice so unrelated repo updates don't
+  // re-render this component.
+  const repo = useWorktreeStore((s) => (canonicalRoot ? s.repos.get(canonicalRoot) : undefined))
+
+  useEffect(() => {
+    // Reset immediately on projectPath change so callers don't briefly see
+    // the previous repo's state while the new subscription resolves.
+    setIsGitRepo(false)
+    setCanonicalRoot(null)
+
+    if (!projectPath) return
+
+    let cancelled = false
+    let acquired = false
+
+    const run = async (): Promise<void> => {
+      try {
+        const sub = await ensureSubscription(projectPath)
+        if (cancelled) {
+          if (sub) releaseSubscription(projectPath)
+          return
+        }
+        if (!sub) {
+          setIsGitRepo(false)
+          return
+        }
+        acquired = true
+        setIsGitRepo(true)
+        setCanonicalRoot(sub.repoRoot)
+        setLoading(sub.repoRoot, false)
+      } catch {
+        // Pre-resolve errors (e.g. git binary missing) are rare and
+        // recoverable via the next projectPath change; there is no
+        // canonical root yet to key into the store's error slice.
+      }
+    }
+
+    void run()
+
+    return () => {
+      cancelled = true
+      if (acquired) releaseSubscription(projectPath)
+    }
+  }, [projectPath, setLoading])
+
+  return {
+    worktrees: repo?.worktrees ?? [],
+    loading: repo?.loading ?? false,
+    error: repo?.error ?? null,
+    isGitRepo,
+    repoRoot: canonicalRoot,
+    refresh: async () => {
+      if (canonicalRoot) {
+        await window.dplex.worktrees.refresh(canonicalRoot)
+      } else if (projectPath) {
+        await window.dplex.worktrees.refresh(projectPath)
+      }
+    }
+  }
+}

--- a/src/renderer/src/services/terminalRegistry.ts
+++ b/src/renderer/src/services/terminalRegistry.ts
@@ -68,15 +68,57 @@ export function getTerminalEntry(terminalId: string): TerminalEntry | undefined 
   return registry.get(terminalId)
 }
 
+// ── Pending exit handlers ───────────────────────────────────────────────
+// Callers (e.g. worktree setup-script flow) may want to react to a
+// terminal's PTY exit without waiting for useTerminal to mount and resolve
+// the ptyId. Registering here is unconditional: the handler fires on the
+// first of (a) PTY exit reported by useTerminal, or (b) destroyTerminal()
+// for cases where the tab never mounted. After firing, it's cleared.
+
+type PendingExitHandler = (exitCode: number) => void
+const pendingExitHandlers = new Map<string, PendingExitHandler>()
+
+export function registerExitHandler(
+  terminalId: string,
+  handler: PendingExitHandler
+): () => void {
+  pendingExitHandlers.set(terminalId, handler)
+  return () => {
+    if (pendingExitHandlers.get(terminalId) === handler) {
+      pendingExitHandlers.delete(terminalId)
+    }
+  }
+}
+
+/** Invoke and clear any pending exit handler for a terminal. Idempotent. */
+export function fireExitHandler(terminalId: string, exitCode: number): void {
+  const handler = pendingExitHandlers.get(terminalId)
+  if (!handler) return
+  pendingExitHandlers.delete(terminalId)
+  try {
+    handler(exitCode)
+  } catch {
+    /* isolate handler errors */
+  }
+}
+
 export function destroyTerminal(terminalId: string): void {
   const entry = registry.get(terminalId)
-  if (!entry) return
+  if (!entry) {
+    // Even if the entry never got registered, fire any pending handler so
+    // callers waiting on an exit result get unblocked with a synthetic code.
+    fireExitHandler(terminalId, -1)
+    return
+  }
 
   if (entry.cleanupIpc) entry.cleanupIpc()
   if (entry.ptyId) window.dplex.pty.destroy(entry.ptyId)
   entry.term.dispose()
   entry.wrapperEl.remove()
   registry.delete(terminalId)
+  // If useTerminal hadn't yet wired pty:exit (fast destroy before PTY
+  // resolved), still fire pending handlers so tmp files get cleaned up.
+  fireExitHandler(terminalId, -1)
 }
 
 export function isTerminalRegistered(terminalId: string): boolean {

--- a/src/renderer/src/services/worktreePostCreate.ts
+++ b/src/renderer/src/services/worktreePostCreate.ts
@@ -1,0 +1,99 @@
+import { useProjectStore } from '../stores/projectStore'
+import { useTerminalStore } from '../stores/terminalStore'
+import { registerExitHandler } from './terminalRegistry'
+import type { Project } from '../types'
+
+export interface WorktreePostCreateInput {
+  /** Origin project the worktree was created from. */
+  originProject: Project
+  worktreePath: string
+  branch: string
+  afterCreate: 'session' | 'terminal' | 'none'
+  providerId: string | null
+  setupScript: string
+  createdByDplexWorktree?: boolean
+}
+
+/**
+ * After a worktree is created on disk, register it as its own top-level
+ * project and (optionally) run the setup script + afterCreate action.
+ *
+ * The worktree-project gets a `parentProjectId` back to its origin, which
+ * the renderer uses to nest it under the parent in the projects list.
+ *
+ * Returns the newly created project.
+ */
+export async function handleWorktreeCreated(input: WorktreePostCreateInput): Promise<Project> {
+  const {
+    originProject,
+    worktreePath,
+    branch,
+    afterCreate,
+    providerId,
+    setupScript,
+    createdByDplexWorktree
+  } = input
+
+  const newProject = useProjectStore.getState().addWorktreeProject({
+    parentProjectId: originProject.id,
+    path: worktreePath,
+    branch,
+    createdByDplexWorktree: createdByDplexWorktree ?? true
+  })
+
+  const termStore = useTerminalStore.getState()
+
+  const runAfterCreate = async (): Promise<void> => {
+    if (afterCreate === 'session') {
+      const tabId = await useProjectStore
+        .getState()
+        .startAISession(newProject, providerId ?? undefined)
+      if (tabId) {
+        useTerminalStore.getState().setWorktreeMetadata(tabId, worktreePath, branch)
+      }
+    } else if (afterCreate === 'terminal') {
+      const tabId = useTerminalStore
+        .getState()
+        .createTerminal(undefined, branch, undefined, undefined, worktreePath)
+      useTerminalStore.getState().setWorktreeMetadata(tabId, worktreePath, branch)
+    }
+  }
+
+  const trimmedScript = setupScript.trim()
+  if (trimmedScript) {
+    let prepared: Awaited<ReturnType<typeof window.dplex.worktrees.prepareSetupScript>> | null =
+      null
+    try {
+      prepared = await window.dplex.worktrees.prepareSetupScript(trimmedScript)
+      const setupTabId = termStore.createTerminal(
+        undefined,
+        `setup · ${branch}`,
+        prepared.command,
+        undefined,
+        worktreePath
+      )
+      termStore.setWorktreeMetadata(setupTabId, worktreePath, branch)
+      const preparedTempPath = prepared.tempPath
+      registerExitHandler(setupTabId, (exitCode) => {
+        void window.dplex.worktrees.recordSetupResult(
+          originProject.path,
+          worktreePath,
+          exitCode
+        )
+        void window.dplex.worktrees.cleanupSetupScript(preparedTempPath)
+        void runAfterCreate()
+      })
+    } catch {
+      // Clean up the temp script if we failed before the exit handler could
+      // be registered — otherwise the file leaks to $TMPDIR on every failure.
+      if (prepared) {
+        void window.dplex.worktrees.cleanupSetupScript(prepared.tempPath)
+      }
+      await runAfterCreate()
+    }
+  } else {
+    await runAfterCreate()
+  }
+
+  return newProject
+}

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -1,7 +1,8 @@
 import { create } from 'zustand'
-import type { Project } from '../types'
+import type { Project, ProjectWorktreeOverrides } from '../types'
 import { useSettingsStore } from './settingsStore'
 import { useTerminalStore } from './terminalStore'
+import { normalizePath } from '../hooks/useProjectSessions'
 
 function generateId(): string {
   return `proj-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
@@ -19,10 +20,20 @@ interface ProjectState {
 
   loadProjects: () => Promise<void>
   addProject: (path?: string) => Promise<void>
+  addWorktreeProject: (opts: {
+    parentProjectId: string
+    path: string
+    branch: string
+    createdByDplexWorktree?: boolean
+  }) => Project
   removeProject: (id: string) => void
   reorderProject: (draggedId: string, targetId: string, position: 'above' | 'below') => void
   toggleExpanded: (id: string) => void
-  startAISession: (project: Project, providerId?: string) => void
+  startAISession: (project: Project, providerId?: string) => Promise<string | null>
+  updateProjectWorktreeOverrides: (
+    projectId: string,
+    overrides: ProjectWorktreeOverrides | null
+  ) => void
   persistProjects: () => void
 }
 
@@ -46,25 +57,97 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     window.dplex.settings.merge({ projects })
   },
 
+  updateProjectWorktreeOverrides: (projectId, overrides) => {
+    const { projects, persistProjects } = get()
+    const next = projects.map((p) =>
+      p.id === projectId
+        ? { ...p, worktreeOverrides: overrides ?? undefined }
+        : p
+    )
+    set({ projects: next })
+    persistProjects()
+  },
+
   addProject: async (selectedPath?: string) => {
     const pathToAdd = selectedPath ?? (await window.dplex.app.selectFolder())
     if (!pathToAdd) return
 
     const { projects } = get()
-    const normalized = pathToAdd.replace(/\\/g, '/').replace(/\/+$/, '')
-    if (projects.some((p) => p.path.replace(/\\/g, '/').replace(/\/+$/, '') === normalized)) {
+    const normalized = normalizePath(pathToAdd)
+    if (projects.some((p) => normalizePath(p.path) === normalized)) {
       return
     }
 
-    const project: Project = {
-      id: generateId(),
-      name: folderName(pathToAdd),
-      path: pathToAdd,
-      addedAt: new Date().toISOString()
+    // Detect whether the chosen path is a linked worktree of a larger repo.
+    // If so, label it with the branch and (if the main repo is already added)
+    // nest it as a child so it renders under its parent in the project list.
+    const info = await window.dplex.git.inspectPath(pathToAdd).catch(() => null)
+
+    let name = folderName(pathToAdd)
+    let parentProjectId: string | undefined
+    let parentRepoName: string | undefined
+    let parentRepoPath: string | undefined
+    if (info?.isWorktree) {
+      name = info.branch || folderName(pathToAdd)
+      parentRepoName = folderName(info.mainRepoPath)
+      parentRepoPath = info.mainRepoPath
+      const parent = projects.find(
+        (p) => normalizePath(p.path) === normalizePath(info.mainRepoPath)
+      )
+      parentProjectId = parent?.id
     }
 
+    const newProject: Project = {
+      id: generateId(),
+      name,
+      path: pathToAdd,
+      addedAt: new Date().toISOString(),
+      parentProjectId,
+      parentRepoName,
+      parentRepoPath
+    }
+
+    // Reconcile: if this newly added project is the main repo for any existing
+    // orphan worktree-projects (they stored parentRepoPath at add-time), claim
+    // them as children now. Only override when the worktree is currently
+    // orphan — i.e., its recorded parentProjectId points to a missing project
+    // or is unset entirely.
+    const idSet = new Set(projects.map((p) => p.id))
+    const isOrphanWorktree = (p: Project): boolean => {
+      if (!p.parentRepoPath) return false
+      if (p.parentProjectId && idSet.has(p.parentProjectId)) return false
+      return normalizePath(p.parentRepoPath) === normalized
+    }
+    const reconciled = projects.map((p) =>
+      isOrphanWorktree(p)
+        ? { ...p, parentProjectId: newProject.id, parentRepoName: newProject.name }
+        : p
+    )
+
+    set({ projects: [...reconciled, newProject] })
+    get().persistProjects()
+  },
+
+  addWorktreeProject: ({ parentProjectId, path, branch, createdByDplexWorktree }) => {
+    const { projects } = get()
+    const normalized = normalizePath(path)
+    const existing = projects.find((p) => normalizePath(p.path) === normalized)
+    if (existing) return existing
+
+    const parent = projects.find((p) => p.id === parentProjectId)
+    const project: Project = {
+      id: generateId(),
+      name: branch || folderName(path),
+      path,
+      addedAt: new Date().toISOString(),
+      parentProjectId,
+      parentRepoName: parent?.name,
+      parentRepoPath: parent?.path,
+      createdByDplexWorktree: createdByDplexWorktree ?? false
+    }
     set({ projects: [...projects, project] })
     get().persistProjects()
+    return project
   },
 
   removeProject: (id) => {
@@ -101,25 +184,27 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     })
   },
 
-  startAISession: (project, providerId?) => {
+  startAISession: async (project, providerId?) => {
     const settings = useSettingsStore.getState().settings
     const pid = providerId ?? settings.defaultAITool
 
-    window.dplex.sessions.getNewSessionCommand(pid).then((cmd) => {
-      window.dplex.sessions.getProviders().then((providers) => {
-        const command = cmd || (pid === 'copilot-cli' ? 'copilot' : pid)
-        const providerName = providers?.find((p) => p.id === pid)?.name ?? 'AI'
-        const title = `${providerName} · ${folderName(project.path)}`
+    const [cmd, providers] = await Promise.all([
+      window.dplex.sessions.getNewSessionCommand(pid),
+      window.dplex.sessions.getProviders()
+    ])
 
-        useTerminalStore.getState().createTerminal(
-          undefined,
-          title,
-          command,
-          undefined,
-          project.path,
-          pid
-        )
-      })
-    })
+    const command = cmd || (pid === 'copilot-cli' ? 'copilot' : pid)
+    const providerName = providers?.find((p) => p.id === pid)?.name ?? 'AI'
+    const title = `${providerName} · ${folderName(project.path)}`
+
+    const tabId = useTerminalStore.getState().createTerminal(
+      undefined,
+      title,
+      command,
+      undefined,
+      project.path,
+      pid
+    )
+    return tabId ?? null
   }
 }))

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand'
-import type { AppSettings } from '../types'
+import type { AppSettings, WorktreeDefaults } from '../types'
 import { getTheme } from '../services/themes'
 
 // Read cached theme from localStorage synchronously to avoid flash
@@ -53,6 +53,13 @@ const cachedTheme = getCachedTheme()
 
 let sidebarWidthPersistTimer: ReturnType<typeof setTimeout> | null = null
 
+export const DEFAULT_WORKTREE_DEFAULTS: WorktreeDefaults = {
+  locationPattern: '../{project}-{branch}',
+  envFiles: ['.env', '.env.local', '.env.*.local'],
+  setupScript: '',
+  afterCreate: 'session'
+}
+
 const DEFAULT_SETTINGS: AppSettings = {
   defaultShell: '',
   defaultAITool: 'copilot-cli',
@@ -72,7 +79,8 @@ const DEFAULT_SETTINGS: AppSettings = {
   dndFrom: null,
   dndTo: null,
   notificationCooldownSeconds: 30,
-  idleTooLongMinutes: 5
+  idleTooLongMinutes: 5,
+  worktreeDefaults: DEFAULT_WORKTREE_DEFAULTS
 }
 
 interface SettingsState {
@@ -90,8 +98,15 @@ export const useSettingsStore = create<SettingsState>((set, get) => ({
 
   loadSettings: async () => {
     try {
-      const saved = await window.dplex.settings.getAll()
-      const merged = { ...DEFAULT_SETTINGS, ...saved }
+      const saved = (await window.dplex.settings.getAll()) as Partial<AppSettings>
+      const merged: AppSettings = {
+        ...DEFAULT_SETTINGS,
+        ...saved,
+        worktreeDefaults: {
+          ...DEFAULT_WORKTREE_DEFAULTS,
+          ...(saved.worktreeDefaults ?? {})
+        }
+      }
       set({ settings: merged, loaded: true })
       cacheTheme(merged.theme)
     } catch {

--- a/src/renderer/src/stores/terminalStore.ts
+++ b/src/renderer/src/stores/terminalStore.ts
@@ -94,6 +94,7 @@ interface TerminalState {
   restoreWorkspace: (groups: EditorGroup[], layout: LayoutNode, activeGroupId: string | null) => void
   setPid: (terminalId: string, pid: number) => void
   associateSessionId: (terminalId: string, sessionId: string) => void
+  setWorktreeMetadata: (terminalId: string, worktreePath: string, worktreeBranch: string | null) => void
 }
 
 export const useTerminalStore = create<TerminalState>((set, get) => ({
@@ -381,6 +382,19 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         tabs: g.tabs.map((t) => (t.id === terminalId ? { ...t, sessionId } : t))
       }))
     }))
+  },
+
+  setWorktreeMetadata: (terminalId, worktreePath, worktreeBranch) => {
+    set((state) => ({
+      groups: state.groups.map((g) => ({
+        ...g,
+        tabs: g.tabs.map((t) =>
+          t.id === terminalId
+            ? { ...t, worktreePath, worktreeBranch: worktreeBranch ?? undefined }
+            : t
+        )
+      }))
+    }))
   }
 }))
 
@@ -401,7 +415,9 @@ function serializeWorkspace(): unknown {
           cwd: t.cwd,
           command: t.command,
           sessionId: t.sessionId,
-          providerId: t.providerId
+          providerId: t.providerId,
+          worktreePath: t.worktreePath,
+          worktreeBranch: t.worktreeBranch
         })),
       activeTabId: g.activeTabId
     })),

--- a/src/renderer/src/stores/worktreeStore.ts
+++ b/src/renderer/src/stores/worktreeStore.ts
@@ -1,0 +1,132 @@
+import { create } from 'zustand'
+import type { WorktreeInfo } from '../../../preload'
+
+interface RepoState {
+  worktrees: WorktreeInfo[]
+  loading: boolean
+  error: string | null
+  lastFetchedAt: number
+}
+
+interface WorktreeStoreState {
+  repos: Map<string, RepoState>
+  applySnapshot: (repoRoot: string, worktrees: WorktreeInfo[]) => void
+  setLoading: (repoRoot: string, loading: boolean) => void
+  setError: (repoRoot: string, error: string | null) => void
+  getRepo: (repoRoot: string) => RepoState | undefined
+  clear: (repoRoot: string) => void
+}
+
+function worktreesEqual(a: WorktreeInfo[], b: WorktreeInfo[]): boolean {
+  if (a === b) return true
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; i++) {
+    const x = a[i]
+    const y = b[i]
+    if (
+      x.path !== y.path ||
+      x.branch !== y.branch ||
+      x.head !== y.head ||
+      x.detached !== y.detached ||
+      x.isMain !== y.isMain ||
+      x.prunable !== y.prunable ||
+      x.createdByDplex !== y.createdByDplex ||
+      x.createdAt !== y.createdAt ||
+      x.baseBranch !== y.baseBranch ||
+      x.status.dirtyCount !== y.status.dirtyCount ||
+      x.status.untrackedCount !== y.status.untrackedCount ||
+      x.status.stagedCount !== y.status.stagedCount ||
+      x.status.ahead !== y.status.ahead ||
+      x.status.behind !== y.status.behind ||
+      x.status.upstream !== y.status.upstream
+    ) {
+      return false
+    }
+  }
+  return true
+}
+
+export const useWorktreeStore = create<WorktreeStoreState>((set, get) => ({
+  repos: new Map(),
+
+  applySnapshot: (repoRoot, worktrees) => {
+    const prev = get().repos.get(repoRoot)
+    // Skip work entirely when the snapshot is structurally unchanged AND
+    // the loading/error flags are already cleared. This prevents a
+    // re-render storm when the main process emits duplicate payloads.
+    if (
+      prev &&
+      !prev.loading &&
+      prev.error === null &&
+      worktreesEqual(prev.worktrees, worktrees)
+    ) {
+      return
+    }
+    const repos = new Map(get().repos)
+    repos.set(repoRoot, {
+      worktrees,
+      loading: false,
+      error: null,
+      lastFetchedAt: Date.now()
+    })
+    set({ repos })
+  },
+
+  setLoading: (repoRoot, loading) => {
+    const prev = get().repos.get(repoRoot) ?? {
+      worktrees: [],
+      loading: false,
+      error: null,
+      lastFetchedAt: 0
+    }
+    if (prev.loading === loading) return
+    const repos = new Map(get().repos)
+    repos.set(repoRoot, { ...prev, loading })
+    set({ repos })
+  },
+
+  setError: (repoRoot, error) => {
+    const prev = get().repos.get(repoRoot) ?? {
+      worktrees: [],
+      loading: false,
+      error: null,
+      lastFetchedAt: 0
+    }
+    if (prev.error === error && prev.loading === false) return
+    const repos = new Map(get().repos)
+    repos.set(repoRoot, { ...prev, error, loading: false })
+    set({ repos })
+  },
+
+  getRepo: (repoRoot) => get().repos.get(repoRoot),
+
+  clear: (repoRoot) => {
+    if (!get().repos.has(repoRoot)) return
+    const repos = new Map(get().repos)
+    repos.delete(repoRoot)
+    set({ repos })
+  }
+}))
+
+// Install a single module-level `onChanged` listener so that every repo
+// subscribed on the main side flows into the store without each hook instance
+// registering its own listener (which caused O(N²) fan-out on the hot path).
+//
+// Guard against Vite HMR re-evaluating this module, which would otherwise
+// stack a new listener on every hot-reload during development.
+declare global {
+  interface Window {
+    __dplexWorktreeListenerInstalled?: boolean
+  }
+}
+
+if (
+  typeof window !== 'undefined' &&
+  window.dplex?.worktrees?.onChanged &&
+  !window.__dplexWorktreeListenerInstalled
+) {
+  window.__dplexWorktreeListenerInstalled = true
+  window.dplex.worktrees.onChanged((payload) => {
+    useWorktreeStore.getState().applySnapshot(payload.repoRoot, payload.worktrees)
+  })
+}

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -7,6 +7,8 @@ export interface TerminalTab {
   sessionId?: string // AI tool session ID (e.g. copilot session dir name) for --resume on restore
   providerId?: string // AI provider id (e.g. 'copilot-cli') for composite attention identity
   pid?: number // PTY process PID, used for PID→session mapping
+  worktreePath?: string // Canonical worktree path if this tab was launched against a worktree
+  worktreeBranch?: string // Worktree branch at launch time (display hint, not authoritative)
 }
 
 export interface ShellInfo {
@@ -71,6 +73,26 @@ export interface AppSettings {
   dndTo: string | null
   notificationCooldownSeconds: number
   idleTooLongMinutes: number
+  /** Global defaults for worktree creation (inherited by per-project settings). */
+  worktreeDefaults: WorktreeDefaults
+}
+
+export interface WorktreeDefaults {
+  /** Path pattern — supports `{project}` and `{branch}` placeholders. */
+  locationPattern: string
+  /** Env files (repo-relative) to copy on create. Supports trailing `*`. */
+  envFiles: string[]
+  /** Setup script to run after creation (bash-style). Empty = none. */
+  setupScript: string
+  /** Default after-create behavior. */
+  afterCreate: 'session' | 'terminal' | 'none'
+}
+
+export interface ProjectWorktreeOverrides {
+  locationPattern?: string
+  envFiles?: string[] | null // null = inherit
+  setupScript?: string
+  afterCreate?: 'session' | 'terminal' | 'none'
 }
 
 export interface Project {
@@ -78,6 +100,17 @@ export interface Project {
   name: string
   path: string
   addedAt: string
+  worktreeOverrides?: ProjectWorktreeOverrides
+  /** If set, this project is a worktree of the project with this id. */
+  parentProjectId?: string
+  /** Display name of the parent repo at creation time — preserved so orphan
+      worktrees (parent project removed) can still show "branch (repo)". */
+  parentRepoName?: string
+  /** Absolute path of the parent repo (main checkout). Used to reconcile
+      parentProjectId when the origin is added later. */
+  parentRepoPath?: string
+  /** True when DPlex created the worktree (affects default "delete from disk" behavior). */
+  createdByDplexWorktree?: boolean
 }
 
 export interface ProviderInfo {

--- a/src/renderer/src/utils/worktreePath.ts
+++ b/src/renderer/src/utils/worktreePath.ts
@@ -1,0 +1,29 @@
+/**
+ * Helpers for worktree path/branch handling in the UI.
+ */
+
+/**
+ * Slugify a branch name for filesystem use:
+ *   feature/auth     → feature-auth
+ *   release/1.2      → release-1.2
+ *   fix my-thing     → fix-my-thing
+ *   héllo/wörld      → hllo-wrld (ascii only)
+ */
+export function slugifyBranch(branch: string): string {
+  return branch
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .toLowerCase()
+}
+
+/**
+ * Expand a location pattern with {project} and {branch} placeholders.
+ * Branch is slugified on the way through.
+ */
+export function expandPattern(pattern: string, projectName: string, branch: string): string {
+  return pattern
+    .replace(/\{project\}/g, projectName)
+    .replace(/\{branch\}/g, slugifyBranch(branch))
+}

--- a/tests/e2e/worktree.e2e.spec.ts
+++ b/tests/e2e/worktree.e2e.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
+import { closeApp, launchApp } from './support/electronApp'
+
+test.describe('DPlex worktree settings', () => {
+  let app: ElectronApplication | undefined
+  let window: Page | undefined
+  let userDataDir: string | undefined
+
+  test.beforeEach(async () => {
+    const launched = await launchApp()
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+  })
+
+  test.afterEach(async () => {
+    await closeApp(app, userDataDir)
+  })
+
+  test('Worktrees tab in Settings shows defaults form and persists changes', async () => {
+    if (!window) throw new Error('Window not available')
+
+    await window.getByTitle(/Settings/).click()
+    await expect(window.getByText('Settings')).toBeVisible()
+
+    await window.getByRole('button', { name: 'Worktrees' }).click()
+
+    // Defaults form fields render.
+    await expect(window.getByText('Location pattern')).toBeVisible()
+    await expect(window.getByText('Env files to copy')).toBeVisible()
+    await expect(window.getByText('Setup script')).toBeVisible()
+    await expect(window.getByText('After creation')).toBeVisible()
+
+    // Edit the location pattern; debounced settings save should leave the value
+    // in the input.
+    const locationInput = window.locator('input[placeholder*="{project}"]').first()
+    await locationInput.fill('../wt/{project}-{branch}')
+    await expect(locationInput).toHaveValue('../wt/{project}-{branch}')
+
+    // Reopen the Settings modal — debounced persisted value should reload.
+    await window.keyboard.press('Escape')
+    await expect(window.getByText('Enable notifications')).toHaveCount(0)
+
+    // Allow the debounced settings save (~250ms) to flush.
+    await window.waitForTimeout(500)
+
+    await window.getByTitle(/Settings/).click()
+    await window.getByRole('button', { name: 'Worktrees' }).click()
+    const reloaded = window.locator('input[placeholder*="{project}"]').first()
+    await expect(reloaded).toHaveValue('../wt/{project}-{branch}')
+
+    // Escape closes the modal.
+    await window.keyboard.press('Escape')
+    await expect(window.getByText('Location pattern')).toHaveCount(0)
+  })
+})

--- a/tests/unit/project-session-index.test.ts
+++ b/tests/unit/project-session-index.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest'
+import { buildProjectSessionIndex } from '../../src/renderer/src/hooks/useProjectSessions'
+import type { AISession, TerminalTab } from '../../src/renderer/src/types'
+
+function makeSession(id: string, cwd: string, status: AISession['status'] = 'idle'): AISession {
+  return {
+    id,
+    aiTool: 'copilot-cli',
+    cwd,
+    title: id,
+    status,
+    updatedAt: new Date(),
+    lastActivityTime: undefined
+  } as AISession
+}
+
+function makeTab(id: string, cwd: string): TerminalTab {
+  return {
+    id,
+    title: id,
+    cwd,
+    shell: '/bin/zsh'
+  } as TerminalTab
+}
+
+describe('buildProjectSessionIndex', () => {
+  it('attributes a session to the registered project that is its longest path prefix', () => {
+    const parent = '/repo'
+    const worktree = '/repo-wt/feat'
+    const projects = [parent, worktree]
+
+    const sessions: AISession[] = [
+      makeSession('s1', '/repo/src'),
+      makeSession('s2', '/repo-wt/feat/pkg'),
+      makeSession('s3', '/repo-wt/feat')
+    ]
+
+    const idx = buildProjectSessionIndex(sessions, [], projects)
+
+    expect(idx.get(parent)!.sessions.map((s) => s.id)).toEqual(['s1'])
+    expect(idx.get(worktree)!.sessions.map((s) => s.id).sort()).toEqual(['s2', 's3'])
+  })
+
+  it('does not let a shorter project path steal sessions from a deeper registered project', () => {
+    const outer = '/workspace'
+    const inner = '/workspace/dplex'
+    const projects = [outer, inner]
+
+    const sessions = [makeSession('s1', '/workspace/dplex/src/main')]
+
+    const idx = buildProjectSessionIndex(sessions, [], projects)
+
+    expect(idx.get(outer)!.sessions).toEqual([])
+    expect(idx.get(inner)!.sessions.map((s) => s.id)).toEqual(['s1'])
+  })
+
+  it('attributes plain terminals (no command) to the matching project', () => {
+    const projects = ['/repo', '/repo-wt/feat']
+    const groups = [
+      {
+        id: 'g1',
+        tabs: [makeTab('t1', '/repo-wt/feat'), makeTab('t2', '/repo/sub')]
+      }
+    ]
+
+    const idx = buildProjectSessionIndex([], groups, projects)
+
+    expect(idx.get('/repo')!.openTabs.map((t) => t.id)).toEqual(['t2'])
+    expect(idx.get('/repo-wt/feat')!.openTabs.map((t) => t.id)).toEqual(['t1'])
+  })
+
+  it('hasActive + activeCount reflect active sessions only', () => {
+    const projects = ['/p1', '/p2']
+    const sessions = [
+      makeSession('a', '/p1', 'active'),
+      makeSession('b', '/p1', 'idle'),
+      makeSession('c', '/p2', 'idle')
+    ]
+    const idx = buildProjectSessionIndex(sessions, [], projects)
+    expect(idx.get('/p1')!.activeCount).toBe(1)
+    expect(idx.get('/p1')!.hasActive).toBe(true)
+    expect(idx.get('/p2')!.activeCount).toBe(0)
+    expect(idx.get('/p2')!.hasActive).toBe(false)
+  })
+
+  it('ignores sessions whose cwd is outside every registered project', () => {
+    const idx = buildProjectSessionIndex(
+      [makeSession('orphan', '/tmp/elsewhere')],
+      [],
+      ['/repo']
+    )
+    expect(idx.get('/repo')!.sessions).toEqual([])
+  })
+
+  it('normalizes trailing slashes and backslashes consistently', () => {
+    const projects = ['/repo/']
+    const sessions = [makeSession('s1', '\\repo\\src')]
+    const idx = buildProjectSessionIndex(sessions, [], projects)
+    // Exact key is preserved in the map; the value should still include the session.
+    expect(idx.get('/repo/')!.sessions.map((s) => s.id)).toEqual(['s1'])
+  })
+})

--- a/tests/unit/worktree-path.test.ts
+++ b/tests/unit/worktree-path.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { expandPattern, slugifyBranch } from '../../src/renderer/src/utils/worktreePath'
+
+describe('slugifyBranch', () => {
+  it('replaces slashes with dashes', () => {
+    expect(slugifyBranch('feature/auth')).toBe('feature-auth')
+  })
+
+  it('preserves dots, dashes and underscores', () => {
+    expect(slugifyBranch('release/1.2.3')).toBe('release-1.2.3')
+    expect(slugifyBranch('fix_my-thing')).toBe('fix_my-thing')
+  })
+
+  it('strips diacritics down to ascii', () => {
+    // 'é' normalizes to 'e' + combining acute, the combining mark is stripped.
+    expect(slugifyBranch('héllo/wörld')).toBe('hello-world')
+  })
+
+  it('lowercases the result', () => {
+    expect(slugifyBranch('Feature/AUTH')).toBe('feature-auth')
+  })
+
+  it('trims leading and trailing dashes from non-alnum runs', () => {
+    expect(slugifyBranch('   weird name   ')).toBe('weird-name')
+    expect(slugifyBranch('//edge//')).toBe('edge')
+  })
+
+  it('returns an empty string for fully-stripped input', () => {
+    expect(slugifyBranch('   ')).toBe('')
+    expect(slugifyBranch('!!!')).toBe('')
+  })
+})
+
+describe('expandPattern', () => {
+  it('substitutes both placeholders', () => {
+    expect(expandPattern('../{project}-{branch}', 'dplex', 'feature/auth')).toBe(
+      '../dplex-feature-auth'
+    )
+  })
+
+  it('repeats placeholder substitution', () => {
+    expect(expandPattern('{branch}/{branch}', 'p', 'foo')).toBe('foo/foo')
+  })
+
+  it('leaves the pattern intact when no placeholders are present', () => {
+    expect(expandPattern('/tmp/static', 'dplex', 'main')).toBe('/tmp/static')
+  })
+
+  it('slugifies the branch on the way through', () => {
+    expect(expandPattern('wt/{branch}', 'p', 'Feature/Auth')).toBe('wt/feature-auth')
+  })
+
+  it('does not slugify the project name', () => {
+    expect(expandPattern('{project}/wt', 'My Project', 'main')).toBe('My Project/wt')
+  })
+})

--- a/tests/unit/worktree-porcelain.test.ts
+++ b/tests/unit/worktree-porcelain.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { parsePorcelain } from '../../src/main/services/worktrees/gitWorktree'
+import { parsePorcelain } from '../../src/main/services/worktrees/porcelain'
 
 describe('parsePorcelain', () => {
   it('returns an empty array for empty input', () => {

--- a/tests/unit/worktree-porcelain.test.ts
+++ b/tests/unit/worktree-porcelain.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from 'vitest'
+import { parsePorcelain } from '../../src/main/services/worktrees/gitWorktree'
+
+describe('parsePorcelain', () => {
+  it('returns an empty array for empty input', () => {
+    expect(parsePorcelain('')).toEqual([])
+  })
+
+  it('parses a single worktree on a branch', () => {
+    const out = [
+      'worktree /repo',
+      'HEAD abcdef1234567890',
+      'branch refs/heads/main',
+      ''
+    ].join('\n')
+    expect(parsePorcelain(out)).toEqual([
+      {
+        path: '/repo',
+        head: 'abcdef1234567890',
+        branch: 'main',
+        detached: false,
+        bare: false,
+        prunable: false
+      }
+    ])
+  })
+
+  it('parses multiple worktrees separated by blank lines', () => {
+    const out = [
+      'worktree /repo',
+      'HEAD aaaaaaa',
+      'branch refs/heads/main',
+      '',
+      'worktree /repo-feature',
+      'HEAD bbbbbbb',
+      'branch refs/heads/feature/auth',
+      ''
+    ].join('\n')
+    const records = parsePorcelain(out)
+    expect(records).toHaveLength(2)
+    expect(records[0].path).toBe('/repo')
+    expect(records[0].branch).toBe('main')
+    expect(records[1].path).toBe('/repo-feature')
+    expect(records[1].branch).toBe('feature/auth')
+  })
+
+  it('marks detached worktrees as detached and clears branch', () => {
+    const out = ['worktree /repo-detached', 'HEAD ccc', 'detached', ''].join('\n')
+    const [rec] = parsePorcelain(out)
+    expect(rec.detached).toBe(true)
+    expect(rec.branch).toBeNull()
+  })
+
+  it('marks bare repositories', () => {
+    const out = ['worktree /repo.git', 'HEAD 0000000', 'bare', ''].join('\n')
+    const [rec] = parsePorcelain(out)
+    expect(rec.bare).toBe(true)
+  })
+
+  it('marks prunable worktrees', () => {
+    const out = [
+      'worktree /repo-prune',
+      'HEAD ddd',
+      'branch refs/heads/old',
+      'prunable gitdir file points to non-existent location',
+      ''
+    ].join('\n')
+    const [rec] = parsePorcelain(out)
+    expect(rec.prunable).toBe(true)
+  })
+
+  it('emits the final record even without a trailing blank line', () => {
+    const out = ['worktree /repo', 'HEAD abc', 'branch refs/heads/main'].join('\n')
+    const records = parsePorcelain(out)
+    expect(records).toHaveLength(1)
+    expect(records[0].path).toBe('/repo')
+  })
+
+  it('preserves multi-segment branch names', () => {
+    const out = [
+      'worktree /repo',
+      'HEAD abc',
+      'branch refs/heads/feature/sub/part',
+      ''
+    ].join('\n')
+    const [rec] = parsePorcelain(out)
+    expect(rec.branch).toBe('feature/sub/part')
+  })
+
+  it('keeps non-refs/heads/ branch refs as-is', () => {
+    const out = ['worktree /repo', 'HEAD abc', 'branch refs/tags/v1', ''].join('\n')
+    const [rec] = parsePorcelain(out)
+    expect(rec.branch).toBe('refs/tags/v1')
+  })
+
+  it('ignores stray lines outside any record', () => {
+    const out = ['junk-line', '', 'worktree /repo', 'HEAD abc', ''].join('\n')
+    const records = parsePorcelain(out)
+    expect(records).toHaveLength(1)
+    expect(records[0].path).toBe('/repo')
+  })
+})


### PR DESCRIPTION
Treat git worktrees as first-class projects nested under their parent repo in the Projects panel. Adds worktree creation/deletion flows, per-project worktree defaults, env-file copy, and setup scripts.

Highlights:
- Nested worktree projects under parent with contrasted container
- Orphan-loaded worktrees display as "branch (repo)" with subtle repo suffix
- "No active sessions" placeholder for expanded empty worktrees
- Deterministic session-to-project attribution via longest-prefix match
- Reliable worktree detection using git-dir vs git-common-dir comparison
- Path-traversal hardening for env-file copy
- Cross-platform recursive fs.watch (darwin/win32) with Linux fallback
- DeleteWorktreeModal dirty check includes staged changes; tab matching falls back to cwd prefix
- Temp setup-script cleanup on terminal-creation failure
- Removed dead folderName helper and defaultProviderId plumbing
- Worktree creation now uses the global default AI tool

Code review policy in copilot-instructions expanded with comprehensive validation checklist (dead code, duplicates, cross-platform, memory leaks, security, perf, anti-patterns).