### PR TITLE
feat: live status dot on AI session tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] — 2026-05-10
+
+### Features
+
+- AI session tabs now show a live status dot — the same colors used in
+  the sidebar — so you can tell at a glance whether a background tab is
+  thinking, running a tool, or waiting on you, without switching to it.
+  Idle tabs stay quiet.
+
 ## [0.12.0] — 2026-05-09
 
 ### Features
@@ -395,7 +404,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.12.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.13.0...HEAD
+[0.13.0]: https://github.com/Ron537/DPlex/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/Ron537/DPlex/compare/v0.11.3...v0.12.0
 [0.11.3]: https://github.com/Ron537/DPlex/compare/v0.11.2...v0.11.3
 [0.11.2]: https://github.com/Ron537/DPlex/compare/v0.11.1...v0.11.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dplex",
-  "version": "0.11.2",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dplex",
-      "version": "0.11.2",
+      "version": "0.13.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/renderer/src/components/terminal/GroupTabBar.tsx
+++ b/src/renderer/src/components/terminal/GroupTabBar.tsx
@@ -7,16 +7,12 @@ import {
   SplitSquareVertical
 } from 'lucide-react'
 import { useTerminalStore } from '../../stores/terminalStore'
-import { useAttentionStore } from '../../stores/attentionStore'
+import { useSessionStore } from '../../stores/sessionStore'
+import { StatusDot } from '../common/StatusDot'
+import { labelForVisual } from '../../utils/sessionStatusVisual'
+import { effectiveSessionVisual } from '../../utils/sessionPairing'
 import { ShellSelector } from './ShellSelector'
 import type { EditorGroup } from '../../types'
