### PR TITLE
fix(release): ad-hoc sign macOS .app before DMG sealing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,26 +66,6 @@ jobs:
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run build:mac:ci -- --publish ${{ github.event_name == 'workflow_dispatch' && 'never' || 'always' }}
 
-      # Ad-hoc codesign as a free fallback when no Developer ID secret is
-      # configured. `codesign -s -` adds a self-anchored signature that
-      # avoids the "DPlex is damaged and can't be opened" Gatekeeper
-      # error on macOS Catalina+. Users still need to right-click → Open
-      # (or run `xattr -dr com.apple.quarantine`) on first launch, but
-      # the binary is no longer treated as outright malicious.
-      - name: Ad-hoc sign macOS app (no Developer ID)
-        if: matrix.os == 'macos-latest' && env.CSC_LINK == ''
-        env:
-          CSC_LINK: ${{ secrets.MAC_CSC_LINK }}
-        run: |
-          set -e
-          for app in dist/mac*/*.app; do
-            if [ -d "$app" ]; then
-              echo "Ad-hoc signing $app"
-              codesign --force --deep --sign - "$app"
-              codesign --verify --verbose=2 "$app" || true
-            fi
-          done
-
       - name: Build Windows
         if: matrix.os == 'windows-latest'
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.14.2] — 2026-05-11
+
+### Bug Fixes
+
+- macOS builds now ship with a valid ad-hoc code signature, so the
+  Electron framework loads cleanly on macOS 14+ and the "DPlex is
+  damaged" Gatekeeper error no longer appears. Previous builds were
+  published completely unsigned. (You may still need
+  `xattr -dr com.apple.quarantine /Applications/DPlex.app` on first
+  launch until a Developer ID signature is in place.)
+
 ## [0.14.1] — 2026-05-11
 
 ### Bug Fixes
@@ -423,6 +434,7 @@ AI-assisted development.
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
 [Unreleased]: https://github.com/Ron537/DPlex/compare/v0.14.0...HEAD
+[0.14.2]: https://github.com/Ron537/DPlex/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/Ron537/DPlex/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Ron537/DPlex/compare/v0.13.0...v0.14.0
 [0.13.0]: https://github.com/Ron537/DPlex/compare/v0.12.0...v0.13.0

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -2,6 +2,11 @@ appId: dev.dplex.app
 productName: DPlex
 directories:
   buildResources: build
+# Apply an ad-hoc codesignature to the macOS .app after pack but before
+# DMG sealing. Without this the published DMG ships an entirely unsigned
+# .app (see issue #45 thread). No-op on Windows/Linux; no-op on macOS
+# when CSC_LINK is set (real Developer ID signing takes over).
+afterPack: scripts/mac-adhoc-sign.mjs
 files:
   - '!**/.vscode/*'
   - '!src/*'
@@ -24,11 +29,16 @@ nsis:
   uninstallDisplayName: ${productName}
   createDesktopShortcut: always
 mac:
-  # identity: null produces an unsigned .app (local/dev builds). When signed
-  # ad-hoc by electron-builder without a Developer ID cert, the main binary
-  # and the bundled Electron Framework end up with different Team IDs, so
-  # macOS 14+ refuses to load the framework ("different Team IDs"). Keeping
-  # the app unsigned avoids the mismatch and lets it launch locally.
+  # `identity: null` disables electron-builder's built-in signing path
+  # entirely. We intentionally skip it because its per-component ad-hoc
+  # signing leaves the bundled `Electron Framework.framework` with a
+  # different (empty/missing) Team ID than the main binary, and macOS
+  # 14+ then refuses to load the framework with `"Team IDs differ"`.
+  # Instead, the `afterPack` hook in this file runs a single recursive
+  # `codesign --deep --sign -` against the fully-packed .app — every
+  # nested Mach-O ends up with the same ad-hoc identity, eliminating
+  # the mismatch. When CSC_LINK is set in CI, both paths are skipped
+  # and electron-builder's real Developer ID signing runs normally.
   identity: null
   entitlementsInherit: build/entitlements.mac.plist
   extendInfo:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/scripts/mac-adhoc-sign.mjs
+++ b/scripts/mac-adhoc-sign.mjs
@@ -1,0 +1,62 @@
+// electron-builder `afterPack` hook — applies an ad-hoc codesignature to
+// the freshly-packed macOS .app BEFORE electron-builder seals it into a
+// DMG. Without this, the published DMG ships an entirely unsigned .app
+// (issue #45 follow-up).
+//
+// Why afterPack and not afterSign:
+//   `identity: null` in electron-builder.yml disables electron-builder's
+//   own signing path, so its `afterSign` hook never fires. We sign here,
+//   one level earlier, so the DMG's HFS payload contains a signed .app.
+//
+// Why `codesign --deep --sign -` against the packed .app rather than
+// letting electron-builder ad-hoc sign per-component:
+//   electron-builder's per-component path signs the main binary and
+//   helpers but historically does not propagate the same ad-hoc identity
+//   to the bundled `Electron Framework.framework`. macOS 14+ then refuses
+//   to load the framework with `"Team IDs differ"`. A single recursive
+//   `codesign --deep --sign -` signs every nested Mach-O — main binary,
+//   helpers, the framework, dylibs — with the same (empty) ad-hoc
+//   identity, eliminating the mismatch.
+//
+// What this DOES give us:
+//   - `codesign -dvvv` reports a valid (ad-hoc) signature
+//   - macOS 14+ loads the Electron Framework without "Team IDs differ"
+//   - The "DPlex is damaged" Gatekeeper error path is avoided
+//
+// What this DOES NOT give us:
+//   - Gatekeeper "Identified Developer" trust (still need Developer ID
+//     + notarization for that — users still see the unidentified
+//     developer warning on first launch and may need
+//     `xattr -dr com.apple.quarantine`).
+/* eslint-disable @typescript-eslint/explicit-function-return-type --
+   Node build/CI hook, not application TypeScript. */
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { execFileSync } from 'node:child_process'
+
+export default async function adhocSignMac(context) {
+  const { electronPlatformName, appOutDir, packager } = context
+
+  if (electronPlatformName !== 'darwin') return
+
+  // Skip when a real Developer ID is configured — electron-builder will
+  // do the proper signing and we'd just stomp on it.
+  if (process.env.CSC_LINK) {
+    console.log('[mac-adhoc-sign] CSC_LINK set — skipping ad-hoc signature')
+    return
+  }
+
+  const productFilename = packager.appInfo.productFilename
+  const appPath = path.join(appOutDir, `${productFilename}.app`)
+  if (!fs.existsSync(appPath)) {
+    console.log(`[mac-adhoc-sign] no .app at ${appPath} — skipping`)
+    return
+  }
+
+  console.log(`[mac-adhoc-sign] ad-hoc signing ${appPath}`)
+  execFileSync('codesign', ['--force', '--deep', '--sign', '-', appPath], {
+    stdio: 'inherit'
+  })
+  execFileSync('codesign', ['--verify', '--verbose=2', appPath], { stdio: 'inherit' })
+}


