### PR TITLE
fix(release): raise Node heap to avoid macOS build OOM

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,15 @@ jobs:
     name: Build ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 40
+    env:
+      # `electron-vite build` peaks well above Node's default 2 GB heap
+      # because of the Monaco editor chunk (~6 MB) plus Vite 7's larger
+      # in-memory graph. Raising the limit globally for the build job
+      # keeps macOS / Linux / Windows on the same configuration and
+      # avoids "Allocation failed - JavaScript heap out of memory" OOMs
+      # on macos-latest (which exits 134 mid-build, see release run
+      # 25514990847).
+      NODE_OPTIONS: --max-old-space-size=8192
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Problem

Release run [25514990847](https://github.com/Ron537/DPlex/actions/runs/25514990847) for v0.11.2 failed on `macos-latest` during `electron-vite build`:

```
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
sh: line 1:  7442 Abort trap: 6           electron-vite build
##[error]Process completed with exit code 134.
```

Renderer bundle includes the Monaco editor chunk (~6 MB) and Vite 7 keeps a larger in-memory graph than v6, so the build now exceeds Node's default 2 GB old-space heap on the macOS runner. Linux + Windows happened to squeak under the limit but the same risk applies to them.

## Fix

Set `NODE_OPTIONS=--max-old-space-size=8192` at the build job level. 8 GB is comfortably under the macos-latest runner's 14 GB, and applies uniformly to all three platforms.

## Next step

Once merged, re-cut the v0.11.2 tag (or push a v0.11.3) so the macOS `.dmg` actually publishes.