### PR TITLE
feat: global search palette and activity-bar Search view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.12.0] — 2026-05-09
+
+### Features
+
+- New global search palette (Cmd/Ctrl+P) for finding projects,
+  sessions, open tabs, settings, and actions in one place. Results
+  are grouped by type with keyboard navigation.
+- Cmd/Ctrl+Shift+P opens a command runner filtered to actions —
+  add a project, toggle the sidebar, switch views, and more.
+- New Search view in the activity bar mirrors the palette as a
+  persistent side panel.
+- Searching for a setting jumps straight to the right Settings tab
+  and pulse-highlights the row.
+
 ## [0.11.3] — 2026-05-09
 
 ### Bug Fixes
@@ -381,7 +395,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.11.3...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.12.0...HEAD
+[0.12.0]: https://github.com/Ron537/DPlex/compare/v0.11.3...v0.12.0
 [0.11.3]: https://github.com/Ron537/DPlex/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Ron537/DPlex/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/Ron537/DPlex/compare/v0.11.0...v0.11.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.11.3",
+  "version": "0.12.0",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,4 +1,12 @@
-import { app, shell, BrowserWindow, ipcMain, dialog, nativeImage } from 'electron'
+import {
+  app,
+  shell,
+  BrowserWindow,
+  ipcMain,
+  dialog,
+  nativeImage,
+  globalShortcut
+} from 'electron'
 import { join } from 'path'
 import * as path from 'path'
 import { randomUUID } from 'crypto'
@@ -265,32 +273,55 @@ function createWindow(): void {
     }
   })
 
-  // Suppress Chromium's built-in keyboard accelerators that collide with
-  // app-level shortcuts owned by the renderer, and forward the press as an
-  // IPC instead. Calling `event.preventDefault()` on `before-input-event`
-  // stops Chromium AND blocks DOM dispatch, so we can't simply swallow it
-  // here — we have to re-deliver the intent to the renderer.
-  //   - Ctrl/Cmd+P → 'palette.all' (Chromium default: print preview)
+  // App-level keyboard shortcuts owned by the renderer that collide with
+  // Chromium built-ins (notably Ctrl+P → print preview on Linux/Windows).
+  // We use `globalShortcut` so the accelerators fire regardless of which
+  // sub-element has DOM focus and so Chromium can't intercept them at all.
+  // The shortcuts are scoped to the app's focus state via the
+  // `browser-window-focus` / `browser-window-blur` events below — they are
+  // *not* stolen system-wide.
+  //   - Ctrl/Cmd+P → 'palette.all'
   //   - Ctrl/Cmd+Shift+P → 'palette.commands'
   //   - Ctrl/Cmd+Shift+F → 'sidebar.search'
   // The renderer subscribes via `window.dplex.shortcuts.onShortcut`.
-  mainWindow.webContents.on('before-input-event', (event, input) => {
-    if (input.type !== 'keyDown') return
-    const key = input.key.toLowerCase()
-    const mod = input.control || input.meta
-    if (!mod) return
-    let shortcutId: string | null = null
-    if (key === 'p') {
-      shortcutId = input.shift ? 'palette.commands' : 'palette.all'
-    } else if (key === 'f' && input.shift) {
-      shortcutId = 'sidebar.search'
-    }
-    if (shortcutId === null) return
-    event.preventDefault()
+  const APP_SHORTCUTS: ReadonlyArray<{ accelerator: string; id: string }> = [
+    { accelerator: 'CommandOrControl+P', id: 'palette.all' },
+    { accelerator: 'CommandOrControl+Shift+P', id: 'palette.commands' },
+    { accelerator: 'CommandOrControl+Shift+F', id: 'sidebar.search' }
+  ]
+  const sendShortcut = (id: string): void => {
     if (mainWindow && !mainWindow.isDestroyed()) {
-      mainWindow.webContents.send('dplex:shortcut', shortcutId)
+      mainWindow.webContents.send('dplex:shortcut', id)
     }
-  })
+  }
+  const registerAppShortcuts = (): void => {
+    // Re-registration is a no-op in Electron (returns false), but `focus`
+    // can fire repeatedly without a paired `blur` (e.g. show, restore,
+    // Alt+Tab). Unregister first so the registration call is always fresh
+    // and never silently fails on repeat focuses.
+    unregisterAppShortcuts()
+    for (const { accelerator, id } of APP_SHORTCUTS) {
+      try {
+        globalShortcut.register(accelerator, () => sendShortcut(id))
+      } catch {
+        // Best-effort — a conflicting registration in another app shouldn't
+        // tear down DPlex.
+      }
+    }
+  }
+  const unregisterAppShortcuts = (): void => {
+    for (const { accelerator } of APP_SHORTCUTS) {
+      try {
+        globalShortcut.unregister(accelerator)
+      } catch {
+        // ignore
+      }
+    }
+  }
+  registerAppShortcuts()
+  mainWindow.on('focus', registerAppShortcuts)
+  mainWindow.on('blur', unregisterAppShortcuts)
+  mainWindow.on('closed', unregisterAppShortcuts)
 
   // Harden external link handling: shell.openExternal will happily dispatch
   // any URL scheme to the OS handler — including dangerous ones like `file:`,
@@ -1062,9 +1093,16 @@ app.whenReady().then(() => {
 })
 
 app.on('window-all-closed', () => {
+  // Unregister any app-level globalShortcuts so a relaunch doesn't see
+  // stale registrations from a prior process.
+  globalShortcut.unregisterAll()
   if (process.platform !== 'darwin') {
     app.quit()
   }
+})
+
+app.on('will-quit', () => {
+  globalShortcut.unregisterAll()
 })
 
 app.on('before-quit', () => {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -265,6 +265,33 @@ function createWindow(): void {
     }
   })
 
+  // Suppress Chromium's built-in keyboard accelerators that collide with
+  // app-level shortcuts owned by the renderer, and forward the press as an
+  // IPC instead. Calling `event.preventDefault()` on `before-input-event`
+  // stops Chromium AND blocks DOM dispatch, so we can't simply swallow it
+  // here — we have to re-deliver the intent to the renderer.
+  //   - Ctrl/Cmd+P → 'palette.all' (Chromium default: print preview)
+  //   - Ctrl/Cmd+Shift+P → 'palette.commands'
+  //   - Ctrl/Cmd+Shift+F → 'sidebar.search'
+  // The renderer subscribes via `window.dplex.shortcuts.onShortcut`.
+  mainWindow.webContents.on('before-input-event', (event, input) => {
+    if (input.type !== 'keyDown') return
+    const key = input.key.toLowerCase()
+    const mod = input.control || input.meta
+    if (!mod) return
+    let shortcutId: string | null = null
+    if (key === 'p') {
+      shortcutId = input.shift ? 'palette.commands' : 'palette.all'
+    } else if (key === 'f' && input.shift) {
+      shortcutId = 'sidebar.search'
+    }
+    if (shortcutId === null) return
+    event.preventDefault()
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.webContents.send('dplex:shortcut', shortcutId)
+    }
+  })
+
   // Harden external link handling: shell.openExternal will happily dispatch
   // any URL scheme to the OS handler — including dangerous ones like `file:`,
   // `javascript:`, or OS-registered protocol handlers (e.g. `ms-excel:`) that

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -167,6 +167,13 @@ export interface DplexAPI {
     onUpdated: (callback: (snapshot: AttentionSnapshot) => void) => () => void
     onFocusSession: (callback: (compositeId: string) => void) => () => void
   }
