### PR TITLE
ci(pages): install npm deps before building the site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        # The site builder uses the `ignore` npm package to respect
+        # .gitignore. Skip lifecycle scripts (no Electron download needed
+        # for a static-site build) to keep this fast.
+        run: npm ci --ignore-scripts --omit=optional
 
       - name: Build site
         run: node scripts/build-site.mjs


### PR DESCRIPTION
## Why

The merged Pages run for #47 failed at the build step:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ignore' imported from .../scripts/build-site.mjs
```

`scripts/build-site.mjs` now reads `.gitignore` via the `ignore` npm package (so any future gitignored path is automatically excluded from the deploy bundle). That introduced a runtime dependency on `node_modules/`, but the Pages workflow only installed Node and ran the script — no `npm ci` step.

## What

- Add `npm ci --ignore-scripts --omit=optional` before `node scripts/build-site.mjs`.
- `ignore-scripts` skips Electron's postinstall download (not needed for a static-site build).
- `omit=optional` skips heavy optionals like `ffmpeg-static`.
- Enable `setup-node`'s npm cache so cold runs finish in ~15s.

## Verified locally

`npm ci --ignore-scripts --omit=optional && node scripts/build-site.mjs` produces the full `_site/` bundle (home + `/changelog/` + sitemap + 12 image assets, no cruft).