### PR DESCRIPTION
Follow-up to #45 / #56 — addresses the unsigned-bundle issue raised by @raphapizzi.

## Problem

Published macOS DMGs through v0.14.1 ship an entirely unsigned `.app`:

```
$ codesign -dvvv /Volumes/DPlex\ 0.14.0/DPlex.app
/Volumes/DPlex 0.14.0/DPlex.app: code object is not signed at all
```

This forces users to manually `xattr -dr com.apple.quarantine` on first launch and can trigger AMFI / "Team IDs differ" errors on macOS 14+.

## Root cause

Two things compound:

1. **`identity: null` in `electron-builder.yml`** disables electron-builder's signing path entirely. The existing comment explains the original motivation: when electron-builder did *partial* ad-hoc signing, the bundled `Electron Framework.framework` ended up with a different Team ID than the main binary, breaking the load on macOS 14+.
2. **The release workflow's `Ad-hoc sign macOS app` step is dead code.** It runs *after* `npm run build:mac:ci -- --publish always`, by which point electron-builder has already created and uploaded the DMG containing the unsigned `.app`. The post-build `codesign` is applied to a file on the runner that nothing downloads.

## Fix

Move the ad-hoc signing into an electron-builder `afterPack` hook that runs after pack but **before DMG sealing**:

- New `scripts/mac-adhoc-sign.mjs` — runs `codesign --force --deep --sign - <.app>`. A single recursive call signs every nested Mach-O (main binary, helpers, framework, dylibs) with the same empty/ad-hoc identity, so the "Team IDs differ" mismatch never arises. No-op on Windows/Linux; no-op on macOS when `CSC_LINK` is set so real Developer ID signing can take over later.
- `electron-builder.yml` — wires the hook via `afterPack:`, and rewrites the `identity: null` comment to explain why we still disable electron-builder's own broken per-component path.
- `.github/workflows/release.yml` — removes the dead post-build `Ad-hoc sign macOS app` step (its job is now handled correctly by the hook).
- `package.json` / `CHANGELOG.md` — patch bump to `v0.14.2` + customer-facing changelog entry.

## What this gets us

- ✅ `codesign -dvvv` reports a valid ad-hoc signature on the published `.app`
- ✅ macOS 14+ loads the bundled Electron Framework without "Team IDs differ"
- ✅ The "DPlex is damaged and can't be opened" Gatekeeper hard-reject path goes away

## What this does NOT get us

Still not signed by a Developer ID, so:
- Users still see the unidentified-developer warning on first launch
- Users may still need `xattr -dr com.apple.quarantine /Applications/DPlex.app`

Both are unavoidable until we add a paid Developer ID + notarization.

## Local verification

Smoke-tested the hook against a real `.app` (Calculator stand-in):

```
=== before ===
/tmp/sign-test/DPlex.app: code object is not signed at all

=== after ===
flags=0x2(adhoc)
/tmp/sign-test/DPlex.app: valid on disk
/tmp/sign-test/DPlex.app: satisfies its Designated Requirement
```

## Pre-release verification

Same recipe as #56 — dry-run the release workflow on this PR, download the macOS artifact, and run:

```bash
hdiutil attach DPlex-x64.dmg -nobrowse
codesign -dvvv "/Volumes/DPlex 0.14.2/DPlex.app"
# Expect: flags=0x2(adhoc), "satisfies its Designated Requirement"
hdiutil detach "/Volumes/DPlex 0.14.2"
```

## Tests

- `npm run lint` — no new issues
- `npm run typecheck` — clean
- `npm run test:unit` — 325/325 pass
- Manual `codesign` smoke test (above)

## Diff

+90 / −26 across 5 files (~30 lines of actual hook logic, the rest is comment, workflow cleanup, version bump, changelog entry).
