### PR TITLE
feat(attention): optional 'mark seen on click' for waiting notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.0] — 2026-05-12
+
+### Features
+
+- Attention bell can now mark waiting notifications as seen when you
+  click them, matching Slack/Gmail-style behavior. A mode pill at the
+  top of the bell dropdown ("View only" / "Mark seen on click") shows
+  the current behavior and toggles it with one click; the same setting
+  also lives under Settings → Notifications. Off by default — when on,
+  clicking a waiting row both jumps to the tab and clears the badge,
+  and the bell will re-surface the event if the session keeps waiting.
+
 ## [0.14.2] — 2026-05-11
 
 ### Bug Fixes
@@ -433,7 +445,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.14.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.15.0...HEAD
+[0.15.0]: https://github.com/Ron537/DPlex/compare/v0.14.2...v0.15.0
 [0.14.2]: https://github.com/Ron537/DPlex/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/Ron537/DPlex/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/Ron537/DPlex/compare/v0.13.0...v0.14.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dplex",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dplex",
-      "version": "0.14.3",
+      "version": "0.15.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/renderer/src/components/attention/AttentionBellButton.tsx
+++ b/src/renderer/src/components/attention/AttentionBellButton.tsx
@@ -1,7 +1,9 @@
 import { useState, useRef, useEffect } from 'react'
-import { Bell, Check, X } from 'lucide-react'
+import { Bell, Check, Eye, X } from 'lucide-react'
 import { useAttentionStore } from '../../stores/attentionStore'
+import { useSettingsStore } from '../../stores/settingsStore'
 import { focusSessionTab } from '../../utils/sessionTabs'
