### PR TITLE
Fix session title display and notification reliability (0.11.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.3] — 2026-05-09
+
+### Bug Fixes
+
+- Copilot CLI sessions now show their real title in the sidebar
+  again. Recent Copilot CLI versions write the session name to
+  `workspace.yaml` instead of `plan.md`, so older builds of DPlex
+  fell back to displaying truncated session ids for both active and
+  idle sessions.
+- Sessions sidebar now reflects the live tab title — the project list
+  and active-session rows update as soon as the AI tool renames the
+  tab on its first response, and stay updated instead of snapping
+  back to the session id while the on-disk name catches up.
+- Desktop notifications no longer silently drop when a session changes
+  attention type quickly (e.g. finishing right before asking for
+  approval). The cooldown now applies per attention type and never
+  blocks idle-too-long reminders.
+
 ## [0.11.2] — 2026-05-07
 
 ### Performance
@@ -363,7 +381,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.11.2...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.11.3...HEAD
+[0.11.3]: https://github.com/Ron537/DPlex/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Ron537/DPlex/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Ron537/DPlex/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/Ron537/DPlex/compare/v0.10.0...v0.11.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.11.2",
+  "version": "0.11.3",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/services/notifications.ts
+++ b/src/main/services/notifications.ts
@@ -14,6 +14,10 @@ import iconAsset from '../../../resources/icon.png?asset'
 
 const lastNotificationTime = new Map<string, number>()
 
