### PR TITLE
fix(release): rebuild node-pty per target arch on macOS (closes #45)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.1] — 2026-05-11
+
+### Bug Fixes
+
+- DPlex on Intel Macs now launches AI sessions correctly. The previous
+  Intel build shipped wrong-architecture native binaries, so every new
+  session failed silently with no usable error in the UI.
+
 ## [0.14.0] — 2026-05-10
 
 ### Improvements
@@ -415,6 +423,7 @@ AI-assisted development.
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
 [Unreleased]: https://github.com/Ron537/DPlex/compare/v0.14.0...HEAD
+[0.14.1]: https://github.com/Ron537/DPlex/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Ron537/DPlex/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/Ron537/DPlex/compare/v0.12.0...v0.13.0
 [0.12.0]: https://github.com/Ron537/DPlex/compare/v0.11.3...v0.12.0

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -63,7 +63,14 @@ appImage:
   artifactName: ${productName}.${ext}
 deb:
   artifactName: ${productName}-${arch}.${ext}
-npmRebuild: false
+# Note: `npmRebuild` is intentionally left at its default (true) so
+# electron-builder runs @electron/rebuild per target arch when packaging
+# multi-arch builds. Disabling it leaks the host runner's host-arch
+# native binaries into every arch's DMG — that was the root cause of
+# issue #45 (Intel Mac users got arm64 spawn-helper from a macos-latest
+# arm64 runner). On macOS, clang cross-compiles x86_64 from arm64 hosts
+# out of the box, so a single macos-latest runner produces correct
+# binaries for both archs.
 publish:
   provider: github
   owner: Ron537

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {


### PR DESCRIPTION
Fixes #45.

## Summary

The v0.13.0 / v0.14.0 `DPlex-x64.dmg` is non-functional on every Intel Mac: opening a session fails with `[Failed to start terminal]`, and the main-process log shows `posix_spawnp failed` from `node-pty`.

## Root cause

`electron-builder.yml` had `npmRebuild: false`, which disables electron-builder's per-arch native-module rebuild step during packaging. With that flag off, the build process packages whatever `node_modules/node-pty/build/Release/` happens to contain on the build host — and since our `postinstall` runs `electron-builder install-app-deps` once for the host arch, that directory only ever has binaries for the runner's arch (arm64 on `macos-latest`). Those arm64 binaries then get bundled into **both** the arm64 DMG (correct by coincidence) **and** the x64 DMG (broken — Intel can't exec arm64).

`node-pty`'s native loader (`lib/utils.js`) probes `build/Release/` → `build/Debug/` → `prebuilds/<plat>-<arch>/`, so the stray host-arch `build/Release/` wins over the per-arch prebuilds at runtime.

## Fix

Remove `npmRebuild: false`. `true` is the default; with it enabled, electron-builder runs `@electron/rebuild` per target arch (clang on macOS cross-compiles `x86_64` from Apple Silicon out of the box), so each arch's `.app` ships with the correct `pty.node` and `spawn-helper`. A comment in `electron-builder.yml` documents why this must stay enabled.

## Alternatives considered and rejected

- **Excluding `build/**`** and falling back to the npm-shipped `prebuilds/`: tempting but the prebuilt `spawn-helper` ships with mode `0644`. Confirmed locally that with only prebuilds present, `posix_spawn` fails with EACCES — same surface error as the arch-mismatch bug. Would have needed an `afterPack` chmod, i.e. binary fiddling.
- **Universal `.dmg`**: doubles download size and still needs per-arch rebuild internally.
- **Per-runner split (`macos-13` for Intel)**: GitHub is retiring Intel macOS runners; cross-compile from a single arm64 runner is the future-proof path.
- **`afterPack` verification script**: ~150 lines of CI surface to catch one regression class that's already documented inline in `electron-builder.yml` and visible in any PR diff. Not worth the maintenance.

## Pre-release verification

Recommended before tagging `v0.14.1`:

```bash
gh workflow run release.yml -f dry-run=true
gh run download --name dplex-macos-latest
hdiutil attach DPlex-x64.dmg
file "/Volumes/DPlex"*/DPlex.app/Contents/Resources/app.asar.unpacked/node_modules/node-pty/build/Release/spawn-helper
# Expect: Mach-O 64-bit executable x86_64
hdiutil detach "/Volumes/DPlex"*
```

## Test plan

- `npm run lint` — no new issues
- `npm run typecheck` — clean
- `npm run test:unit` — 325/325 pass
- Manual verification of the produced `DPlex-x64.dmg` on an Intel Mac (or via `file` inspection of the packaged binary) before tagging.

## Diff size

+18 / −2 lines across 3 files. The actual fix is one line; the rest is the explanatory comment + version bump + changelog entry.

Thanks to @raphapizzi for the detailed report and root-cause analysis in #45 — it pointed straight at the right config flag.