+import { decideRowClickAction } from './rowClickAction'
 import type { AttentionEvent, AttentionKind } from '../../../../preload/attentionTypes'
 
 const KIND_LABEL: Record<AttentionKind, string> = {
@@ -34,6 +36,8 @@ export function AttentionBellButton(): React.JSX.Element {
   const acknowledge = useAttentionStore((s) => s.acknowledge)
   const acknowledgeAll = useAttentionStore((s) => s.acknowledgeAll)
   const dismiss = useAttentionStore((s) => s.dismiss)
+  const clickClearsWaiting = useSettingsStore((s) => s.settings.attentionClickClearsWaiting)
+  const updateSettings = useSettingsStore((s) => s.updateSettings)
 
   const [open, setOpen] = useState(false)
   const rootRef = useRef<HTMLDivElement>(null)
@@ -59,8 +63,14 @@ export function AttentionBellButton(): React.JSX.Element {
 
   const handleRowClick = (event: AttentionEvent): void => {
     focusSessionTab(event.sessionId, event.providerId)
-    if (event.kind === 'finished') acknowledge(event.compositeId)
+    const action = decideRowClickAction(event.kind, clickClearsWaiting)
+    if (action === 'acknowledge') acknowledge(event.compositeId)
+    else if (action === 'dismiss') dismiss(event.compositeId)
     setOpen(false)
+  }
+
+  const toggleClickMode = (): void => {
+    updateSettings({ attentionClickClearsWaiting: !clickClearsWaiting })
   }
 
   return (
@@ -94,12 +104,40 @@ export function AttentionBellButton(): React.JSX.Element {
           }}
         >
           <div
-            className="flex items-center justify-between px-3 py-2"
+            className="flex items-center gap-2 px-3 py-2"
             style={{ borderBottom: '1px solid var(--dplex-border)' }}
           >
             <span className="text-[11px] font-semibold" style={{ color: 'var(--dplex-text)' }}>
               Attention
             </span>
+            <button
+              onClick={toggleClickMode}
+              className="text-[10px] flex items-center gap-1 px-2 py-[2px] rounded-full transition-colors hover:bg-[var(--dplex-hover)]"
+              style={
+                clickClearsWaiting
+                  ? {
+                      color: 'var(--dplex-accent)',
+                      border: '1px solid var(--dplex-accent)',
+                      backgroundColor: 'var(--dplex-accent-soft)'
+                    }
+                  : {
+                      color: 'var(--dplex-text-muted)',
+                      border: '1px solid var(--dplex-border)',
+                      backgroundColor: 'transparent'
+                    }
+              }
+              title={
+                clickClearsWaiting
+                  ? 'Clicking a row navigates and clears the notification. Click here to switch to view-only.'
+                  : 'Clicking a row only navigates. Click here to also clear waiting notifications when you click them.'
+              }
+              aria-pressed={clickClearsWaiting}
+              aria-label="Toggle: mark waiting notifications as seen on click"
+            >
+              {clickClearsWaiting ? <Check size={10} /> : <Eye size={10} />}
+              {clickClearsWaiting ? 'Mark seen on click' : 'View only'}
+            </button>
+            <span className="flex-1" />
             {grouped.finished.length > 0 && (
               <button
                 onClick={() => acknowledgeAll()}

--- a/src/renderer/src/components/attention/rowClickAction.ts
+++ b/src/renderer/src/components/attention/rowClickAction.ts
@@ -1,0 +1,28 @@
+import type { AttentionKind } from '../../../../preload/attentionTypes'
+
+/**
+ * Decision returned by {@link decideRowClickAction}.
+ *
+ * - `acknowledge` — call `acknowledge(compositeId)`. Used for `finished`
+ *   events: they have no natural transition to clear them, so a click is
+ *   the user saying "I saw it, it's done."
+ * - `dismiss` — call `dismiss(compositeId)`. Used for waiting events when
+ *   the user has opted into Slack/Gmail-style "click marks seen" mode. The
+ *   attention service re-surfaces the event on the next status transition
+ *   or via the idle-too-long escalation.
+ * - `none` — navigate only; leave the event in place.
+ */
+export type RowClickAction = 'acknowledge' | 'dismiss' | 'none'
+
+/**
+ * Pure decision used by `AttentionBellButton.handleRowClick`. Kept separate
+ * so it can be unit-tested without rendering React.
+ */
+export function decideRowClickAction(
+  kind: AttentionKind,
+  clickClearsWaiting: boolean
+): RowClickAction {
+  if (kind === 'finished') return 'acknowledge'
+  if (clickClearsWaiting) return 'dismiss'
+  return 'none'
+}

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -726,6 +726,26 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                   </SettingItem>
 
                   <SettingItem
+                    label="Mark seen on click"
+                    settingId="notify-click-clears-waiting"
+                    description="When on, clicking a row in the attention bell will navigate to the tab and clear the notification. The bell will re-surface the event if the session keeps waiting after a state change or stays idle past the escalation threshold. You can also toggle this mode inline from the bell dropdown header."
+                  >
+                    <label className="flex items-center gap-2 cursor-pointer">
+                      <input
+                        type="checkbox"
+                        checked={settings.attentionClickClearsWaiting}
+                        onChange={(e) =>
+                          applyNow({ attentionClickClearsWaiting: e.target.checked })
+                        }
+                        className="accent-[var(--dplex-accent)]"
+                      />
+                      <span className="text-[11px]" style={{ color: 'var(--dplex-text)' }}>
+                        Mark waiting notifications as seen when I click them
+                      </span>
+                    </label>
+                  </SettingItem>
+
+                  <SettingItem
                     label="Play sound"
                     settingId="notify-sound"
                     description="Use the OS default sound when a notification fires."

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -147,6 +147,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   dndTo: null,
   notificationCooldownSeconds: 30,
   idleTooLongMinutes: 5,
+  attentionClickClearsWaiting: false,
   worktreeDefaults: DEFAULT_WORKTREE_DEFAULTS,
   projectPanelShowFooter: true,
   gitPanel: {

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -133,6 +133,16 @@ export interface AppSettings {
   dndTo: string | null
   notificationCooldownSeconds: number
   idleTooLongMinutes: number
+  /**
+   * When true, clicking a row in the attention bell will navigate to the
+   * tab AND dismiss waiting events (`waitingForApproval`, `waitingForInput`),
+   * matching Slack/Gmail "click to mark seen" behavior. Finished events are
+   * always acknowledged on click regardless of this setting. The bell will
+   * re-surface dismissed events on the next status transition or via the
+   * idle-too-long escalation. Default is false to preserve historical
+   * behavior where row-click only navigates.
+   */
+  attentionClickClearsWaiting: boolean
   /** Global defaults for worktree creation (inherited by per-project settings). */
   worktreeDefaults: WorktreeDefaults
   /** Show the health footer bar at the bottom of the Projects panel. */

--- a/tests/unit/attention-row-click-action.test.ts
+++ b/tests/unit/attention-row-click-action.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { decideRowClickAction } from '../../src/renderer/src/components/attention/rowClickAction'
+
+describe('decideRowClickAction', () => {
+  it('always acknowledges finished events regardless of the setting', () => {
+    expect(decideRowClickAction('finished', false)).toBe('acknowledge')
+    expect(decideRowClickAction('finished', true)).toBe('acknowledge')
+  })
+
+  it('does nothing for waiting events when click-clears-waiting is off (default)', () => {
+    expect(decideRowClickAction('waitingForApproval', false)).toBe('none')
+    expect(decideRowClickAction('waitingForInput', false)).toBe('none')
+  })
+
+  it('dismisses waiting events when click-clears-waiting is on', () => {
+    expect(decideRowClickAction('waitingForApproval', true)).toBe('dismiss')
+    expect(decideRowClickAction('waitingForInput', true)).toBe('dismiss')
+  })
+})


### PR DESCRIPTION
Closes #59.

## Problem

Clicking a row in the attention bell for a session in `waitingForApproval` / `waitingForInput` state correctly navigates to the tab, but the event stays in the bell and keeps counting toward the unread badge. Only `finished` events are cleared on click. Reporter argued for Slack/Gmail-style "click = mark seen" UX.

The current behavior is intentional (the dedicated X button on each row is the explicit dismiss path; a row click is "passive — let me look"), but the alternative is reasonable. So this PR makes both available as a user choice.

## Changes

- New setting **`attentionClickClearsWaiting`** (default `false`, preserves historical behavior).
- Inline **mode pill** at the top of the bell dropdown header — shows the current mode and toggles it with one click. Uses theme `--dplex-accent` so it's readable on both light and dark themes.
- Mirror toggle under **Settings → Notifications → Mark seen on click**.
- Decision logic extracted into a pure helper (`rowClickAction.ts`) for testability.
- New unit test covers the helper at 100% (3 cases).

`finished` still always acknowledges on click — independent of the setting. The existing `dismiss()` flow handles re-surfacing: events come back on the next status transition or via `sweepIdle()` escalation.

## Verification

- `npm run typecheck` passes
- `npm run test:unit` — 328/328 passing, including 3 new tests
- Dual code review (Claude Opus 4.7 + GPT-5.5):
  - Opus flagged hardcoded `color: 'white'` invisible on light themes — fixed
  - GPT flagged stale `package-lock.json` version — fixed