+function cooldownKey(compositeId: string, kind: AttentionKind): string {
+  return `${compositeId}:${kind}`
+}
+
 let cachedIcon: NativeImage | null = null
 function getNotificationIcon(): NativeImage | undefined {
   if (!cachedIcon) {
@@ -81,7 +85,12 @@ export function applyNotificationSettings(patch: Partial<NotificationSettings>):
 }
 
 export function clearNotificationState(compositeIdOrSessionId: string): void {
-  lastNotificationTime.delete(compositeIdOrSessionId)
+  // Wipe any per-kind cooldown entries for this composite id.
+  for (const key of [...lastNotificationTime.keys()]) {
+    if (key === compositeIdOrSessionId || key.startsWith(`${compositeIdOrSessionId}:`)) {
+      lastNotificationTime.delete(key)
+    }
+  }
   dismissNotificationFor(compositeIdOrSessionId)
 }
 
@@ -193,11 +202,21 @@ export function handleAttentionEvent(ev: AttentionEvent): void {
     return
   }
 
-  const now = Date.now()
-  const lastTime = lastNotificationTime.get(ev.compositeId) ?? 0
-  const cooldownMs = Math.max(0, settings.cooldownSeconds) * 1000
-  if (cooldownMs > 0 && now - lastTime < cooldownMs) return
-  lastNotificationTime.set(ev.compositeId, now)
+  // Cooldown is per (session, kind). A 30s cooldown across all kinds caused
+  // legitimate notifications to silently drop — e.g. a session that finished,
+  // immediately got a follow-up prompt, then asked for approval would only
+  // notify once. The attention inbox showed all events but the OS popup
+  // didn't, which is exactly the "sometimes works, sometimes doesn't"
+  // symptom users reported. Escalations always notify (the whole point of an
+  // escalation is to remind a user who already missed the first ping).
+  if (!ev.escalated) {
+    const key = cooldownKey(ev.compositeId, ev.kind)
+    const lastTime = lastNotificationTime.get(key) ?? 0
+    const cooldownMs = Math.max(0, settings.cooldownSeconds) * 1000
+    const now = Date.now()
+    if (cooldownMs > 0 && now - lastTime < cooldownMs) return
+    lastNotificationTime.set(key, now)
+  }
 
   const notification = new Notification({
     title: kindTitle(ev.kind, ev.escalated),

--- a/src/main/services/providers/copilotProvider.ts
+++ b/src/main/services/providers/copilotProvider.ts
@@ -86,11 +86,17 @@ export class CopilotProvider extends BaseSessionProvider {
   // ── Private Helpers ──────────────────────────────────────────────
 
   private async getDisplayName(sessionDir: string, sessionId: string): Promise<string> {
+    // Newer Copilot CLI versions write the human-readable session title to
+    // `workspace.yaml` as `name:`. Older versions used `summary:` and/or a
+    // `plan.md` heading. Check the modern field first, fall back through the
+    // legacy sources, and finally to the first user prompt and a truncated id.
+    const workspace = await this.parseWorkspaceYaml(sessionDir)
+    if (workspace.name) return workspace.name
+
     const planPath = path.join(sessionDir, 'plan.md')
     const planName = await this.parsePlanSummary(planPath)
     if (planName) return planName
 
-    const workspace = await this.parseWorkspaceYaml(sessionDir)
     if (workspace.summary) return workspace.summary
 
     const firstMsg = await this.parseFirstUserMessage(sessionDir)
@@ -111,14 +117,16 @@ export class CopilotProvider extends BaseSessionProvider {
 
   private async parseWorkspaceYaml(
     sessionDir: string
-  ): Promise<{ summary?: string; cwd?: string; branch?: string }> {
+  ): Promise<{ name?: string; summary?: string; cwd?: string; branch?: string }> {
     try {
       const yamlPath = path.join(sessionDir, 'workspace.yaml')
       const content = await fsp.readFile(yamlPath, 'utf-8')
+      const nameMatch = content.match(/^name:\s*(.+)$/m)
       const summaryMatch = content.match(/^summary:\s*(.+)$/m)
       const cwdMatch = content.match(/^cwd:\s*(.+)$/m)
       const branchMatch = content.match(/^branch:\s*(.+)$/m)
       return {
+        name: nameMatch?.[1]?.trim().replace(/^["']|["']$/g, '') || undefined,
         summary: summaryMatch?.[1]?.trim() || undefined,
         cwd: cwdMatch?.[1]?.trim() || undefined,
         branch: branchMatch?.[1]?.trim() || undefined

--- a/src/renderer/src/hooks/useTerminal.ts
+++ b/src/renderer/src/hooks/useTerminal.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
+import { useSessionStore } from '../stores/sessionStore'
 import { useTerminalStore } from '../stores/terminalStore'
 import {
   getOrCreateTerminal,
@@ -12,6 +13,16 @@ import {
 const SESSION_RESOLVE_RETRY_MS = 5000
 const SESSION_RESOLVE_MAX_RETRIES = 6
 
+/**
+ * OSC titles received before the tab's sessionId has been resolved.
+ * Indexed by terminalId so we can replay the latest title into the live-title
+ * override (and back into the tab) once {@link resolveSessionIdForTab}
+ * associates the session. Without this, the title that the AI tool sets in
+ * the first second or two — typically the most useful summary — was clobbered
+ * by the provider's truncated-id displayName when association completed.
+ */
+const pendingOscTitles = new Map<string, string>()
+
 function tabExists(terminalId: string): boolean {
   return useTerminalStore.getState().groups.some((g) => g.tabs.some((t) => t.id === terminalId))
 }
@@ -23,7 +34,10 @@ async function resolveSessionIdForTab(
   providerId: string | undefined,
   attempt = 0
 ): Promise<void> {
-  if (!tabExists(terminalId)) return
+  if (!tabExists(terminalId)) {
+    pendingOscTitles.delete(terminalId)
+    return
+  }
   // Already resolved — never overwrite. The persisted sessionId is
   // authoritative on restore, and overwriting it during slow PID lookups
   // would let CWD fallback misassign a session from a different running
@@ -32,14 +46,26 @@ async function resolveSessionIdForTab(
     .getState()
     .groups.flatMap((g) => g.tabs)
     .find((t) => t.id === terminalId)
-  if (currentTab && currentTab.kind !== 'fileDiff' && currentTab.sessionId) return
+  if (currentTab && currentTab.kind !== 'fileDiff' && currentTab.sessionId) {
+    pendingOscTitles.delete(terminalId)
+    return
+  }
   try {
     const result = await window.dplex.sessions.resolveSessionId(pid, cwd, providerId)
     if (result) {
       if (tabExists(terminalId)) {
         const store = useTerminalStore.getState()
         store.associateSessionId(terminalId, result.sessionId)
-        store.renameTerminal(terminalId, result.displayName)
+        // If an OSC title arrived before resolution, prefer it — that's
+        // typically the AI tool's own summary of what the session is about
+        // and is more useful than the provider's truncated-id fallback.
+        const pending = pendingOscTitles.get(terminalId)
+        const titleToUse = pending ?? result.displayName
+        store.renameTerminal(terminalId, titleToUse)
+        if (pending && providerId) {
+          useSessionStore.getState().setLiveTabTitle(providerId, result.sessionId, pending)
+        }
+        pendingOscTitles.delete(terminalId)
       }
       return
     }
@@ -185,10 +211,29 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
             window.dplex.pty.resize(ptyId, cols, rows)
           })
 
-          // Sync terminal title changes (OSC escape sequences) to the tab title
+          // Sync terminal title changes (OSC escape sequences) to the tab
+          // title, and mirror to the matching AI session row in the sidebar
+          // via a live override. The override survives subsequent provider
+          // re-parses, which is necessary because Copilot CLI emits its OSC
+          // title before plan.md / events.jsonl land on disk — without the
+          // override the sidebar briefly shows the right name and then snaps
+          // back to the truncated session id when the provider's update
+          // arrives. The override is cleared when the tab is closed via
+          // useTerminalStore.removeTerminal. If the title arrives before
+          // session id resolution completes we stash it in pendingOscTitles
+          // so resolveSessionIdForTab can apply it once the sessionId is
+          // known.
           const onTitleDisposable = entry.term.onTitleChange((title) => {
-            if (title && tabExists(terminalId)) {
-              useTerminalStore.getState().renameTerminal(terminalId, title)
+            if (!title || !tabExists(terminalId)) return
+            const store = useTerminalStore.getState()
+            store.renameTerminal(terminalId, title)
+            const t = store.groups.flatMap((g) => g.tabs).find((tab) => tab.id === terminalId)
+            if (!t || t.kind === 'fileDiff' || !t.providerId) return
+            if (t.sessionId) {
+              useSessionStore.getState().setLiveTabTitle(t.providerId, t.sessionId, title)
+              pendingOscTitles.delete(terminalId)
+            } else {
+              pendingOscTitles.set(terminalId, title)
             }
           })
 

--- a/src/renderer/src/stores/sessionStore.ts
+++ b/src/renderer/src/stores/sessionStore.ts
@@ -8,12 +8,22 @@ interface SessionState {
   searchQuery: string
   watching: boolean
   sessionNameOverrides: Record<string, string>
+  /**
+   * In-memory titles set by the AI tool's OSC title sequences for currently
+   * open tabs. Survives provider re-parses (which can briefly flip displayName
+   * back to the truncated session id before plan.md / first user message
+   * lands on disk). Not persisted — cleared on app reload and when the tab
+   * is closed via {@link clearLiveTabTitle}.
+   */
+  liveTabTitles: Record<string, string>
 
   refreshSessions: () => Promise<void>
   setSearchQuery: (query: string) => void
   closeSession: (sessionId: string) => Promise<void>
   deleteSession: (sessionId: string) => Promise<void>
   setSessionNameOverride: (sessionId: string, name: string) => void
+  setLiveTabTitle: (aiTool: string, sessionId: string, title: string) => void
+  clearLiveTabTitle: (aiTool: string, sessionId: string) => void
   startWatching: () => void
   stopWatching: () => void
 
@@ -29,12 +39,20 @@ function sessionKey(aiTool: string, id: string): string {
 
 function mapDiscoveredToAISession(
   s: Awaited<ReturnType<typeof window.dplex.sessions.discover>>[number],
-  nameOverrides: Record<string, string>
+  nameOverrides: Record<string, string>,
+  liveTabTitles: Record<string, string>
 ): AISession {
   const key = sessionKey(s.aiTool, s.id)
+  // Precedence: user-set persistent override → live OSC title from open tab
+  // → provider-derived displayName. The live title bridges the gap between
+  // the AI tool sending an OSC title (which arrives in the tab immediately)
+  // and the provider's on-disk parse picking up a name (which can lag for
+  // several seconds while plan.md / events.jsonl get written).
+  const displayName =
+    nameOverrides[key] ?? nameOverrides[s.id] ?? liveTabTitles[key] ?? s.displayName
   return {
     id: s.id,
-    displayName: nameOverrides[key] ?? nameOverrides[s.id] ?? s.displayName,
+    displayName,
     status: s.status === 'active' ? ('active' as const) : ('idle' as const),
     aiTool: s.aiTool,
     createdAt: new Date(s.createdAt),
@@ -60,6 +78,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
     searchQuery: '',
     watching: false,
     sessionNameOverrides: {},
+    liveTabTitles: {},
 
     refreshSessions: async () => {
       set({ loading: true, error: null })
@@ -73,8 +92,10 @@ export const useSessionStore = create<SessionState>((set, get) => {
           }
         }
         const raw = await window.dplex.sessions.discover()
-        const { sessionNameOverrides } = get()
-        const sessions = raw.map((s) => mapDiscoveredToAISession(s, sessionNameOverrides))
+        const { sessionNameOverrides, liveTabTitles } = get()
+        const sessions = raw.map((s) =>
+          mapDiscoveredToAISession(s, sessionNameOverrides, liveTabTitles)
+        )
         set({ sessions, loading: false })
       } catch (err) {
         set({ error: String(err), loading: false })
@@ -133,11 +154,43 @@ export const useSessionStore = create<SessionState>((set, get) => {
       })
     },
 
+    setLiveTabTitle: (aiTool, sessionId, title) => {
+      const key = sessionKey(aiTool, sessionId)
+      set((state) => {
+        if (state.liveTabTitles[key] === title) return state
+        const liveTabTitles = { ...state.liveTabTitles, [key]: title }
+        // Apply immediately to any matching session row, but never override
+        // a user-set persistent name.
+        const persistent =
+          state.sessionNameOverrides[key] ?? state.sessionNameOverrides[sessionId]
+        if (persistent) return { liveTabTitles }
+        return {
+          liveTabTitles,
+          sessions: state.sessions.map((s) =>
+            s.id === sessionId && s.aiTool === aiTool && s.displayName !== title
+              ? { ...s, displayName: title }
+              : s
+          )
+        }
+      })
+    },
+
+    clearLiveTabTitle: (aiTool, sessionId) => {
+      const key = sessionKey(aiTool, sessionId)
+      set((state) => {
+        if (!(key in state.liveTabTitles)) return state
+        const { [key]: _removed, ...rest } = state.liveTabTitles
+        void _removed
+        return { liveTabTitles: rest }
+      })
+    },
+
     startWatching: () => {
       if (get().watching) return
 
       const unsubUpdated = window.dplex.sessions.onSessionUpdated((raw) => {
-        const updated = mapDiscoveredToAISession(raw, get().sessionNameOverrides)
+        const { sessionNameOverrides, liveTabTitles } = get()
+        const updated = mapDiscoveredToAISession(raw, sessionNameOverrides, liveTabTitles)
         set((state) => ({
           sessions: state.sessions.map((s) =>
             s.id === updated.id && s.aiTool === updated.aiTool ? updated : s
@@ -146,7 +199,8 @@ export const useSessionStore = create<SessionState>((set, get) => {
       })
 
       const unsubAdded = window.dplex.sessions.onSessionAdded((raw) => {
-        const added = mapDiscoveredToAISession(raw, get().sessionNameOverrides)
+        const { sessionNameOverrides, liveTabTitles } = get()
+        const added = mapDiscoveredToAISession(raw, sessionNameOverrides, liveTabTitles)
         set((state) => {
           if (state.sessions.some((s) => s.id === added.id && s.aiTool === added.aiTool)) {
             return state

--- a/src/renderer/src/stores/terminalStore.ts
+++ b/src/renderer/src/stores/terminalStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import type { TerminalTab, FileDiffTab, EditorTab, EditorGroup, LayoutNode } from '../types'
 import { isFileDiffTab, isTerminalTab } from '../types'
 import { destroyTerminal } from '../services/terminalRegistry'
+import { useSessionStore } from './sessionStore'
 
 let tabCounter = 0
 let groupCounter = 0
@@ -210,6 +211,11 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       void window.dplex.sessions.close(tab.sessionId, tab.providerId).catch(() => {
         // ignore — provider may fail if the session is already gone
       })
+      // Drop the live OSC-title override so future provider updates can win
+      // again. The current sessions[].displayName keeps the last OSC title
+      // until the provider's onUpdated callback re-derives it (which happens
+      // shortly after closeSession kills the lock file).
+      useSessionStore.getState().clearLiveTabTitle(tab.providerId, tab.sessionId)
     }
 
     destroyTerminal(terminalId)


### PR DESCRIPTION
## Summary

Three bug fixes:

### 1. Copilot CLI session titles missing from sidebar
Recent Copilot CLI versions write the session name to `workspace.yaml` as `name:` instead of `plan.md`. `CopilotProvider.getDisplayName` now reads the new field first, with the legacy sources as fallbacks. Existing idle Copilot sessions will now show their real titles instead of truncated session ids.

### 2. Tab title not reflected in projects/sessions sidebar
The OSC title set by the AI tool updated `tab.title` but the sidebar kept showing the stale provider-derived `displayName`. Two changes:

- Added `liveTabTitles` in-memory map in `sessionStore` that overrides `displayName` for currently-open tabs and survives subsequent provider re-parses.
- Buffered pending OSC titles received before `sessionId` resolution and replay them once association completes (previously `resolveSessionIdForTab` clobbered the OSC title with the provider's truncated-id fallback).

The override is cleared when the tab is closed.

### 3. Desktop notifications sometimes dropped
The 30 s cooldown was per-`compositeId`, so a session transitioning between attention kinds (e.g. `finished` → `waitingForApproval`) within the cooldown window only got the first OS notification — the second showed in the attention inbox but never as a desktop popup. Cooldown is now per (`compositeId`, `kind`) and idle-too-long escalations always notify.

## Testing

- `npm run typecheck` — passes
- `npm run test:unit` — 262 / 262 pass

## Code review

Ran two parallel code-review agents (Claude Opus 4.7 + GPT-5.5). Both findings addressed:

- **GPT (Medium)**: OSC titles arriving before sessionId resolution were dropped — fixed via `pendingOscTitles` buffer.
- **Opus (Low)**: Misleading doc comment in `closeTerminal` — corrected.

## Versioning

Bumped to **0.11.3** (PATCH — bug fixes only). `CHANGELOG.md` updated.