-import type { AttentionKind } from '../../../../preload/attentionTypes'
-
-const DOT_COLOR: Record<AttentionKind, string> = {
-  waitingForApproval: 'var(--dplex-status-approval)',
-  waitingForInput: 'var(--dplex-status-waiting)',
-  finished: 'var(--dplex-status-thinking)'
-}
 
 interface GroupTabBarProps {
   group: EditorGroup
@@ -47,7 +43,7 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
-  const activeEvents = useAttentionStore((s) => s.active)
+  const sessions = useSessionStore((s) => s.sessions)
 
   const handleDoubleClick = (tabId: string, currentTitle: string): void => {
     setEditingTabId(tabId)
@@ -188,18 +184,22 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
               />
               {(() => {
                 if (!tabSessionId || !tabProviderId) return null
-                const compositeId = `${tabProviderId}:${tabSessionId}`
-                const event = activeEvents.find(
-                  (e) => e.compositeId === compositeId && !e.suppressed
+                const session = sessions.find(
+                  (s) => s.id === tabSessionId && s.aiTool === tabProviderId
                 )
-                if (!event) return null
-                return (
-                  <span
-                    className="w-1.5 h-1.5 rounded-full flex-shrink-0"
-                    style={{ backgroundColor: DOT_COLOR[event.kind] }}
-                    title={event.kind}
-                  />
-                )
+                // Guard against stale `detailedStatus` lingering on sessions
+                // whose lock has died (status === 'idle'). Mirrors the same
+                // safety check applied in ProjectAvatarButton.
+                if (!session || session.status !== 'active') return null
+                // `effectiveSessionVisual` treats active-but-untyped sessions
+                // as `thinking` so a freshly-spawned session (still in PTY
+                // bring-up before any JSONL events land) shows a live dot
+                // instead of disappearing.
+                const visual = effectiveSessionVisual(session)
+                // Hide on idle to keep tabs visually quiet — only show when
+                // the AI is actively working or waiting on the user.
+                if (visual === 'idle') return null
+                return <StatusDot visual={visual} title={labelForVisual(visual)} />
               })()}
               {editingTabId === tab.id ? (
                 <input

--- a/tests/unit/session-pairing.test.ts
+++ b/tests/unit/session-pairing.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { pairTabsToSessions } from '../../src/renderer/src/utils/sessionPairing'
-import type { AISession, TerminalTab } from '../../src/renderer/src/types'
+import { effectiveSessionVisual, pairTabsToSessions } from '../../src/renderer/src/utils/sessionPairing'
+import type { AISession, SessionStatus, TerminalTab } from '../../src/renderer/src/types'
 
 const cwd = '/Users/me/repo'
 
@@ -107,5 +107,37 @@ describe('pairTabsToSessions', () => {
     const r = pairTabsToSessions(sessions, tabs)
     expect(r.pairs[0].match).toBeUndefined()
     expect(r.unpaired.map((u) => u.id)).toEqual(['a'])
+  })
+})
+
+describe('effectiveSessionVisual', () => {
+  function mkSession(
+    status: 'active' | 'idle',
+    detailedStatus?: SessionStatus
+  ): AISession {
+    return {
+      id: 'x',
+      aiTool: 'copilot-cli',
+      status,
+      detailedStatus,
+      title: 'x',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    } as unknown as AISession
+  }
+
+  it('uses detailedStatus when present', () => {
+    expect(effectiveSessionVisual(mkSession('active', 'thinking'))).toBe('thinking')
+    expect(effectiveSessionVisual(mkSession('active', 'executingTool'))).toBe('running')
+    expect(effectiveSessionVisual(mkSession('active', 'awaitingApproval'))).toBe('attn')
+    expect(effectiveSessionVisual(mkSession('active', 'waitingForUser'))).toBe('waiting')
+  })
+
+  it('falls back to "thinking" for active sessions without detailedStatus', () => {
+    expect(effectiveSessionVisual(mkSession('active', undefined))).toBe('thinking')
+  })
+
+  it('falls back to "idle" for non-active sessions without detailedStatus', () => {
+    expect(effectiveSessionVisual(mkSession('idle', undefined))).toBe('idle')
   })
 })

--- a/tests/unit/session-status-visual.test.ts
+++ b/tests/unit/session-status-visual.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import {
+  labelForVisual,
+  visualForStatus
+} from '../../src/renderer/src/utils/sessionStatusVisual'
+
+describe('visualForStatus', () => {
+  it('maps every SessionStatus to a visual', () => {
+    expect(visualForStatus('idle')).toBe('idle')
+    expect(visualForStatus('thinking')).toBe('thinking')
+    expect(visualForStatus('executingTool')).toBe('running')
+    expect(visualForStatus('waitingForUser')).toBe('waiting')
+    expect(visualForStatus('awaitingApproval')).toBe('attn')
+  })
+
+  it('falls back to idle for undefined', () => {
+    expect(visualForStatus(undefined)).toBe('idle')
+  })
+})
+
+describe('labelForVisual', () => {
+  it('returns a human-readable label for every visual', () => {
+    expect(labelForVisual('idle')).toBe('Idle')
+    expect(labelForVisual('thinking')).toBe('Thinking')
+    expect(labelForVisual('running')).toBe('Running')
+    expect(labelForVisual('waiting')).toBe('Waiting for input')
+    expect(labelForVisual('attn')).toBe('Needs approval')
+  })
+})


### PR DESCRIPTION
## Summary

Adds a live per-tab status indicator for AI session tabs, so you can tell at a glance whether a background tab is **thinking**, **running a tool**, **awaiting approval**, or **waiting for input** — without switching to it. Idle tabs stay visually quiet (no dot).

Before, the tab dot was driven by `useAttentionStore` and only surfaced for the 3 attention kinds (`waitingForApproval`, `waitingForInput`, `finished`). Working states (`thinking`, `executingTool`) were invisible from another tab.

## Approach

The renderer already had everything needed:

- `SessionStatus` (5-state enum) is parsed live from JSONL events by each provider and propagates to the renderer via `sessionStore` watchers.
- The sidebar (`SessionItem`) already renders all 5 states with the same `StatusDot` and `--dplex-status-*` color tokens.
- `effectiveSessionVisual` (`utils/sessionPairing.ts`) was already the canonical helper for "what is this session doing right now?" — it falls back to `thinking` for an active session whose `detailedStatus` hasn't landed yet.

The change just rewires `GroupTabBar.tsx` to ask the same question as the sidebar:

```ts
if (!session || session.status !== 'active') return null  // guard stale detailedStatus
const visual = effectiveSessionVisual(session)
if (visual === 'idle') return null                        // hide on idle
return <StatusDot visual={visual} title={labelForVisual(visual)} />
```

The bell / inbox attention indicator (`useAttentionStore`) is unchanged — that is a different surface answering a different question ("which sessions need *me*?").

## Design choices (confirmed with the user)

- **Hide on idle** — only show the dot when the AI is actively working or waiting on the user.
- **Just the dot, tooltip carries the label** — keeps the tab compact.

## Code review

Ran the dual-model review (Opus + GPT-5.5) per the codebase policy:

- Opus: nothing.
- GPT-5.5: caught a real bug — using `detailedStatus` directly meant freshly-spawned sessions (active, no events yet) showed nothing, and stale `detailedStatus` could light up idle sessions. **Fixed** by routing through `effectiveSessionVisual` + the `status === 'active'` guard.

## Tests

- New unit file `session-status-visual.test.ts` covers `visualForStatus` and `labelForVisual`.
- Extended `session-pairing.test.ts` with `effectiveSessionVisual` cases.
- Full suite: **287 passed** (+6 new tests from this PR). Typecheck clean.

## Versioning

User-visible feature → MINOR bump: `0.12.0` → `0.13.0`. Changelog entry added under `### Features`.