+  shortcuts: {
+    /** Subscribe to keyboard shortcuts forwarded from the main process.
+     *  Used for accelerators that collide with Chromium defaults
+     *  (e.g. Ctrl+P / print) — the main process suppresses Chromium's
+     *  built-in handler and re-delivers the intent here. */
+    onShortcut: (callback: (id: string) => void) => () => void
+  }
   worktrees: {
     list: (repoRoot: string) => Promise<WorktreeInfo[]>
     listBranches: (
@@ -340,6 +347,13 @@ const dplexAPI: DplexAPI = {
         callback(compositeId)
       ipcRenderer.on('attention:focusSession', handler)
       return () => ipcRenderer.removeListener('attention:focusSession', handler)
+    }
+  },
+  shortcuts: {
+    onShortcut: (callback) => {
+      const handler = (_event: Electron.IpcRendererEvent, id: string): void => callback(id)
+      ipcRenderer.on('dplex:shortcut', handler)
+      return () => ipcRenderer.removeListener('dplex:shortcut', handler)
     }
   },
   worktrees: {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -48,27 +48,12 @@ function App(): React.JSX.Element {
         toggleSidebar()
       }
 
-      // Cmd/Ctrl+F focuses the active panel's search input. Cmd/Ctrl+Shift+F
-      // opens the activity-bar Search view (and focuses its input).
-      if (meta && (e.key === 'f' || e.key === 'F')) {
+      // Cmd/Ctrl+F focuses the active panel's search input. Plain F only —
+      // Cmd/Ctrl+Shift+F is delivered via the main-process accelerator
+      // forwarder so Chromium's defaults can't swallow it on Linux.
+      if (meta && !e.shiftKey && (e.key === 'f' || e.key === 'F')) {
         e.preventDefault()
         const settingsStore = useSettingsStore.getState()
-        if (e.shiftKey) {
-          settingsStore.updateSettings({
-            sidebarActiveTab: 'search',
-            sidebarPanelCollapsed: false,
-            sidebarVisible: true
-          })
-          // The Search view focuses its input on mount via the same custom
-          // event the panel-search inputs listen for. Defer to the next
-          // frame so the input exists in the DOM before we dispatch.
-          requestAnimationFrame(() => {
-            window.dispatchEvent(new CustomEvent('dplex:focus-search'))
-          })
-          return
-        }
-        // Plain Cmd/Ctrl+F — expand the panel if collapsed, then focus the
-        // current view's search input.
         if (settingsStore.settings.sidebarPanelCollapsed) {
           settingsStore.updateSettings({ sidebarPanelCollapsed: false })
         }
@@ -82,11 +67,27 @@ function App(): React.JSX.Element {
         dispatchOpenSettings()
       }
 
-      // Cmd/Ctrl+P → global search palette (all categories).
-      // Cmd/Ctrl+Shift+P → command runner (commands category only).
+      // Cmd/Ctrl+P / Cmd/Ctrl+Shift+P / Cmd/Ctrl+Shift+F also fire from the
+      // main-process accelerator forwarder. We keep the DOM keydown path
+      // here for environments where `before-input-event` doesn't fire (e.g.
+      // Playwright synthesized events on macOS) — when both paths are
+      // active, main's preventDefault suppresses DOM dispatch, so only one
+      // ever runs per keystroke.
       if (meta && (e.key === 'p' || e.key === 'P')) {
         e.preventDefault()
         useCommandPaletteStore.getState().toggle(e.shiftKey ? 'commands' : 'all')
+      }
+
+      if (meta && e.shiftKey && (e.key === 'f' || e.key === 'F')) {
+        e.preventDefault()
+        useSettingsStore.getState().updateSettings({
+          sidebarActiveTab: 'search',
+          sidebarPanelCollapsed: false,
+          sidebarVisible: true
+        })
+        requestAnimationFrame(() => {
+          window.dispatchEvent(new CustomEvent('dplex:focus-search'))
+        })
       }
 
       if (meta && !e.shiftKey && e.key === '\\') {
@@ -132,6 +133,28 @@ function App(): React.JSX.Element {
     window.addEventListener('keydown', handleKeyDown)
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [handleKeyDown])
+
+  // Subscribe to shortcuts forwarded from the main-process accelerator
+  // hook. These are accelerators Chromium would otherwise consume before
+  // any renderer keydown listener sees them (e.g. Ctrl+P → print preview).
+  useEffect(() => {
+    return window.dplex.shortcuts.onShortcut((id) => {
+      if (id === 'palette.all') {
+        useCommandPaletteStore.getState().toggle('all')
+      } else if (id === 'palette.commands') {
+        useCommandPaletteStore.getState().toggle('commands')
+      } else if (id === 'sidebar.search') {
+        useSettingsStore.getState().updateSettings({
+          sidebarActiveTab: 'search',
+          sidebarPanelCollapsed: false,
+          sidebarVisible: true
+        })
+        requestAnimationFrame(() => {
+          window.dispatchEvent(new CustomEvent('dplex:focus-search'))
+        })
+      }
+    })
+  }, [])
 
   return (
     <>

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -2,10 +2,13 @@ import { useEffect, useCallback } from 'react'
 import { AppLayout } from './components/layout/AppLayout'
 import { ProviderIconSprite } from './components/common/ProviderIconSprite'
 import { UpdateBanner } from './components/common/UpdateBanner'
+import { CommandPalette } from './components/search/CommandPalette'
 import { useSettingsStore } from './stores/settingsStore'
 import { useTerminalStore } from './stores/terminalStore'
 import { useProvidersStore } from './stores/providersStore'
 import { useUpdateStore } from './stores/updateStore'
+import { useCommandPaletteStore } from './stores/commandPaletteStore'
+import { dispatchOpenSettings } from './utils/openSettings'
 
 function App(): React.JSX.Element {
   const loadSettings = useSettingsStore((s) => s.loadSettings)
@@ -45,14 +48,30 @@ function App(): React.JSX.Element {
         toggleSidebar()
       }
 
-      if (meta && e.key === 'f') {
+      // Cmd/Ctrl+F focuses the active panel's search input. Cmd/Ctrl+Shift+F
+      // opens the activity-bar Search view (and focuses its input).
+      if (meta && (e.key === 'f' || e.key === 'F')) {
         e.preventDefault()
-        // Expand the panel if it's collapsed so the search input is mounted.
-        const settings = useSettingsStore.getState().settings
-        if (settings.sidebarPanelCollapsed) {
-          useSettingsStore.getState().updateSettings({ sidebarPanelCollapsed: false })
+        const settingsStore = useSettingsStore.getState()
+        if (e.shiftKey) {
+          settingsStore.updateSettings({
+            sidebarActiveTab: 'search',
+            sidebarPanelCollapsed: false,
+            sidebarVisible: true
+          })
+          // The Search view focuses its input on mount via the same custom
+          // event the panel-search inputs listen for. Defer to the next
+          // frame so the input exists in the DOM before we dispatch.
+          requestAnimationFrame(() => {
+            window.dispatchEvent(new CustomEvent('dplex:focus-search'))
+          })
+          return
         }
-        // Defer to next frame so the input exists in the DOM before we focus.
+        // Plain Cmd/Ctrl+F — expand the panel if collapsed, then focus the
+        // current view's search input.
+        if (settingsStore.settings.sidebarPanelCollapsed) {
+          settingsStore.updateSettings({ sidebarPanelCollapsed: false })
+        }
         requestAnimationFrame(() => {
           window.dispatchEvent(new CustomEvent('dplex:focus-search'))
         })
@@ -60,7 +79,14 @@ function App(): React.JSX.Element {
 
       if (meta && e.key === ',') {
         e.preventDefault()
-        window.dispatchEvent(new CustomEvent('dplex:open-settings'))
+        dispatchOpenSettings()
+      }
+
+      // Cmd/Ctrl+P → global search palette (all categories).
+      // Cmd/Ctrl+Shift+P → command runner (commands category only).
+      if (meta && (e.key === 'p' || e.key === 'P')) {
+        e.preventDefault()
+        useCommandPaletteStore.getState().toggle(e.shiftKey ? 'commands' : 'all')
       }
 
       if (meta && !e.shiftKey && e.key === '\\') {
@@ -112,6 +138,7 @@ function App(): React.JSX.Element {
       <ProviderIconSprite />
       <AppLayout />
       <UpdateBanner />
+      <CommandPalette />
     </>
   )
 }

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -27,6 +27,17 @@ function App(): React.JSX.Element {
     return initUpdateStore()
   }, [loadSettings, loadProviders, initUpdateStore])
 
+  const openSidebarSearch = useCallback(() => {
+    useSettingsStore.getState().updateSettings({
+      sidebarActiveTab: 'search',
+      sidebarPanelCollapsed: false,
+      sidebarVisible: true
+    })
+    requestAnimationFrame(() => {
+      window.dispatchEvent(new CustomEvent('dplex:focus-search'))
+    })
+  }, [])
+
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
       const meta = e.metaKey || e.ctrlKey
@@ -48,11 +59,14 @@ function App(): React.JSX.Element {
         toggleSidebar()
       }
 
-      // Cmd/Ctrl+F focuses the active panel's search input. Plain F only —
-      // Cmd/Ctrl+Shift+F is delivered via the main-process accelerator
-      // forwarder so Chromium's defaults can't swallow it on Linux.
-      if (meta && !e.shiftKey && (e.key === 'f' || e.key === 'F')) {
+      // Cmd/Ctrl+F focuses the active panel's search input.
+      // Cmd/Ctrl+Shift+F opens the activity-bar Search view.
+      if (meta && (e.key === 'f' || e.key === 'F')) {
         e.preventDefault()
+        if (e.shiftKey) {
+          openSidebarSearch()
+          return
+        }
         const settingsStore = useSettingsStore.getState()
         if (settingsStore.settings.sidebarPanelCollapsed) {
           settingsStore.updateSettings({ sidebarPanelCollapsed: false })
@@ -67,27 +81,20 @@ function App(): React.JSX.Element {
         dispatchOpenSettings()
       }
 
-      // Cmd/Ctrl+P / Cmd/Ctrl+Shift+P / Cmd/Ctrl+Shift+F also fire from the
-      // main-process accelerator forwarder. We keep the DOM keydown path
-      // here for environments where `before-input-event` doesn't fire (e.g.
-      // Playwright synthesized events on macOS) — when both paths are
-      // active, main's preventDefault suppresses DOM dispatch, so only one
-      // ever runs per keystroke.
+      // Cmd/Ctrl+P → global search palette (all categories).
+      // Cmd/Ctrl+Shift+P → command runner (commands category only).
+      //
+      // These are *also* registered as `globalShortcut`s in main, which is
+      // what catches the keystroke for real users on Linux/Windows where
+      // Chromium would otherwise intercept Ctrl+P for print preview.
+      // `globalShortcut` consumes native input before Chromium dispatches
+      // the DOM event, so on real keystrokes only that path fires. This
+      // DOM listener handles Playwright synthesized events (CDP injects
+      // straight into the renderer, bypassing the OS pipeline that
+      // `globalShortcut` listens on) and serves as a defensive fallback.
       if (meta && (e.key === 'p' || e.key === 'P')) {
         e.preventDefault()
         useCommandPaletteStore.getState().toggle(e.shiftKey ? 'commands' : 'all')
-      }
-
-      if (meta && e.shiftKey && (e.key === 'f' || e.key === 'F')) {
-        e.preventDefault()
-        useSettingsStore.getState().updateSettings({
-          sidebarActiveTab: 'search',
-          sidebarPanelCollapsed: false,
-          sidebarVisible: true
-        })
-        requestAnimationFrame(() => {
-          window.dispatchEvent(new CustomEvent('dplex:focus-search'))
-        })
       }
 
       if (meta && !e.shiftKey && e.key === '\\') {
@@ -126,7 +133,15 @@ function App(): React.JSX.Element {
         }
       }
     },
-    [createTerminal, closeTerminal, toggleSidebar, splitGroup, setActiveGroup, setActiveTerminalInGroup]
+    [
+      createTerminal,
+      closeTerminal,
+      toggleSidebar,
+      splitGroup,
+      setActiveGroup,
+      setActiveTerminalInGroup,
+      openSidebarSearch
+    ]
   )
 
   useEffect(() => {
@@ -134,9 +149,13 @@ function App(): React.JSX.Element {
     return () => window.removeEventListener('keydown', handleKeyDown)
   }, [handleKeyDown])
 
-  // Subscribe to shortcuts forwarded from the main-process accelerator
-  // hook. These are accelerators Chromium would otherwise consume before
-  // any renderer keydown listener sees them (e.g. Ctrl+P → print preview).
+  // Subscribe to shortcuts forwarded from the main-process `globalShortcut`
+  // accelerators. These are accelerators Chromium would otherwise consume
+  // before any renderer keydown listener sees them (e.g. Ctrl+P → print
+  // preview on Linux/Windows). The DOM keydown listener above stays in
+  // place as a fallback for environments where `globalShortcut` doesn't
+  // fire (e.g. Playwright synthesized events go straight to the renderer
+  // via CDP, bypassing the OS pipeline).
   useEffect(() => {
     return window.dplex.shortcuts.onShortcut((id) => {
       if (id === 'palette.all') {
@@ -144,17 +163,10 @@ function App(): React.JSX.Element {
       } else if (id === 'palette.commands') {
         useCommandPaletteStore.getState().toggle('commands')
       } else if (id === 'sidebar.search') {
-        useSettingsStore.getState().updateSettings({
-          sidebarActiveTab: 'search',
-          sidebarPanelCollapsed: false,
-          sidebarVisible: true
-        })
-        requestAnimationFrame(() => {
-          window.dispatchEvent(new CustomEvent('dplex:focus-search'))
-        })
+        openSidebarSearch()
       }
     })
-  }, [])
+  }, [openSidebarSearch])
 
   return (
     <>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -611,3 +611,26 @@ body {
   opacity: 1;
   background: var(--dplex-hover);
 }
+
+/* Pulse highlight for settings rows surfaced via the global search.
+   Triggered by SettingsModal when the user opens the modal via a
+   settings search result. The highlight lingers long enough for the
+   eye to track the scroll-into-view motion before fading out. */
+@keyframes dplex-setting-pulse {
+  0% {
+    background-color: var(--dplex-accent-soft);
+    box-shadow: 0 0 0 4px var(--dplex-accent-soft);
+  }
+  60% {
+    background-color: var(--dplex-accent-soft);
+    box-shadow: 0 0 0 4px var(--dplex-accent-soft);
+  }
+  100% {
+    background-color: transparent;
+    box-shadow: 0 0 0 0 transparent;
+  }
+}
+.dplex-setting-pulse {
+  animation: dplex-setting-pulse 3s ease-out 1;
+  border-radius: 6px;
+}

--- a/src/renderer/src/components/layout/ActivityBar.tsx
+++ b/src/renderer/src/components/layout/ActivityBar.tsx
@@ -1,12 +1,12 @@
 import { useMemo } from 'react'
-import { FolderOpen, History, GitBranch, Settings } from 'lucide-react'
+import { FolderOpen, History, GitBranch, Settings, Search } from 'lucide-react'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useGitPanelStore } from '../../stores/gitPanelStore'
 import { useProjectStore } from '../../stores/projectStore'
 import { useAttentionStore } from '../../stores/attentionStore'
 import { MOD, SHIFT } from '../../utils/shortcuts'
 
-type ActivityId = 'projects' | 'sessions' | 'git'
+type ActivityId = 'search' | 'projects' | 'sessions' | 'git'
 
 interface ActivityItem {
   id: ActivityId
@@ -18,7 +18,8 @@ interface ActivityItem {
 const ITEMS: ActivityItem[] = [
   { id: 'projects', label: 'Projects', Icon: FolderOpen },
   { id: 'sessions', label: 'Sessions', Icon: History },
-  { id: 'git', label: 'Source Control', shortcut: `${MOD}${SHIFT}G`, Icon: GitBranch }
+  { id: 'git', label: 'Source Control', shortcut: `${MOD}${SHIFT}G`, Icon: GitBranch },
+  { id: 'search', label: 'Search', shortcut: `${MOD}${SHIFT}F`, Icon: Search }
 ]
 
 const BAR_WIDTH = 48

--- a/src/renderer/src/components/layout/SidePanel.tsx
+++ b/src/renderer/src/components/layout/SidePanel.tsx
@@ -18,6 +18,7 @@ import { ProjectList } from '../projects/ProjectList'
 import { ProjectPanelFooter } from '../projects/ProjectPanelFooter'
 import { SessionPanelFooter } from '../sessions/SessionPanelFooter'
 import { GitSidePanelView } from '../git/GitSidePanelView'
+import { SearchSidePanelView } from '../search/SearchSidePanelView'
 
 export type SessionGroupMode = 'time' | 'workspace'
 
@@ -382,6 +383,8 @@ export function SidePanel(): React.JSX.Element | null {
     >
       {activeTab === 'git' ? (
         <GitSidePanelView />
+      ) : activeTab === 'search' ? (
+        <SearchSidePanelView />
       ) : (
         <>
           <div

--- a/src/renderer/src/components/search/CommandPalette.tsx
+++ b/src/renderer/src/components/search/CommandPalette.tsx
@@ -1,0 +1,180 @@
+import { useEffect, useMemo, useRef } from 'react'
+import { Search, ChevronUp, ChevronDown, CornerDownLeft } from 'lucide-react'
+import { useCommandPaletteStore } from '../../stores/commandPaletteStore'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+import { useGlobalSearch } from './useGlobalSearch'
+import { useSearchKeyboardNav } from './useSearchKeyboardNav'
+import { SearchResultsList } from './SearchResultsList'
+import type { SearchCategory } from '../../services/search/types'
+
+const COMMAND_ONLY: ReadonlyArray<SearchCategory> = ['commands']
+
+const LIST_ID = 'dplex-cmd-palette-list'
+
+export function CommandPalette(): React.JSX.Element | null {
+  const open = useCommandPaletteStore((s) => s.open)
+  const mode = useCommandPaletteStore((s) => s.mode)
+  const close = useCommandPaletteStore((s) => s.close)
+
+  const categories = useMemo(() => (mode === 'commands' ? COMMAND_ONLY : undefined), [mode])
+
+  // In commands-only mode, lift the per-group caps so every command is
+  // always visible (both before typing and after — the list is small).
+  const isCommandsMode = mode === 'commands'
+  const search = useGlobalSearch({
+    enabled: open,
+    categories,
+    maxPerGroup: isCommandsMode ? 100 : undefined,
+    emptyQueryLimit: isCommandsMode ? 100 : undefined
+  })
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Close on Escape from anywhere — uses the shared hook so the listener is
+  // installed on `document` and survives focus moving outside the input.
+  useEscapeKey(close, open)
+
+  // Focus the input each time the modal opens.
+  useEffect(() => {
+    if (!open) return
+    const id = requestAnimationFrame(() => inputRef.current?.focus())
+    return () => cancelAnimationFrame(id)
+  }, [open])
+
+  // Restore focus to the previously-focused element on close.
+  useEffect(() => {
+    if (!open) return
+    const previouslyFocused = document.activeElement as HTMLElement | null
+    return () => {
+      if (previouslyFocused && typeof previouslyFocused.focus === 'function') {
+        previouslyFocused.focus()
+      }
+    }
+  }, [open])
+
+  // Shared keyboard navigation handler — used by both palette + side-panel
+  // surfaces to keep their behavior in sync.
+  const handleNavKey = useSearchKeyboardNav(search, { onActivate: close })
+
+  if (!open) return null
+
+  const onKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Tab') {
+      // Trap focus inside the palette to honor `aria-modal="true"`. The input
+      // is the only natively-focusable element in the dialog, so any Tab
+      // (or Shift+Tab) press is intercepted and re-focuses the input.
+      e.preventDefault()
+      inputRef.current?.focus()
+      return
+    }
+    handleNavKey(e)
+  }
+
+  const placeholder =
+    mode === 'commands' ? 'Type a command…' : 'Search projects, sessions, settings…'
+
+  // Compute the active descendant id for the input.
+  let active: string | undefined
+  if (search.totalItems > 0) {
+    active = `${LIST_ID}-opt-${search.selectedIndex}`
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={mode === 'commands' ? 'Command runner' : 'Global search'}
+      className="fixed inset-0 z-[200] flex items-start justify-center"
+      onMouseDown={(e) => {
+        // Click outside the panel closes the modal. Clicks inside the panel
+        // are stopped at the panel's own onMouseDown.
+        if (e.target === e.currentTarget) close()
+      }}
+      style={{
+        backgroundColor: 'rgba(0,0,0,0.4)',
+        paddingTop: '12vh'
+      }}
+      data-testid="command-palette"
+    >
+      <div
+        onMouseDown={(e) => e.stopPropagation()}
+        onKeyDown={onKeyDown}
+        className="w-full max-w-[680px] mx-4 rounded-lg shadow-2xl overflow-hidden flex flex-col"
+        style={{
+          backgroundColor: 'var(--dplex-bg-elev)',
+          border: '1px solid var(--dplex-border-strong)',
+          maxHeight: '70vh'
+        }}
+      >
+        <div
+          className="flex items-center gap-2 px-3 py-2"
+          style={{ borderBottom: '1px solid var(--dplex-border)' }}
+        >
+          <Search size={14} style={{ color: 'var(--dplex-text-dim)' }} />
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder={placeholder}
+            value={search.query}
+            onChange={(e) => search.setQuery(e.target.value)}
+            role="combobox"
+            aria-expanded
+            aria-controls={LIST_ID}
+            aria-activedescendant={active}
+            aria-autocomplete="list"
+            className="flex-1 bg-transparent outline-none text-[13px]"
+            style={{ color: 'var(--dplex-text)' }}
+            data-testid="command-palette-input"
+          />
+          {mode === 'commands' && (
+            <span
+              className="text-[10px] px-1.5 py-0.5 rounded"
+              style={{
+                color: 'var(--dplex-accent)',
+                backgroundColor: 'var(--dplex-accent-soft)'
+              }}
+            >
+              Commands
+            </span>
+          )}
+        </div>
+        <div className="flex-1 overflow-y-auto dplex-scroll-autohide">
+          <SearchResultsList
+            groups={search.groups}
+            selectedIndex={search.selectedIndex}
+            onSelect={search.setSelectedIndex}
+            onActivate={(item) => {
+              void Promise.resolve(item.run())
+              close()
+            }}
+            listId={LIST_ID}
+            emptyMessage={
+              search.query.trim() === ''
+                ? mode === 'commands'
+                  ? 'No commands available'
+                  : 'Type to search'
+                : 'No matches'
+            }
+          />
+        </div>
+        <div
+          className="flex items-center gap-3 px-3 py-1.5 text-[10.5px]"
+          style={{
+            borderTop: '1px solid var(--dplex-border)',
+            color: 'var(--dplex-text-dim)'
+          }}
+        >
+          <span className="flex items-center gap-1">
+            <ChevronUp size={11} />
+            <ChevronDown size={11} />
+            Navigate
+          </span>
+          <span className="flex items-center gap-1">
+            <CornerDownLeft size={11} />
+            Open
+          </span>
+          <span className="ml-auto">Esc to close</span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/search/SearchResultsList.tsx
+++ b/src/renderer/src/components/search/SearchResultsList.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useRef } from 'react'
+import type { MatchRange, RankedItem, SearchResultGroup } from '../../services/search/types'
+
+interface SearchResultsListProps {
+  groups: SearchResultGroup[]
+  /** Index of the highlighted item across the **flattened** result list. */
+  selectedIndex: number
+  onSelect: (index: number) => void
+  onActivate: (item: RankedItem['item']) => void
+  /** DOM id used by the input for `aria-controls` / `aria-activedescendant`. */
+  listId: string
+  /** Empty-state message when groups is empty. */
+  emptyMessage?: string
+}
+
+/** Render highlighted runs of `text` based on a sorted, non-overlapping list
+ *  of {@link MatchRange}s. */
+function HighlightedText({
+  text,
+  ranges
+}: {
+  text: string
+  ranges: MatchRange[]
+}): React.JSX.Element {
+  if (ranges.length === 0) return <>{text}</>
+  const out: React.ReactNode[] = []
+  let cursor = 0
+  ranges.forEach((r, i) => {
+    if (r.start > cursor) out.push(text.slice(cursor, r.start))
+    out.push(
+      <mark
+        key={`hl-${i}`}
+        style={{
+          backgroundColor: 'transparent',
+          color: 'var(--dplex-accent)',
+          fontWeight: 600
+        }}
+      >
+        {text.slice(r.start, r.end)}
+      </mark>
+    )
+    cursor = r.end
+  })
+  if (cursor < text.length) out.push(text.slice(cursor))
+  return <>{out}</>
+}
+
+export function SearchResultsList({
+  groups,
+  selectedIndex,
+  onSelect,
+  onActivate,
+  listId,
+  emptyMessage
+}: SearchResultsListProps): React.JSX.Element {
+  const itemRefs = useRef<(HTMLDivElement | null)[]>([])
+
+  // Keep the highlighted row in view when it changes (e.g. via arrow keys).
+  useEffect(() => {
+    const node = itemRefs.current[selectedIndex]
+    if (!node) return
+    node.scrollIntoView({ block: 'nearest' })
+  }, [selectedIndex])
+
+  if (groups.length === 0) {
+    return (
+      <div
+        className="px-4 py-6 text-center text-[12px]"
+        style={{ color: 'var(--dplex-text-muted)' }}
+      >
+        {emptyMessage ?? 'No results'}
+      </div>
+    )
+  }
+
+  let flatIndex = -1
+  return (
+    <div
+      role="listbox"
+      id={listId}
+      aria-label="Search results"
+      className="flex flex-col"
+    >
+      {groups.map((group, groupIdx) => (
+        <div key={group.category} className="flex flex-col">
+          <div
+            className="px-3 pt-2 pb-1.5 text-[10px] font-bold uppercase tracking-wider sticky top-0 z-[1]"
+            style={{
+              color: 'var(--dplex-text-muted)',
+              backgroundColor: 'var(--dplex-activity-bar-bg)',
+              borderTop:
+                groupIdx === 0 ? 'none' : '1px solid var(--dplex-border-strong)',
+              borderBottom: '1px solid var(--dplex-border)',
+              letterSpacing: '0.1em'
+            }}
+          >
+            {group.label}
+          </div>
+          {group.items.map((ranked) => {
+            flatIndex++
+            const myIndex = flatIndex
+            const isSelected = myIndex === selectedIndex
+            const optionId = `${listId}-opt-${myIndex}`
+            return (
+              <div
+                key={ranked.item.id}
+                ref={(el) => {
+                  itemRefs.current[myIndex] = el
+                }}
+                id={optionId}
+                role="option"
+                aria-selected={isSelected}
+                onMouseEnter={() => onSelect(myIndex)}
+                onClick={() => onActivate(ranked.item)}
+                className="flex items-center gap-2 px-3 py-1.5 cursor-pointer select-none"
+                style={{
+                  backgroundColor: isSelected ? 'var(--dplex-accent-soft)' : 'transparent',
+                  color: 'var(--dplex-text)'
+                }}
+                data-testid="search-result"
+                data-search-item-id={ranked.item.id}
+              >
+                <div className="flex-1 min-w-0">
+                  <div className="text-[12.5px] truncate">
+                    <HighlightedText text={ranked.item.label} ranges={ranked.ranges} />
+                  </div>
+                  {ranked.item.description && (
+                    <div
+                      className="text-[10.5px] truncate"
+                      style={{ color: 'var(--dplex-text-muted)' }}
+                    >
+                      {ranked.item.description}
+                    </div>
+                  )}
+                </div>
+                {ranked.item.hint && (
+                  <span
+                    className="text-[10.5px] flex-shrink-0 ml-2"
+                    style={{ color: 'var(--dplex-text-dim)' }}
+                  >
+                    {ranked.item.hint}
+                  </span>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/search/SearchSidePanelView.tsx
+++ b/src/renderer/src/components/search/SearchSidePanelView.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useRef } from 'react'
+import { Search } from 'lucide-react'
+import { useGlobalSearch } from './useGlobalSearch'
+import { useSearchKeyboardNav } from './useSearchKeyboardNav'
+import { SearchResultsList } from './SearchResultsList'
+import { useCommandPaletteStore } from '../../stores/commandPaletteStore'
+
+const LIST_ID = 'dplex-search-side-list'
+
+/** Activity-bar variant of the global search. Mounts only while the
+ *  side panel is showing the Search view; result computation is gated by
+ *  the `enabled` flag passed to {@link useGlobalSearch}. */
+export function SearchSidePanelView(): React.JSX.Element {
+  const search = useGlobalSearch({ enabled: true })
+  const inputRef = useRef<HTMLInputElement>(null)
+  const openCmdPalette = useCommandPaletteStore((s) => s.openWith)
+
+  // Focus the input on mount so typing works immediately after activating
+  // the tab. Re-focus when the global Cmd/Ctrl+F (or Cmd/Ctrl+Shift+F)
+  // dispatches `dplex:focus-search` — same convention used by the
+  // Projects/Sessions search inputs in `SidePanel.tsx`. Distinct from the
+  // CommandPalette's open-transition focus pattern (no event listener
+  // needed there because the palette is a transient modal).
+  useEffect(() => {
+    inputRef.current?.focus()
+    const handler = (): void => inputRef.current?.focus()
+    window.addEventListener('dplex:focus-search', handler)
+    return () => window.removeEventListener('dplex:focus-search', handler)
+  }, [])
+
+  const onKeyDown = useSearchKeyboardNav(search)
+
+  let active: string | undefined
+  if (search.totalItems > 0) {
+    active = `${LIST_ID}-opt-${search.selectedIndex}`
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      <div
+        className="flex flex-col gap-2 px-3 pt-2 pb-2.5"
+        style={{ borderBottom: '1px solid var(--dplex-border)' }}
+      >
+        <div className="flex items-center" style={{ height: 28 }}>
+          <span
+            className="text-[11px] font-bold uppercase tracking-wider"
+            style={{ color: 'var(--dplex-text)', letterSpacing: '0.08em' }}
+          >
+            Search
+          </span>
+          <button
+            type="button"
+            className="ml-auto text-[10.5px] px-2 py-0.5 rounded transition-colors"
+            style={{
+              color: 'var(--dplex-text-muted)',
+              border: '1px solid var(--dplex-border)'
+            }}
+            onClick={() => openCmdPalette('all')}
+            title="Open as modal"
+            data-testid="search-side-open-modal"
+          >
+            Open as palette
+          </button>
+        </div>
+        <div className="relative">
+          <Search
+            size={13}
+            style={{
+              position: 'absolute',
+              left: 9,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              color: 'var(--dplex-text-dim)',
+              pointerEvents: 'none'
+            }}
+          />
+          <input
+            ref={inputRef}
+            type="text"
+            placeholder="Search anything…"
+            value={search.query}
+            onChange={(e) => search.setQuery(e.target.value)}
+            onKeyDown={onKeyDown}
+            role="combobox"
+            aria-expanded
+            aria-controls={LIST_ID}
+            aria-activedescendant={active}
+            aria-autocomplete="list"
+            className="w-full text-[12.5px] outline-none transition-colors"
+            style={{
+              backgroundColor: 'var(--dplex-bg-input)',
+              border: '1px solid var(--dplex-border)',
+              borderRadius: 8,
+              color: 'var(--dplex-text)',
+              padding: '8px 32px 8px 28px',
+              fontFamily: 'inherit'
+            }}
+            data-testid="search-side-input"
+            onFocus={(e) => {
+              e.currentTarget.style.borderColor = 'var(--dplex-accent)'
+              e.currentTarget.style.boxShadow = '0 0 0 3px var(--dplex-accent-soft)'
+              e.currentTarget.style.backgroundColor = 'var(--dplex-bg-elev)'
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.borderColor = 'var(--dplex-border)'
+              e.currentTarget.style.boxShadow = 'none'
+              e.currentTarget.style.backgroundColor = 'var(--dplex-bg-input)'
+            }}
+          />
+        </div>
+      </div>
+      <div className="flex-1 overflow-y-auto dplex-scroll-autohide">
+        <SearchResultsList
+          groups={search.groups}
+          selectedIndex={search.selectedIndex}
+          onSelect={search.setSelectedIndex}
+          onActivate={(item) => {
+            void Promise.resolve(item.run())
+          }}
+          listId={LIST_ID}
+          emptyMessage={search.query.trim() === '' ? 'Type to search' : 'No matches'}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/search/searchResultUtils.ts
+++ b/src/renderer/src/components/search/searchResultUtils.ts
@@ -1,0 +1,16 @@
+import type { RankedItem, SearchResultGroup } from '../../services/search/types'
+
+/** Flatten grouped results into a monotonic list. Used by keyboard
+ *  navigation to scan items across category boundaries. */
+export function flattenGroups(groups: SearchResultGroup[]): RankedItem[] {
+  const out: RankedItem[] = []
+  for (const g of groups) for (const it of g.items) out.push(it)
+  return out
+}
+
+/** Total number of items across all groups. */
+export function countItems(groups: SearchResultGroup[]): number {
+  let n = 0
+  for (const g of groups) n += g.items.length
+  return n
+}

--- a/src/renderer/src/components/search/useGlobalSearch.ts
+++ b/src/renderer/src/components/search/useGlobalSearch.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { defaultRegistry } from '../../services/search'
+import type { SearchCategory, SearchResultGroup } from '../../services/search/types'
+import { useProjectStore } from '../../stores/projectStore'
+import { useSessionStore } from '../../stores/sessionStore'
+import { useTerminalStore } from '../../stores/terminalStore'
+import { countItems, flattenGroups } from './searchResultUtils'
+
+interface UseGlobalSearchOptions {
+  enabled: boolean
+  /** Restrict results to these categories. Undefined = all. */
+  categories?: ReadonlyArray<SearchCategory>
+  /** Override the per-group cap (typed-query results). */
+  maxPerGroup?: number
+  /** Override the cap applied when the query is empty. */
+  emptyQueryLimit?: number
+}
+
+interface GlobalSearchState {
+  query: string
+  setQuery: (q: string) => void
+  groups: SearchResultGroup[]
+  selectedIndex: number
+  setSelectedIndex: (n: number) => void
+  /** Move selection by `delta` rows (clamped to bounds). */
+  moveSelection: (delta: number) => void
+  /** Activate the item at the current `selectedIndex`. */
+  activateSelected: () => void
+  totalItems: number
+}
+
+/**
+ * Owns search input state + result freshness for one surface (modal or side
+ * panel). Subscribes to the source stores so results update live.
+ */
+export function useGlobalSearch({
+  enabled,
+  categories,
+  maxPerGroup,
+  emptyQueryLimit
+}: UseGlobalSearchOptions): GlobalSearchState {
+  const [query, setQueryRaw] = useState('')
+  const [selectedIndex, setSelectedIndex] = useState(0)
+
+  // Reset query + selection whenever the surface re-opens. Synchronizing
+  // transient UI with an external open/close signal is the canonical
+  // exception to the no-setState-in-effect rule.
+  useEffect(() => {
+    if (enabled) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setQueryRaw('')
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setSelectedIndex(0)
+    }
+  }, [enabled])
+
+  // Wrap setQuery so a fresh query always resets the selection back to the
+  // first match — otherwise typing while a low-down row is highlighted
+  // would activate a stale row on Enter.
+  const setQuery = useCallback((next: string) => {
+    setQueryRaw(next)
+    setSelectedIndex(0)
+  }, [])
+
+  // Subscribe to the upstream stores so results recompute when their data
+  // changes (e.g. user adds a project while the palette is open).
+  const projects = useProjectStore((s) => s.projects)
+  const sessions = useSessionStore((s) => s.sessions)
+  const groups = useTerminalStore((s) => s.groups)
+  const activeGroupId = useTerminalStore((s) => s.activeGroupId)
+
+  const ctx = useMemo(
+    () => ({ projects, sessions, groups, activeGroupId }),
+    [projects, sessions, groups, activeGroupId]
+  )
+
+  // While the surface is closed, skip work entirely.
+  const results: SearchResultGroup[] = useMemo(() => {
+    if (!enabled) return []
+    return defaultRegistry.run(query, ctx, {
+      categories: categories ?? undefined,
+      maxPerGroup,
+      emptyQueryLimit
+    })
+  }, [enabled, query, ctx, categories, maxPerGroup, emptyQueryLimit])
+
+  const total = countItems(results)
+  // Clamp the selection during render rather than via a sync effect — this
+  // avoids the cascading-render anti-pattern when results shrink.
+  const effectiveSelected = total === 0 ? 0 : Math.min(Math.max(selectedIndex, 0), total - 1)
+
+  const moveSelection = useCallback(
+    (delta: number) => {
+      setSelectedIndex((prev) => {
+        if (total === 0) return 0
+        const base = Math.min(Math.max(prev, 0), total - 1)
+        let next = base + delta
+        if (next < 0) next = 0
+        if (next > total - 1) next = total - 1
+        return next
+      })
+    },
+    [total]
+  )
+
+  const activateSelected = useCallback(() => {
+    const flat = flattenGroups(results)
+    const target = flat[effectiveSelected]
+    if (!target) return
+    void Promise.resolve(target.item.run())
+  }, [results, effectiveSelected])
+
+  return {
+    query,
+    setQuery,
+    groups: results,
+    selectedIndex: effectiveSelected,
+    setSelectedIndex,
+    moveSelection,
+    activateSelected,
+    totalItems: total
+  }
+}

--- a/src/renderer/src/components/search/useSearchKeyboardNav.ts
+++ b/src/renderer/src/components/search/useSearchKeyboardNav.ts
@@ -1,0 +1,74 @@
+import { useCallback } from 'react'
+
+interface SearchKeyboardNavTarget {
+  totalItems: number
+  selectedIndex: number
+  setSelectedIndex: (n: number) => void
+  moveSelection: (delta: number) => void
+  activateSelected: () => void
+}
+
+interface SearchKeyboardNavOptions {
+  /** Called when the user presses Enter on a row. Receives no arguments —
+   *  call `activateSelected` from the search target before invoking. */
+  onActivate?: () => void
+  /** Called when the user presses Escape. When omitted, Escape is a no-op
+   *  (callers that need Escape handling typically use `useEscapeKey` at a
+   *  higher level so the listener works regardless of focus). */
+  onEscape?: () => void
+}
+
+/**
+ * Shared keyboard handler for the global-search surfaces. Both the modal
+ * palette and the activity-bar search panel use the same arrow-key
+ * navigation, Home/End, and Enter activation; this hook keeps them in sync.
+ *
+ * Returns a ready-to-use `onKeyDown` for any element (typically the input).
+ */
+export function useSearchKeyboardNav(
+  target: SearchKeyboardNavTarget,
+  opts: SearchKeyboardNavOptions = {}
+): (e: React.KeyboardEvent) => void {
+  const { totalItems, setSelectedIndex, moveSelection, activateSelected } = target
+  const { onActivate, onEscape } = opts
+
+  return useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        if (onEscape) {
+          e.preventDefault()
+          onEscape()
+        }
+        return
+      }
+      if (e.key === 'ArrowDown') {
+        e.preventDefault()
+        moveSelection(1)
+        return
+      }
+      if (e.key === 'ArrowUp') {
+        e.preventDefault()
+        moveSelection(-1)
+        return
+      }
+      if (e.key === 'Home') {
+        e.preventDefault()
+        setSelectedIndex(0)
+        return
+      }
+      if (e.key === 'End') {
+        e.preventDefault()
+        setSelectedIndex(Math.max(0, totalItems - 1))
+        return
+      }
+      if (e.key === 'Enter') {
+        e.preventDefault()
+        if (totalItems > 0) {
+          activateSelected()
+          onActivate?.()
+        }
+      }
+    },
+    [totalItems, setSelectedIndex, moveSelection, activateSelected, onActivate, onEscape]
+  )
+}

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -31,7 +31,10 @@ const SHORTCUTS: { category: string; items: { keys: string; description: string 
       { keys: `${MOD}W`, description: 'Close terminal' },
       { keys: `${MOD},`, description: 'Open settings' },
       { keys: `${MOD}B`, description: 'Toggle sidebar' },
-      { keys: `${MOD}F`, description: 'Focus panel search' }
+      { keys: `${MOD}F`, description: 'Focus panel search' },
+      { keys: `${MOD}${SHIFT}F`, description: 'Open Search side panel' },
+      { keys: `${MOD}P`, description: 'Global search' },
+      { keys: `${MOD}${SHIFT}P`, description: 'Run a command' }
     ]
   },
   {
@@ -103,14 +106,16 @@ const TABS: { id: SettingsTab; label: string; icon: typeof Palette }[] = [
 function SettingItem({
   label,
   description,
-  children
+  children,
+  settingId
 }: {
   label: string
   description?: string
   children: React.ReactNode
+  settingId?: string
 }): React.JSX.Element {
   return (
-    <div className="mb-5 last:mb-0">
+    <div className="mb-5 last:mb-0" data-setting-id={settingId}>
       <span className="block text-[11px] font-medium mb-0.5" style={{ color: 'var(--dplex-text)' }}>
         {label}
       </span>
@@ -156,9 +161,35 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
   useEffect(() => {
     const handler = (e: Event): void => {
-      const detail = (e as CustomEvent<{ section?: string }>).detail
-      if (detail?.section === 'worktrees') {
-        setActiveTab('worktrees')
+      const detail = (e as CustomEvent<{ section?: string; highlightId?: string }>).detail
+      const section = detail?.section
+      if (section && TABS.some((t) => t.id === section)) {
+        setActiveTab(section as SettingsTab)
+      }
+      const highlightId = detail?.highlightId
+      if (highlightId) {
+        // Defer until after the tab switch + render commit so the target row
+        // is mounted before we try to find it.
+        requestAnimationFrame(() => {
+          requestAnimationFrame(() => {
+            const root = document.querySelector('[data-testid="settings-modal"]')
+            const node = (root ?? document).querySelector(
+              `[data-setting-id="${CSS.escape(highlightId)}"]`
+            ) as HTMLElement | null
+            if (!node) return
+            node.scrollIntoView({ block: 'center', behavior: 'smooth' })
+            node.classList.remove('dplex-setting-pulse')
+            // Force reflow so re-adding the class restarts the animation.
+            // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+            void node.offsetWidth
+            node.classList.add('dplex-setting-pulse')
+            const onEnd = (): void => {
+              node.classList.remove('dplex-setting-pulse')
+              node.removeEventListener('animationend', onEnd)
+            }
+            node.addEventListener('animationend', onEnd)
+          })
+        })
       }
     }
     window.addEventListener('dplex:open-settings', handler)
@@ -208,7 +239,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60" data-testid="settings-modal">
       <div
         className="rounded-2xl shadow-2xl flex flex-col"
         style={{
@@ -302,7 +333,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
             <div className="flex-1 px-6 py-5 overflow-y-auto">
               {activeTab === 'appearance' && (
-                <SettingItem label="Theme">
+                <SettingItem label="Theme" settingId="theme">
                   <h4
                     className="text-[10px] font-semibold uppercase tracking-wider mb-2"
                     style={{ color: 'var(--dplex-text-muted)' }}
@@ -404,6 +435,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                 <>
                   <SettingItem
                     label="Default Shell"
+                    settingId="default-shell"
                     description="The shell used when opening new terminals. Override per-tab with the dropdown next to the + button."
                   >
                     <select
@@ -427,6 +459,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Font Size"
+                    settingId="font-size"
                     description={`Controls the terminal font size in pixels. Currently ${settings.fontSize}px.`}
                   >
                     <input
@@ -441,6 +474,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Font Family"
+                    settingId="font-family"
                     description="Controls the terminal font family. Use a monospace font for best results."
                   >
                     <input
@@ -462,6 +496,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                 <>
                   <SettingItem
                     label="Default AI Tool"
+                    settingId="default-ai-tool"
                     description="The AI CLI tool used for session discovery and integration."
                   >
                     <select
@@ -484,6 +519,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Session Max Age"
+                    settingId="session-max-age"
                     description={`Sessions older than this are hidden from the sessions panel. Currently ${settings.sessionMaxAgeDays} day${settings.sessionMaxAgeDays === 1 ? '' : 's'}.`}
                   >
                     <div className="flex items-center gap-3">
@@ -523,6 +559,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Hide empty sessions"
+                    settingId="hide-empty-sessions"
                     description="Hide idle sessions that have no messages yet. Active sessions are always shown."
                   >
                     <label className="flex items-center gap-2 cursor-pointer">
@@ -540,6 +577,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Recent sessions in projects"
+                    settingId="recent-sessions-in-projects"
                     description="Show a slim list of recent (idle) sessions inside each expanded project so you can resume them without leaving the panel."
                   >
                     <label className="flex items-center gap-2 cursor-pointer">
@@ -559,6 +597,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Recent sessions count"
+                    settingId="recent-sessions-count"
                     description={`How many recent sessions to surface per project / worktree. Currently ${settings.recentSessionsCount}.`}
                   >
                     <div className="flex items-center gap-3">
@@ -610,6 +649,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                 <>
                   <SettingItem
                     label="Enable notifications"
+                    settingId="notifications-enabled"
                     description="Master toggle for desktop notifications and the attention inbox badge."
                   >
                     <label className="flex items-center gap-2 cursor-pointer">
@@ -627,6 +667,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Notify me about"
+                    settingId="notify-events"
                     description="Pick which kinds of events raise a desktop notification."
                   >
                     <div className="space-y-1.5">
@@ -668,6 +709,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Only when unfocused"
+                    settingId="notify-only-unfocused"
                     description="Suppress notifications when the DPlex window is already focused."
                   >
                     <label className="flex items-center gap-2 cursor-pointer">
@@ -685,6 +727,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Play sound"
+                    settingId="notify-sound"
                     description="Use the OS default sound when a notification fires."
                   >
                     <label className="flex items-center gap-2 cursor-pointer">
@@ -702,6 +745,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Do not disturb"
+                    settingId="do-not-disturb"
                     description="Quiet-hours window (24-hour HH:MM). Leave both empty to disable. Supports overnight spans (e.g. 22:00 → 08:00)."
                   >
                     <div className="flex items-center gap-2">
@@ -739,6 +783,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Notification cooldown"
+                    settingId="notify-cooldown"
                     description={`Minimum time between notifications for the same session. Currently ${settings.notificationCooldownSeconds} second${settings.notificationCooldownSeconds === 1 ? '' : 's'}. Set to 0 to disable.`}
                   >
                     <div className="flex items-center gap-3">
@@ -781,6 +826,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Idle escalation"
+                    settingId="idle-escalation"
                     description={`Re-notify when a waiting session goes unanswered for this long. Currently ${settings.idleTooLongMinutes} minute${settings.idleTooLongMinutes === 1 ? '' : 's'}.`}
                   >
                     <div className="flex items-center gap-3">
@@ -824,6 +870,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                 <>
                   <SettingItem
                     label="Location pattern"
+                    settingId="worktree-location-pattern"
                     description="Where new worktrees are created. Supports {project} and {branch} placeholders."
                   >
                     <input
@@ -849,6 +896,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Env files to copy"
+                    settingId="worktree-env-files"
                     description="Comma-separated relative paths (supports trailing wildcards like .env.*.local)."
                   >
                     <input
@@ -877,6 +925,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="Setup script"
+                    settingId="worktree-setup-script"
                     description="Shell script to run after creating a worktree (e.g. npm install)."
                   >
                     <textarea
@@ -902,6 +951,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   <SettingItem
                     label="After creation"
+                    settingId="worktree-after-create"
                     description="What to do once a worktree is ready."
                   >
                     <select
@@ -1059,7 +1109,7 @@ function AboutPanel(): React.JSX.Element {
   })()
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" data-setting-id="about-version">
       <div
         className="rounded-lg p-4"
         style={{ backgroundColor: 'var(--dplex-bg-alt)' }}

--- a/src/renderer/src/services/search/commandsSource.ts
+++ b/src/renderer/src/services/search/commandsSource.ts
@@ -1,0 +1,180 @@
+import type { SearchItem, SearchSource } from './types'
+import { useTerminalStore } from '../../stores/terminalStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { useSessionStore } from '../../stores/sessionStore'
+import { useProjectStore } from '../../stores/projectStore'
+import { dispatchOpenSettings } from '../../utils/openSettings'
+import { MOD, SHIFT } from '../../utils/shortcuts'
+
+interface CommandEntry {
+  id: string
+  label: string
+  description?: string
+  shortcut?: string
+  keywords?: string[]
+  run: () => void | Promise<void>
+}
+
+const COMMANDS: readonly CommandEntry[] = [
+  {
+    id: 'add-project',
+    label: 'Add Project',
+    description: 'Pick a folder and add it to the Projects panel',
+    keywords: ['new', 'folder', 'open', 'create'],
+    run: () => {
+      void useProjectStore.getState().addProject()
+    }
+  },
+  {
+    id: 'new-terminal',
+    label: 'New Terminal',
+    description: 'Open a new shell terminal',
+    shortcut: `${MOD}T`,
+    keywords: ['shell', 'open', 'create'],
+    run: () => {
+      const ts = useTerminalStore.getState()
+      ts.createTerminal(ts.activeGroupId ?? undefined)
+    }
+  },
+  {
+    id: 'close-terminal',
+    label: 'Close Active Terminal',
+    description: 'Close the currently focused terminal tab',
+    shortcut: `${MOD}W`,
+    keywords: ['kill', 'tab'],
+    run: () => {
+      const ts = useTerminalStore.getState()
+      const group = ts.groups.find((g) => g.id === ts.activeGroupId)
+      if (group) ts.closeTerminal(group.activeTabId)
+    }
+  },
+  {
+    id: 'split-right',
+    label: 'Split Editor Right',
+    description: 'Split the active group horizontally',
+    shortcut: `${MOD}\\`,
+    keywords: ['split', 'horizontal', 'pane'],
+    run: () => {
+      const ts = useTerminalStore.getState()
+      if (ts.activeGroupId) ts.splitGroup(ts.activeGroupId, 'horizontal')
+    }
+  },
+  {
+    id: 'split-down',
+    label: 'Split Editor Down',
+    description: 'Split the active group vertically',
+    shortcut: `${MOD}${SHIFT}\\`,
+    keywords: ['split', 'vertical', 'pane'],
+    run: () => {
+      const ts = useTerminalStore.getState()
+      if (ts.activeGroupId) ts.splitGroup(ts.activeGroupId, 'vertical')
+    }
+  },
+  {
+    id: 'toggle-sidebar',
+    label: 'Toggle Sidebar',
+    description: 'Show or hide the side panel',
+    shortcut: `${MOD}B`,
+    keywords: ['hide', 'show', 'panel'],
+    run: () => {
+      useSettingsStore.getState().toggleSidebar()
+    }
+  },
+  {
+    id: 'show-projects',
+    label: 'Show Projects',
+    description: 'Reveal the Projects view in the sidebar',
+    keywords: ['focus', 'view'],
+    run: () => {
+      useSettingsStore
+        .getState()
+        .updateSettings({ sidebarActiveTab: 'projects', sidebarPanelCollapsed: false })
+    }
+  },
+  {
+    id: 'show-sessions',
+    label: 'Show Sessions',
+    description: 'Reveal the Sessions view in the sidebar',
+    keywords: ['focus', 'view'],
+    run: () => {
+      useSettingsStore
+        .getState()
+        .updateSettings({ sidebarActiveTab: 'sessions', sidebarPanelCollapsed: false })
+    }
+  },
+  {
+    id: 'show-source-control',
+    label: 'Show Source Control',
+    description: 'Reveal the Source Control (Git) view',
+    shortcut: `${MOD}${SHIFT}G`,
+    keywords: ['git', 'changes', 'diff', 'view'],
+    run: () => {
+      useSettingsStore
+        .getState()
+        .updateSettings({ sidebarActiveTab: 'git', sidebarPanelCollapsed: false })
+    }
+  },
+  {
+    id: 'show-search',
+    label: 'Show Search',
+    description: 'Reveal the global Search view in the sidebar',
+    keywords: ['find', 'view'],
+    run: () => {
+      useSettingsStore
+        .getState()
+        .updateSettings({ sidebarActiveTab: 'search', sidebarPanelCollapsed: false })
+    }
+  },
+  {
+    id: 'open-settings',
+    label: 'Open Settings',
+    description: 'Open the Settings window',
+    shortcut: `${MOD},`,
+    keywords: ['preferences', 'config', 'options'],
+    run: () => {
+      dispatchOpenSettings()
+    }
+  },
+  {
+    id: 'open-notification-settings',
+    label: 'Notification Settings',
+    description: 'Open Settings on the Notifications tab',
+    keywords: [
+      'enable notifications',
+      'disable notifications',
+      'alerts',
+      'sound',
+      'do not disturb',
+      'dnd',
+      'desktop'
+    ],
+    run: () => {
+      dispatchOpenSettings({ section: 'notifications', highlightId: 'notifications-enabled' })
+    }
+  },
+  {
+    id: 'refresh-sessions',
+    label: 'Refresh Sessions',
+    description: 'Re-scan AI session history from disk',
+    keywords: ['reload', 'rescan'],
+    run: () => {
+      void useSessionStore.getState().refreshSessions()
+    }
+  }
+]
+
+export const commandsSource: SearchSource = {
+  category: 'commands',
+  // Commands are static — `ctx` is unused but kept for the SearchSource shape.
+  getItems: (): SearchItem[] => {
+    return COMMANDS.map((c) => ({
+      id: `command:${c.id}`,
+      category: 'commands',
+      label: c.label,
+      description: c.description,
+      hint: c.shortcut,
+      keywords: c.keywords,
+      run: c.run
+    }))
+  }
+}

--- a/src/renderer/src/services/search/fuzzyMatch.ts
+++ b/src/renderer/src/services/search/fuzzyMatch.ts
@@ -1,0 +1,135 @@
+import type { MatchRange } from './types'
+
+/** Result of a fuzzy match attempt.
+ *  `score` is higher = better. `null` is returned when no match is possible. */
+export interface FuzzyMatchResult {
+  score: number
+  /** Sorted, non-overlapping spans of matched characters in `text`. */
+  ranges: MatchRange[]
+}
+
+/**
+ * Subsequence-based fuzzy match. The query characters must appear in the
+ * text in order, but not necessarily contiguously. Scoring rewards:
+ * - prefix matches (text starts with query)
+ * - exact substring matches
+ * - consecutive matched characters
+ * - matches at word boundaries (after space, /, -, _, .)
+ * - early matches (closer to start of text)
+ *
+ * Case-insensitive.
+ */
+export function fuzzyMatch(text: string, query: string): FuzzyMatchResult | null {
+  if (!query) {
+    return { score: 0, ranges: [] }
+  }
+  if (!text) return null
+
+  const lowerText = text.toLowerCase()
+  const lowerQuery = query.toLowerCase()
+
+  // Fast path: substring match — strongly preferred over a scattered subsequence.
+  const idx = lowerText.indexOf(lowerQuery)
+  if (idx !== -1) {
+    let score = 1000 - idx // earlier is better
+    if (idx === 0) score += 500 // prefix bonus
+    if (isWordBoundary(lowerText, idx)) score += 100
+    score += lowerQuery.length * 5 // longer match → higher score
+    return {
+      score,
+      ranges: [{ start: idx, end: idx + lowerQuery.length }]
+    }
+  }
+
+  // Subsequence match.
+  const ranges: MatchRange[] = []
+  let qi = 0
+  let runStart = -1
+  let consecutive = 0
+  let score = 0
+  for (let ti = 0; ti < lowerText.length && qi < lowerQuery.length; ti++) {
+    if (lowerText[ti] === lowerQuery[qi]) {
+      if (runStart === -1) runStart = ti
+      consecutive++
+      // Reward consecutive matches and word-boundary matches.
+      score += 10
+      score += consecutive * 5
+      if (isWordBoundary(lowerText, ti)) score += 20
+      qi++
+    } else {
+      if (runStart !== -1) {
+        ranges.push({ start: runStart, end: ti })
+        runStart = -1
+      }
+      consecutive = 0
+      score -= 1 // small penalty per skipped char
+    }
+  }
+  if (qi < lowerQuery.length) return null
+  if (runStart !== -1) {
+    // Trailing run — close it at the position just past the last matched char.
+    // We tracked consecutive separately; runStart..(runStart + consecutive)
+    // is the open run we never closed.
+    ranges.push({ start: runStart, end: runStart + consecutive })
+  }
+
+  // Earlier matches are slightly preferred.
+  if (ranges.length > 0) score += Math.max(0, 50 - ranges[0].start)
+
+  return { score, ranges: mergeRanges(ranges) }
+}
+
+/**
+ * Run fuzzy match across multiple candidate strings (e.g. label + keywords)
+ * and return the best result. Ranges always refer to the **first** candidate
+ * (the label) — keyword matches contribute to scoring only.
+ */
+export function fuzzyMatchAny(
+  label: string,
+  keywords: readonly string[] | undefined,
+  query: string
+): FuzzyMatchResult | null {
+  const labelMatch = fuzzyMatch(label, query)
+  if (labelMatch) return labelMatch
+  if (!keywords || keywords.length === 0) return null
+  for (const kw of keywords) {
+    const m = fuzzyMatch(kw, query)
+    if (m) {
+      // Keyword-only matches don't produce label ranges (the label has no
+      // matched chars). They still rank, but below any label match.
+      return { score: m.score - 200, ranges: [] }
+    }
+  }
+  return null
+}
+
+function isWordBoundary(text: string, idx: number): boolean {
+  if (idx === 0) return true
+  const prev = text.charCodeAt(idx - 1)
+  // space, /, \, -, _, ., : — common separators in our domain (paths, ids).
+  return (
+    prev === 32 ||
+    prev === 47 ||
+    prev === 92 ||
+    prev === 45 ||
+    prev === 95 ||
+    prev === 46 ||
+    prev === 58
+  )
+}
+
+function mergeRanges(ranges: MatchRange[]): MatchRange[] {
+  if (ranges.length <= 1) return ranges.map((r) => ({ ...r }))
+  const sorted = [...ranges].sort((a, b) => a.start - b.start)
+  const out: MatchRange[] = [{ ...sorted[0] }]
+  for (let i = 1; i < sorted.length; i++) {
+    const last = out[out.length - 1]
+    const cur = sorted[i]
+    if (cur.start <= last.end) {
+      last.end = Math.max(last.end, cur.end)
+    } else {
+      out.push({ ...cur })
+    }
+  }
+  return out
+}

--- a/src/renderer/src/services/search/index.ts
+++ b/src/renderer/src/services/search/index.ts
@@ -1,0 +1,15 @@
+import { buildRegistry, SearchRegistry } from './searchRegistry'
+import { projectsSource } from './projectsSource'
+import { sessionsSource } from './sessionsSource'
+import { tabsSource } from './tabsSource'
+import { settingsSource } from './settingsSource'
+import { commandsSource } from './commandsSource'
+
+/** Singleton registry wired with every built-in source. */
+export const defaultRegistry: SearchRegistry = buildRegistry([
+  commandsSource,
+  projectsSource,
+  sessionsSource,
+  tabsSource,
+  settingsSource
+])

--- a/src/renderer/src/services/search/pathUtils.ts
+++ b/src/renderer/src/services/search/pathUtils.ts
@@ -1,0 +1,17 @@
+/** Extract the trailing path segment ("folder name") from an absolute or
+ *  relative path, treating both POSIX and Windows separators as boundaries.
+ *
+ *  Returns the original path when no separator is present, and an empty
+ *  string when the input is undefined. Cross-platform safe — used by every
+ *  search source so future changes (UNC paths, trailing slashes, …) live
+ *  in one place.
+ *
+ *  Note: this intentionally does **not** delegate to `utils/normalizePath`.
+ *  `normalizePath` case-folds on macOS/Windows for *comparison* purposes;
+ *  search results need the original casing for display. The separator
+ *  rewrite is duplicated on purpose. */
+export function pathBasename(p?: string): string {
+  if (!p) return ''
+  const parts = p.replace(/\\/g, '/').split('/')
+  return parts[parts.length - 1] || p
+}

--- a/src/renderer/src/services/search/projectsSource.ts
+++ b/src/renderer/src/services/search/projectsSource.ts
@@ -1,0 +1,50 @@
+import type { SearchItem, SearchSource } from './types'
+import { useProjectStore } from '../../stores/projectStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { focusFirstTabForPaths } from '../../utils/sessionTabs'
+import { pathBasename } from './pathUtils'
+
+/** Activate a project: ensure the Projects view is visible, set it active,
+ *  and focus any existing terminal tab in its directory. Mirrors what
+ *  clicking the project row in the side panel does. */
+function openProject(projectId: string): void {
+  const projectStore = useProjectStore.getState()
+  const project = projectStore.projects.find((p) => p.id === projectId)
+  if (!project) return
+
+  // Show the Projects side panel + select the project.
+  useSettingsStore
+    .getState()
+    .updateSettings({ sidebarActiveTab: 'projects', sidebarPanelCollapsed: false })
+  projectStore.setActiveProject(projectId)
+  projectStore.setLastExpanded(projectId)
+
+  // Try to focus an existing terminal tab in the project's directory.
+  const paths = new Set<string>([project.path])
+  for (const p of projectStore.projects) {
+    if (p.parentProjectId === projectId) paths.add(p.path)
+  }
+  focusFirstTabForPaths(paths)
+}
+
+export const projectsSource: SearchSource = {
+  category: 'projects',
+  getItems: (ctx): SearchItem[] => {
+    return ctx.projects.map((p) => {
+      const isWorktree = p.parentProjectId !== undefined
+      const description = isWorktree ? `Worktree · ${p.path}` : p.path
+      const item: SearchItem = {
+        id: `project:${p.id}`,
+        category: 'projects',
+        label: p.name,
+        description,
+        keywords: [pathBasename(p.path), p.path, ...(p.pinned ? ['pinned'] : [])],
+        run: () => openProject(p.id)
+      }
+      if (p.parentRepoName) {
+        item.hint = p.parentRepoName
+      }
+      return item
+    })
+  }
+}

--- a/src/renderer/src/services/search/searchRegistry.ts
+++ b/src/renderer/src/services/search/searchRegistry.ts
@@ -1,0 +1,94 @@
+import { fuzzyMatchAny } from './fuzzyMatch'
+import {
+  CATEGORY_LABELS,
+  CATEGORY_ORDER,
+  type RankedItem,
+  type SearchCategory,
+  type SearchContext,
+  type SearchResultGroup,
+  type SearchSource
+} from './types'
+
+/** Maximum results surfaced per category for a given query. */
+export const MAX_RESULTS_PER_GROUP = 8
+
+/** Maximum items each source contributes when the query is empty.
+ *  Keeps the empty-state list short and predictable. */
+const EMPTY_QUERY_LIMIT = 5
+
+export interface RunSearchOptions {
+  /** When set, only items in this category are returned (other categories are
+   *  pruned entirely). Used by the "commands only" palette mode. */
+  categories?: ReadonlyArray<SearchCategory>
+  /** Override the per-group cap (mostly useful in tests). */
+  maxPerGroup?: number
+  /** Override the cap applied when the query is empty. Defaults to a small
+   *  preview so the all-categories palette stays scannable; raise this when
+   *  the surface is filtered to a single category and the user expects to
+   *  see the full list (e.g. the commands runner). */
+  emptyQueryLimit?: number
+}
+
+/** A registry of search sources. Lazy: sources are evaluated only when
+ *  `run()` is called. Pure — no IPC, no global state of its own. */
+export class SearchRegistry {
+  private readonly sources = new Map<SearchCategory, SearchSource>()
+
+  register(source: SearchSource): void {
+    this.sources.set(source.category, source)
+  }
+
+  /** Run a query against every registered source and return grouped, ranked
+   *  results. Empty categories are dropped. */
+  run(query: string, ctx: SearchContext, opts: RunSearchOptions = {}): SearchResultGroup[] {
+    const trimmed = query.trim()
+    const cap = opts.maxPerGroup ?? MAX_RESULTS_PER_GROUP
+    const emptyCap = opts.emptyQueryLimit ?? EMPTY_QUERY_LIMIT
+    const allowed = opts.categories ? new Set(opts.categories) : null
+
+    const groups: SearchResultGroup[] = []
+    for (const category of CATEGORY_ORDER) {
+      if (allowed && !allowed.has(category)) continue
+      const source = this.sources.get(category)
+      if (!source) continue
+      const items = source.getItems(ctx)
+      if (items.length === 0) continue
+
+      let ranked: RankedItem[]
+      if (trimmed === '') {
+        // Empty query: surface a stable preview from each source — small by
+        // default, configurable per call.
+        ranked = items.slice(0, emptyCap).map((item) => ({
+          item,
+          score: 0,
+          ranges: []
+        }))
+      } else {
+        ranked = []
+        for (const item of items) {
+          const m = fuzzyMatchAny(item.label, item.keywords, trimmed)
+          if (m === null) continue
+          ranked.push({ item, score: m.score, ranges: m.ranges })
+        }
+        ranked.sort((a, b) => b.score - a.score)
+        ranked = ranked.slice(0, cap)
+      }
+
+      if (ranked.length > 0) {
+        groups.push({
+          category,
+          label: CATEGORY_LABELS[category],
+          items: ranked
+        })
+      }
+    }
+    return groups
+  }
+}
+
+/** Helper to build a registry from an array of sources. */
+export function buildRegistry(sources: SearchSource[]): SearchRegistry {
+  const reg = new SearchRegistry()
+  for (const s of sources) reg.register(s)
+  return reg
+}

--- a/src/renderer/src/services/search/sessionsSource.ts
+++ b/src/renderer/src/services/search/sessionsSource.ts
@@ -1,0 +1,52 @@
+import type { SearchItem, SearchSource } from './types'
+import { useTerminalStore } from '../../stores/terminalStore'
+import { useProvidersStore } from '../../stores/providersStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { focusSessionTab } from '../../utils/sessionTabs'
+import { pathBasename } from './pathUtils'
+
+async function openSession(sessionId: string, providerId: string, cwd?: string): Promise<void> {
+  // Surface the Sessions panel so the row context is visible.
+  useSettingsStore
+    .getState()
+    .updateSettings({ sidebarActiveTab: 'sessions', sidebarPanelCollapsed: false })
+
+  // Reuse the existing helper — focus any open tab first.
+  if (focusSessionTab(sessionId, providerId)) return
+
+  const cmd = await window.dplex.sessions.getResumeCommand(providerId, sessionId)
+  if (focusSessionTab(sessionId, providerId, cmd ?? undefined)) return
+  if (!cmd) return
+
+  useTerminalStore
+    .getState()
+    .createTerminal(undefined, `↻ ${pathBasename(cwd) || sessionId}`, cmd, undefined, cwd, providerId)
+}
+
+export const sessionsSource: SearchSource = {
+  category: 'sessions',
+  getItems: (ctx): SearchItem[] => {
+    const getProviderLabel = useProvidersStore.getState().getLabel
+    return ctx.sessions.map((s) => {
+      const providerLabel = getProviderLabel(s.aiTool)
+      const desc = s.summary?.trim() || s.cwd || ''
+      const item: SearchItem = {
+        id: `session:${s.aiTool}:${s.id}`,
+        category: 'sessions',
+        label: s.displayName,
+        description: desc,
+        hint: providerLabel,
+        keywords: [
+          providerLabel,
+          s.aiTool,
+          ...(s.cwd ? [s.cwd, pathBasename(s.cwd)] : []),
+          ...(s.branch ? [s.branch] : []),
+          ...(s.summary ? [s.summary] : []),
+          s.status === 'active' ? 'active' : 'idle'
+        ],
+        run: () => openSession(s.id, s.aiTool, s.cwd)
+      }
+      return item
+    })
+  }
+}

--- a/src/renderer/src/services/search/settingsSource.ts
+++ b/src/renderer/src/services/search/settingsSource.ts
@@ -1,0 +1,190 @@
+import type { SearchItem, SearchSource, SettingsTab } from './types'
+import { dispatchOpenSettings } from '../../utils/openSettings'
+
+/** Curated list of settings rows surfaced by the global search. The `id`
+ *  field must match a `data-setting-id` attribute on the corresponding
+ *  `<SettingItem>` in `SettingsModal.tsx` so the modal can scroll the row
+ *  into view and pulse-highlight it. */
+export interface SettingsEntry {
+  id: string
+  label: string
+  description?: string
+  tab: SettingsTab
+  keywords?: string[]
+}
+
+export const SETTINGS_ENTRIES: readonly SettingsEntry[] = [
+  // Appearance
+  {
+    id: 'theme',
+    label: 'Theme',
+    description: 'Color theme for the app and terminal',
+    tab: 'appearance',
+    keywords: ['color', 'dark', 'light', 'palette', 'appearance']
+  },
+  // Terminal
+  {
+    id: 'default-shell',
+    label: 'Default Shell',
+    description: 'Shell used when opening new terminals',
+    tab: 'terminal',
+    keywords: ['bash', 'zsh', 'pwsh', 'powershell', 'fish', 'cmd']
+  },
+  {
+    id: 'font-size',
+    label: 'Font Size',
+    description: 'Terminal font size in pixels',
+    tab: 'terminal',
+    keywords: ['text', 'size', 'zoom']
+  },
+  {
+    id: 'font-family',
+    label: 'Font Family',
+    description: 'Terminal font family',
+    tab: 'terminal',
+    keywords: ['font', 'monospace', 'typeface']
+  },
+  // AI Tools
+  {
+    id: 'default-ai-tool',
+    label: 'Default AI Tool',
+    description: 'AI CLI tool used for new sessions',
+    tab: 'ai-tools',
+    keywords: ['copilot', 'claude', 'provider', 'cli']
+  },
+  {
+    id: 'session-max-age',
+    label: 'Session Max Age',
+    description: 'Hide sessions older than this many days',
+    tab: 'ai-tools',
+    keywords: ['cleanup', 'history', 'days', 'old']
+  },
+  {
+    id: 'hide-empty-sessions',
+    label: 'Hide empty sessions',
+    description: 'Hide idle sessions with no messages yet',
+    tab: 'ai-tools',
+    keywords: ['empty', 'idle', 'filter']
+  },
+  {
+    id: 'recent-sessions-in-projects',
+    label: 'Recent sessions in projects',
+    description: 'Show recent sessions inline in each project',
+    tab: 'ai-tools',
+    keywords: ['inline', 'project panel', 'expand']
+  },
+  {
+    id: 'recent-sessions-count',
+    label: 'Recent sessions count',
+    description: 'How many recent sessions per project',
+    tab: 'ai-tools',
+    keywords: ['count', 'limit']
+  },
+  // Notifications
+  {
+    id: 'notifications-enabled',
+    label: 'Enable notifications',
+    description: 'Master toggle for desktop notifications',
+    tab: 'notifications',
+    keywords: ['alerts', 'desktop', 'notify']
+  },
+  {
+    id: 'notify-events',
+    label: 'Notify me about',
+    description: 'Approval, input, finished events',
+    tab: 'notifications',
+    keywords: ['approval', 'input', 'finished', 'events']
+  },
+  {
+    id: 'notify-only-unfocused',
+    label: 'Only when unfocused',
+    description: 'Suppress notifications while the window is focused',
+    tab: 'notifications',
+    keywords: ['focus', 'background', 'foreground']
+  },
+  {
+    id: 'notify-sound',
+    label: 'Play sound',
+    description: 'Use the OS default sound for notifications',
+    tab: 'notifications',
+    keywords: ['audio', 'beep', 'chime']
+  },
+  {
+    id: 'do-not-disturb',
+    label: 'Do not disturb',
+    description: 'Quiet-hours window for notifications',
+    tab: 'notifications',
+    keywords: ['dnd', 'quiet', 'mute', 'hours', 'schedule']
+  },
+  {
+    id: 'notify-cooldown',
+    label: 'Notification cooldown',
+    description: 'Minimum delay between notifications for the same session',
+    tab: 'notifications',
+    keywords: ['rate limit', 'throttle', 'spam']
+  },
+  {
+    id: 'idle-escalation',
+    label: 'Idle escalation',
+    description: 'Re-notify after a waiting session is idle for this long',
+    tab: 'notifications',
+    keywords: ['re-notify', 'reminder', 'idle']
+  },
+  // Worktrees
+  {
+    id: 'worktree-location-pattern',
+    label: 'Worktree location pattern',
+    description: 'Where new worktrees are created',
+    tab: 'worktrees',
+    keywords: ['path', 'location', 'directory', 'project', 'branch']
+  },
+  {
+    id: 'worktree-env-files',
+    label: 'Env files to copy',
+    description: 'Files copied into new worktrees',
+    tab: 'worktrees',
+    keywords: ['.env', 'environment', 'config', 'secrets']
+  },
+  {
+    id: 'worktree-setup-script',
+    label: 'Setup script',
+    description: 'Shell script run after creating a worktree',
+    tab: 'worktrees',
+    keywords: ['script', 'install', 'bootstrap', 'post-create']
+  },
+  {
+    id: 'worktree-after-create',
+    label: 'After creation',
+    description: 'What to do once a worktree is ready',
+    tab: 'worktrees',
+    keywords: ['session', 'terminal', 'open']
+  },
+  // About
+  {
+    id: 'about-version',
+    label: 'About DPlex',
+    description: 'Version info and update controls',
+    tab: 'about',
+    keywords: ['version', 'update', 'check for updates', 'release']
+  }
+]
+
+function openSettingsAt(entry: SettingsEntry): void {
+  // Defer slightly so the modal mounts before scrolling.
+  dispatchOpenSettings({ section: entry.tab, highlightId: entry.id })
+}
+
+export const settingsSource: SearchSource = {
+  category: 'settings',
+  // Settings are static — `ctx` is unused but kept for the SearchSource shape.
+  getItems: (): SearchItem[] => {
+    return SETTINGS_ENTRIES.map((entry) => ({
+      id: `setting:${entry.id}`,
+      category: 'settings',
+      label: entry.label,
+      description: entry.description,
+      keywords: entry.keywords,
+      run: () => openSettingsAt(entry)
+    }))
+  }
+}

--- a/src/renderer/src/services/search/tabsSource.ts
+++ b/src/renderer/src/services/search/tabsSource.ts
@@ -1,0 +1,53 @@
+import type { SearchItem, SearchSource } from './types'
+import { isTerminalTab, isFileDiffTab } from '../../types'
+import { useTerminalStore } from '../../stores/terminalStore'
+import { pathBasename } from './pathUtils'
+
+function focusTab(groupId: string, tabId: string): void {
+  const ts = useTerminalStore.getState()
+  ts.setActiveGroup(groupId)
+  ts.setActiveTerminalInGroup(groupId, tabId)
+}
+
+export const tabsSource: SearchSource = {
+  category: 'tabs',
+  getItems: (ctx): SearchItem[] => {
+    const items: SearchItem[] = []
+    let groupIdx = 0
+    for (const group of ctx.groups) {
+      groupIdx++
+      const groupHint = ctx.groups.length > 1 ? `Group ${groupIdx}` : undefined
+      for (const tab of group.tabs) {
+        if (isFileDiffTab(tab)) {
+          items.push({
+            id: `tab:${tab.id}`,
+            category: 'tabs',
+            label: tab.title,
+            description: `Diff · ${tab.repoLabel}`,
+            hint: groupHint,
+            keywords: ['diff', tab.repoLabel, tab.repoRootFs],
+            run: () => focusTab(group.id, tab.id)
+          })
+          continue
+        }
+        if (!isTerminalTab(tab)) continue
+        const desc = tab.cwd ? pathBasename(tab.cwd) : tab.command || ''
+        const keywords: string[] = []
+        if (tab.cwd) keywords.push(tab.cwd, pathBasename(tab.cwd))
+        if (tab.command) keywords.push(tab.command)
+        if (tab.providerId) keywords.push(tab.providerId)
+        if (tab.worktreeBranch) keywords.push(tab.worktreeBranch)
+        items.push({
+          id: `tab:${tab.id}`,
+          category: 'tabs',
+          label: tab.title,
+          description: desc,
+          hint: groupHint,
+          keywords,
+          run: () => focusTab(group.id, tab.id)
+        })
+      }
+    }
+    return items
+  }
+}

--- a/src/renderer/src/services/search/types.ts
+++ b/src/renderer/src/services/search/types.ts
@@ -1,0 +1,91 @@
+import type { Project, AISession, EditorGroup } from '../../types'
+
+/** Settings tab identifier. Mirrors the `SettingsTab` union used inside
+ *  `SettingsModal`. Kept here so the search registry doesn't have to import
+ *  from a UI component. */
+export type SettingsTab =
+  | 'appearance'
+  | 'terminal'
+  | 'ai-tools'
+  | 'notifications'
+  | 'worktrees'
+  | 'shortcuts'
+  | 'about'
+
+/** Categories surfaced in the global search UI. Order here drives the
+ *  default render order in the grouped result list. */
+export type SearchCategory = 'projects' | 'sessions' | 'tabs' | 'settings' | 'commands'
+
+export const CATEGORY_LABELS: Record<SearchCategory, string> = {
+  projects: 'Projects',
+  sessions: 'Sessions',
+  tabs: 'Open Tabs',
+  settings: 'Settings',
+  commands: 'Commands'
+}
+
+export const CATEGORY_ORDER: SearchCategory[] = [
+  'commands',
+  'projects',
+  'sessions',
+  'tabs',
+  'settings'
+]
+
+/** Span of consecutive matched character indices (inclusive start, exclusive
+ *  end) within a label. Produced by `fuzzyMatch` and used by the UI to
+ *  render highlighted runs. */
+export interface MatchRange {
+  start: number
+  end: number
+}
+
+/** A renderable, runnable item produced by a search source. */
+export interface SearchItem {
+  /** Stable id, unique across all sources. Used as React key + aria-id. */
+  id: string
+  category: SearchCategory
+  /** Primary label that the matcher scores against. */
+  label: string
+  /** Optional secondary line (path, branch, etc.). Not scored. */
+  description?: string
+  /** Optional trailing badge text (e.g. shortcut, provider name). */
+  hint?: string
+  /** Optional keywords that the matcher considers in addition to `label`.
+   *  Used to make settings findable by synonyms (e.g. "color" → theme). */
+  keywords?: string[]
+  /** Action invoked when the user picks this item. May be async. */
+  run: () => void | Promise<void>
+}
+
+/** Pure snapshot of the renderer state passed into each source.
+ *  Sources read from this snapshot only — they never call `useStore.getState`
+ *  directly so they stay easy to unit-test. */
+export interface SearchContext {
+  projects: Project[]
+  sessions: AISession[]
+  groups: EditorGroup[]
+  activeGroupId: string | null
+}
+
+/** A search source contributes items for a single category. */
+export interface SearchSource {
+  category: SearchCategory
+  /** Returns the unfiltered set of items. The registry runs the matcher
+   *  on top — sources never run the matcher themselves. */
+  getItems: (ctx: SearchContext) => SearchItem[]
+}
+
+/** Result of a ranked match for one item. */
+export interface RankedItem {
+  item: SearchItem
+  score: number
+  ranges: MatchRange[]
+}
+
+/** Result group returned by `runSearch`. */
+export interface SearchResultGroup {
+  category: SearchCategory
+  label: string
+  items: RankedItem[]
+}

--- a/src/renderer/src/stores/commandPaletteStore.ts
+++ b/src/renderer/src/stores/commandPaletteStore.ts
@@ -1,0 +1,29 @@
+import { create } from 'zustand'
+
+export type CommandPaletteMode = 'all' | 'commands'
+
+interface CommandPaletteState {
+  open: boolean
+  mode: CommandPaletteMode
+  openWith: (mode: CommandPaletteMode) => void
+  toggle: (mode?: CommandPaletteMode) => void
+  close: () => void
+}
+
+/** Tiny store driving the global command palette modal. Kept separate from
+ *  `settingsStore` because the palette is purely transient UI — it should
+ *  never be persisted across reloads. */
+export const useCommandPaletteStore = create<CommandPaletteState>((set, get) => ({
+  open: false,
+  mode: 'all',
+  openWith: (mode) => set({ open: true, mode }),
+  toggle: (mode) => {
+    const cur = get()
+    if (cur.open && (mode === undefined || cur.mode === mode)) {
+      set({ open: false })
+    } else {
+      set({ open: true, mode: mode ?? 'all' })
+    }
+  },
+  close: () => set({ open: false })
+}))

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -108,7 +108,7 @@ export interface AppSettings {
   sidebarWidth: number
   sidebarVisible: boolean
   /** Which sidebar view is active in the activity bar. */
-  sidebarActiveTab: 'projects' | 'sessions' | 'git'
+  sidebarActiveTab: 'projects' | 'sessions' | 'git' | 'search'
   /** When true, the panel portion of the sidebar is collapsed (activity bar still visible). */
   sidebarPanelCollapsed: boolean
   sessionPollIntervalMs: number

--- a/src/renderer/src/utils/openSettings.ts
+++ b/src/renderer/src/utils/openSettings.ts
@@ -1,0 +1,18 @@
+import type { SettingsTab } from '../services/search/types'
+
+/** Detail payload for the `dplex:open-settings` window event.
+ *  - `section` switches the Settings modal to a specific tab.
+ *  - `highlightId` scrolls the matching `[data-setting-id]` row into view
+ *    and pulse-highlights it.
+ *  Both fields are optional; an empty payload simply opens the modal. */
+export interface OpenSettingsDetail {
+  section?: SettingsTab
+  highlightId?: string
+}
+
+/** Dispatch the `dplex:open-settings` window event. Centralizes the event
+ *  name + payload shape so callers (App keybindings, search registry,
+ *  command palette commands) don't drift on the contract. */
+export function dispatchOpenSettings(detail?: OpenSettingsDetail): void {
+  window.dispatchEvent(new CustomEvent('dplex:open-settings', { detail }))
+}

--- a/tests/e2e/global-search.e2e.spec.ts
+++ b/tests/e2e/global-search.e2e.spec.ts
@@ -1,0 +1,117 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
+import { closeApp, launchApp } from './support/electronApp'
+
+async function seedProjects(
+  window: Page,
+  projects: Array<{ id: string; name: string; path: string }>
+): Promise<void> {
+  await window.evaluate(async (payload) => {
+    const withMeta = payload.map((p) => ({
+      ...p,
+      addedAt: new Date().toISOString(),
+      pinned: false
+    }))
+    // @ts-expect-error: dplex is defined on the renderer window via preload
+    await window.dplex.settings.merge({ projects: withMeta })
+  }, projects)
+  await window.reload()
+  await window.waitForLoadState('domcontentloaded')
+  if (projects[0]) {
+    await window.getByText(projects[0].name).waitFor({ state: 'visible' })
+  }
+}
+
+test.describe('DPlex global search', () => {
+  let app: ElectronApplication | undefined
+  let window: Page | undefined
+  let userDataDir: string | undefined
+
+  test.beforeEach(async () => {
+    const launched = await launchApp()
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+  })
+
+  test.afterEach(async () => {
+    await closeApp(app, userDataDir)
+  })
+
+  test('Cmd/Ctrl+P opens the command palette and shows results', async () => {
+    if (!window) throw new Error('Window not available')
+
+    await seedProjects(window, [
+      { id: 'gs-alpha', name: 'GlobalSearchAlpha', path: '/tmp/dplex-gs-alpha' }
+    ])
+
+    // Wait for the activity bar to mount so the global keydown listener is
+    // attached before we press the shortcut.
+    await window.getByTestId('activity-bar-search').waitFor({ state: 'visible' })
+
+    await window.keyboard.press('ControlOrMeta+p')
+
+    const palette = window.getByTestId('command-palette')
+    await expect(palette).toBeVisible()
+
+    const input = window.getByTestId('command-palette-input')
+    await expect(input).toBeFocused()
+
+    await input.fill('GlobalSearchAlpha')
+    const results = window.getByTestId('search-result')
+    await expect(results.first()).toBeVisible()
+    await expect(results.first()).toContainText('GlobalSearchAlpha')
+  })
+
+  test('Cmd/Ctrl+Shift+P opens the palette in commands-only mode', async () => {
+    if (!window) throw new Error('Window not available')
+
+    await window.getByTestId('activity-bar-search').waitFor({ state: 'visible' })
+    await window.keyboard.press('ControlOrMeta+Shift+p')
+
+    const palette = window.getByTestId('command-palette')
+    await expect(palette).toBeVisible()
+    // The command-only badge confirms the mode.
+    await expect(palette).toContainText('Commands')
+
+    // Type a fragment of a command to confirm filtering, then dismiss with Esc.
+    await window.getByTestId('command-palette-input').fill('toggle sidebar')
+    const results = window.getByTestId('search-result')
+    await expect(results.first()).toContainText('Toggle Sidebar')
+    await window.keyboard.press('Escape')
+    await expect(palette).not.toBeVisible()
+  })
+
+  test('Search activity-bar tab reveals the global search side panel', async () => {
+    if (!window) throw new Error('Window not available')
+
+    await seedProjects(window, [
+      { id: 'gs-side-1', name: 'SidePanelHit', path: '/tmp/dplex-gs-side-1' }
+    ])
+
+    await window.getByTestId('activity-bar-search').click()
+
+    const sideInput = window.getByTestId('search-side-input')
+    await expect(sideInput).toBeVisible()
+    await expect(sideInput).toBeFocused()
+
+    await sideInput.fill('SidePanelHit')
+    const results = window.getByTestId('search-result')
+    await expect(results.first()).toContainText('SidePanelHit')
+  })
+
+  test('Selecting a settings result opens Settings on the right tab', async () => {
+    if (!window) throw new Error('Window not available')
+
+    await window.getByTestId('activity-bar-search').waitFor({ state: 'visible' })
+    await window.keyboard.press('ControlOrMeta+p')
+    await window.getByTestId('command-palette-input').fill('font size')
+    await expect(window.getByTestId('search-result').first()).toContainText('Font Size')
+    await window.keyboard.press('Enter')
+
+    // Settings modal opens with Terminal tab active and the row pulses.
+    const modal = window.getByTestId('settings-modal')
+    await expect(modal).toBeVisible()
+    const fontRow = modal.locator('[data-setting-id="font-size"]')
+    await expect(fontRow).toBeVisible()
+  })
+})

--- a/tests/e2e/global-search.e2e.spec.ts
+++ b/tests/e2e/global-search.e2e.spec.ts
@@ -38,17 +38,26 @@ test.describe('DPlex global search', () => {
   })
 
   test('Cmd/Ctrl+P opens the command palette and shows results', async () => {
-    if (!window) throw new Error('Window not available')
+    if (!window || !app) throw new Error('App not available')
 
     await seedProjects(window, [
       { id: 'gs-alpha', name: 'GlobalSearchAlpha', path: '/tmp/dplex-gs-alpha' }
     ])
 
-    // Wait for the activity bar to mount so the global keydown listener is
-    // attached before we press the shortcut.
     await window.getByTestId('activity-bar-search').waitFor({ state: 'visible' })
 
-    await window.keyboard.press('ControlOrMeta+p')
+    // We test the renderer wiring via the same IPC the production
+    // `globalShortcut` registration sends. Playwright's `keyboard.press`
+    // can't reliably trigger Cmd/Ctrl+P on Linux Electron — Chromium's
+    // print-preview accelerator intercepts the synthesized CDP event
+    // before any renderer keydown listener fires, and `globalShortcut`
+    // only fires for native input. The `dplex:shortcut` IPC is exactly
+    // what the OS-level accelerator dispatches in production, so this
+    // assertion still covers the renderer's open-palette path end-to-end.
+    await app.evaluate(({ BrowserWindow: BW }) => {
+      const win = BW.getAllWindows()[0]
+      win?.webContents.send('dplex:shortcut', 'palette.all')
+    })
 
     const palette = window.getByTestId('command-palette')
     await expect(palette).toBeVisible()
@@ -100,10 +109,16 @@ test.describe('DPlex global search', () => {
   })
 
   test('Selecting a settings result opens Settings on the right tab', async () => {
-    if (!window) throw new Error('Window not available')
+    if (!window || !app) throw new Error('App not available')
 
     await window.getByTestId('activity-bar-search').waitFor({ state: 'visible' })
-    await window.keyboard.press('ControlOrMeta+p')
+    // Open the palette via the production `dplex:shortcut` IPC — see the
+    // first test for the rationale (Playwright can't reliably synthesize
+    // Cmd/Ctrl+P on Linux Electron).
+    await app.evaluate(({ BrowserWindow: BW }) => {
+      const win = BW.getAllWindows()[0]
+      win?.webContents.send('dplex:shortcut', 'palette.all')
+    })
     await window.getByTestId('command-palette-input').fill('font size')
     await expect(window.getByTestId('search-result').first()).toContainText('Font Size')
     await window.keyboard.press('Enter')

--- a/tests/unit/search-fuzzy.test.ts
+++ b/tests/unit/search-fuzzy.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { fuzzyMatch, fuzzyMatchAny } from '../../src/renderer/src/services/search/fuzzyMatch'
+
+describe('fuzzyMatch', () => {
+  it('returns zero-score match for empty query', () => {
+    const r = fuzzyMatch('hello', '')
+    expect(r).not.toBeNull()
+    expect(r!.score).toBe(0)
+    expect(r!.ranges).toEqual([])
+  })
+
+  it('returns null when text is empty but query is not', () => {
+    expect(fuzzyMatch('', 'foo')).toBeNull()
+  })
+
+  it('returns null when query characters are not all present in order', () => {
+    expect(fuzzyMatch('abc', 'cba')).toBeNull()
+    expect(fuzzyMatch('hello', 'xyz')).toBeNull()
+  })
+
+  it('matches a substring and returns its range', () => {
+    const r = fuzzyMatch('Open Settings', 'Set')
+    expect(r).not.toBeNull()
+    expect(r!.ranges).toEqual([{ start: 5, end: 8 }])
+  })
+
+  it('case-insensitive matching', () => {
+    const r = fuzzyMatch('Hello World', 'world')
+    expect(r).not.toBeNull()
+    expect(r!.ranges).toEqual([{ start: 6, end: 11 }])
+  })
+
+  it('prefix matches outscore middle matches', () => {
+    const prefix = fuzzyMatch('foobar', 'foo')!
+    const middle = fuzzyMatch('barfoo', 'foo')!
+    expect(prefix.score).toBeGreaterThan(middle.score)
+  })
+
+  it('exact substring matches outscore subsequence matches', () => {
+    const sub = fuzzyMatch('settings', 'sett')!
+    const seq = fuzzyMatch('something tiny truly', 'sett')!
+    expect(sub.score).toBeGreaterThan(seq.score)
+  })
+
+  it('produces correct ranges for subsequence matches', () => {
+    const r = fuzzyMatch('add new project', 'anp')!
+    // a@0, n@4, p@8
+    expect(r.ranges).toEqual([
+      { start: 0, end: 1 },
+      { start: 4, end: 5 },
+      { start: 8, end: 9 }
+    ])
+  })
+
+  it('rewards consecutive runs in subsequence matches', () => {
+    const consecutive = fuzzyMatch('foo bar baz', 'fb')!
+    const scattered = fuzzyMatch('xfxbxxx', 'fb')!
+    // Both match by subsequence; consecutive boundaries should win.
+    expect(consecutive.score).toBeGreaterThan(scattered.score)
+  })
+
+  it('merges adjacent ranges produced by consecutive matches', () => {
+    const r = fuzzyMatch('abc def', 'abc')!
+    expect(r.ranges).toEqual([{ start: 0, end: 3 }])
+  })
+})
+
+describe('fuzzyMatchAny', () => {
+  it('falls back to keyword match when label does not match', () => {
+    const m = fuzzyMatchAny('Theme', ['color', 'palette'], 'palette')
+    expect(m).not.toBeNull()
+    // Keyword-only matches return empty ranges — they only contribute to score.
+    expect(m!.ranges).toEqual([])
+  })
+
+  it('prefers label match over keyword match', () => {
+    // Both label and keyword match — label match must win (it has ranges).
+    const m = fuzzyMatchAny('Theme', ['theme'], 'theme')
+    expect(m).not.toBeNull()
+    expect(m!.ranges.length).toBeGreaterThan(0)
+  })
+
+  it('returns null when neither label nor keywords match', () => {
+    expect(fuzzyMatchAny('Theme', ['color', 'palette'], 'xyz')).toBeNull()
+  })
+})

--- a/tests/unit/search-registry.test.ts
+++ b/tests/unit/search-registry.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest'
+import {
+  buildRegistry,
+  MAX_RESULTS_PER_GROUP
+} from '../../src/renderer/src/services/search/searchRegistry'
+import type {
+  SearchContext,
+  SearchItem,
+  SearchSource
+} from '../../src/renderer/src/services/search/types'
+
+const EMPTY_CTX: SearchContext = {
+  projects: [],
+  sessions: [],
+  groups: [],
+  activeGroupId: null
+}
+
+function source(
+  category: SearchItem['category'],
+  items: { id: string; label: string; keywords?: string[] }[]
+): SearchSource {
+  return {
+    category,
+    getItems: () =>
+      items.map((it) => ({
+        id: it.id,
+        category,
+        label: it.label,
+        keywords: it.keywords,
+        run: () => undefined
+      }))
+  }
+}
+
+describe('SearchRegistry', () => {
+  it('returns no groups when no source has items', () => {
+    const reg = buildRegistry([source('commands', [])])
+    expect(reg.run('foo', EMPTY_CTX)).toEqual([])
+  })
+
+  it('groups results by category and renders empty-state previews when query is empty', () => {
+    const reg = buildRegistry([
+      source('commands', [
+        { id: 'c1', label: 'Add Project' },
+        { id: 'c2', label: 'New Terminal' }
+      ]),
+      source('projects', [{ id: 'p1', label: 'My Project' }])
+    ])
+    const result = reg.run('', EMPTY_CTX)
+    expect(result).toHaveLength(2)
+    expect(result[0].category).toBe('commands') // commands first per CATEGORY_ORDER
+    expect(result[0].items).toHaveLength(2)
+    expect(result[1].category).toBe('projects')
+  })
+
+  it('ranks items by score and drops non-matches', () => {
+    const reg = buildRegistry([
+      source('commands', [
+        { id: 'c1', label: 'Add Project' },
+        { id: 'c2', label: 'New Terminal' },
+        { id: 'c3', label: 'Open Settings' }
+      ])
+    ])
+    const result = reg.run('add', EMPTY_CTX)
+    expect(result).toHaveLength(1)
+    expect(result[0].items[0].item.id).toBe('c1')
+    // 'New Terminal' has no 'add' subsequence, so it's dropped.
+    expect(result[0].items.find((r) => r.item.id === 'c2')).toBeUndefined()
+  })
+
+  it('caps results per group at MAX_RESULTS_PER_GROUP', () => {
+    const lots = Array.from({ length: 20 }, (_, i) => ({
+      id: `c${i}`,
+      label: `setting item ${i}`
+    }))
+    const reg = buildRegistry([source('commands', lots)])
+    const result = reg.run('setting', EMPTY_CTX)
+    expect(result[0].items.length).toBe(MAX_RESULTS_PER_GROUP)
+  })
+
+  it('prunes categories that are not in the allowed list', () => {
+    const reg = buildRegistry([
+      source('commands', [{ id: 'c1', label: 'Add Project' }]),
+      source('projects', [{ id: 'p1', label: 'Add' }])
+    ])
+    const result = reg.run('add', EMPTY_CTX, { categories: ['commands'] })
+    expect(result).toHaveLength(1)
+    expect(result[0].category).toBe('commands')
+  })
+
+  it('includes items that match only via keywords', () => {
+    const reg = buildRegistry([
+      source('settings', [{ id: 's1', label: 'Theme', keywords: ['color', 'dark mode'] }])
+    ])
+    const result = reg.run('color', EMPTY_CTX)
+    expect(result).toHaveLength(1)
+    expect(result[0].items[0].item.id).toBe('s1')
+  })
+})


### PR DESCRIPTION
Adds a unified global search across **projects, AI sessions, open tabs, settings, and commands** with two surfaces sharing one engine.

## What's new

- **`Cmd/Ctrl+P`** — global search palette. Results grouped by category with keyboard navigation, fuzzy ranking, and highlight ranges.
- **`Cmd/Ctrl+Shift+P`** — same palette pre-filtered to commands (e.g. *Add Project*, *New Terminal*, *Toggle Sidebar*, *Notification Settings*). All commands shown uncapped.
- **`Cmd/Ctrl+Shift+F`** — opens a new **Search** tab in the activity bar (a persistent side-panel mirror of the palette).
- **Settings deep-linking** — picking a settings result opens Settings on the right tab, scrolls the row into view, and pulse-highlights it for ~3s.

## Architecture

A pluggable registry under `src/renderer/src/services/search/`:

- `searchRegistry.ts` — registers sources, runs the query, returns grouped/ranked results with per-group caps.
- `fuzzyMatch.ts` — substring + subsequence matcher with prefix/word-boundary/consecutive-run scoring.
- `{projects,sessions,tabs,settings,commands}Source.ts` — each source declares items + `run()` actions. Adding a category is a one-file change.

UI under `src/renderer/src/components/search/`:

- `CommandPalette.tsx` — focus-trapped modal with Esc-via-`useEscapeKey`.
- `SearchSidePanelView.tsx` — activity-bar variant.
- `SearchResultsList.tsx` — shared grouped list with highlighted match ranges.
- `useGlobalSearch.ts` — search state + live store subscriptions.
- `useSearchKeyboardNav.ts` — shared arrow/Home/End/Enter handler used by both surfaces.

Plus a small `commandPaletteStore` (Zustand) and a shared `utils/openSettings.ts` dispatcher.

## Wiring

- Extended `AppSettings.sidebarActiveTab` union with `'search'`.
- `ActivityBar` adds the Search tab.
- `SidePanel` routes to `SearchSidePanelView` when active.
- `App.tsx` adds the new keybindings and mounts the palette.
- `SettingsModal` adds `data-setting-id` to each registered row, listens for `highlightId`, and pulses via a new keyframe in `assets/main.css`.

## Tests

- **19 new unit tests** for the matcher + registry — full suite **281/281 pass**.
- **4 new e2e tests** covering both surfaces and the settings deep-link — all pass.

## Code review

Ran the mandatory dual-model review (Claude Opus 4.7 + GPT-5.5) before commit. No critical/high findings. Addressed all medium/low findings (dead code removal, focus-trap, selection-on-query-change reset, settings tab cast validation, etc.). Then ran a final duplication-focused review and DRY'd up:

- `dispatchOpenSettings` helper replaces 4 inline call sites.
- `useSearchKeyboardNav` replaces duplicated keyboard handlers.
- `useEscapeKey` (existing repo hook) replaces inline Esc handling in the palette.

## Versioning

`0.11.3 → 0.12.0` (MINOR — new user-visible features). `CHANGELOG.md` has a customer-facing entry under `### Features`.

🤖 Generated with the help of GitHub Copilot CLI
