### PR TITLE
fix(status): poll pidfile registry as fallback for missed fs.watch events

### DIFF
--- a/src/main/services/providers/claudePidfileRegistry.ts
+++ b/src/main/services/providers/claudePidfileRegistry.ts
@@ -69,8 +69,25 @@ export class ClaudePidfileRegistry {
   private listeners = new Set<Listener>()
   private watcher: fs.FSWatcher | null = null
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>()
+  /**
+   * Polling timer that re-scans the directory at a fixed interval. Acts as a
+   * safety net for {@link fs.FSWatcher} missing events — on macOS, `fs.watch`
+   * is implemented via FSEvents and is known to miss in-place rewrites of
+   * small files (the exact pattern Claude Code uses for its pidfiles). When
+   * the watcher drops a `busy → waiting` transition, the UI stays stuck on
+   * the previous status (green "Running Tool" while the user is actually
+   * staring at an approval prompt). The poll guarantees eventual consistency
+   * within {@link POLL_MS}.
+   */
+  private pollTimer: ReturnType<typeof setInterval> | null = null
   private started = false
   private startPromise: Promise<void> | null = null
+  /**
+   * True after the first `scanAll` has notified subscribers. Lets the
+   * polling rescan stay silent in steady state while still seeding the
+   * initial state even when the directory is empty.
+   */
+  private seededSubscribers = false
   /**
    * Increments on every `stop()`. In-flight async operations (initial scan,
    * debounced refreshFile, attachWatcher) capture the generation at entry
@@ -80,6 +97,7 @@ export class ClaudePidfileRegistry {
   private generation = 0
 
   private static readonly DEBOUNCE_MS = 200
+  private static readonly POLL_MS = 2000
   private static readonly HEARTBEAT_FILE = '.fleetview-heartbeat'
 
   constructor(sessionsDir?: string) {
@@ -216,10 +234,15 @@ export class ClaudePidfileRegistry {
       }
       this.watcher = null
     }
+    if (this.pollTimer) {
+      clearInterval(this.pollTimer)
+      this.pollTimer = null
+    }
     for (const t of this.debounceTimers.values()) clearTimeout(t)
     this.debounceTimers.clear()
     this.snapshots.clear()
     this.bySessionId.clear()
+    this.seededSubscribers = false
   }
 
   // ── Internal ─────────────────────────────────────────────────────
@@ -238,6 +261,33 @@ export class ClaudePidfileRegistry {
     await this.scanAll(myGen)
     if (myGen !== this.generation) return
     this.attachWatcher()
+    this.attachPoller()
+  }
+
+  /**
+   * Periodic safety-net rescan. {@link fs.FSWatcher} drops events under
+   * a number of platform-specific conditions (FSEvents coalescing on macOS,
+   * non-recursive watches missing rapid sequential writes, network mounts,
+   * etc.). When that happens, snapshots silently drift away from the
+   * on-disk truth and downstream consumers (status dot colour, attention
+   * inbox, sessionStore) act on stale state.
+   *
+   * The poll is deliberately cheap: read directory listing, refresh each
+   * `.json` file, dedup unchanged snapshots via `shallowEqualSnapshot`.
+   * In the steady state (no pidfile mutations) it produces zero listener
+   * notifications. The first poll after a missed watcher event closes the
+   * status-detection gap within {@link POLL_MS}.
+   */
+  private attachPoller(): void {
+    if (this.pollTimer) clearInterval(this.pollTimer)
+    this.pollTimer = setInterval(() => {
+      const myGen = this.generation
+      void this.scanAll(myGen)
+    }, ClaudePidfileRegistry.POLL_MS)
+    // Allow the Node event loop to exit even when only the poller is left
+    // (matters in CLI/test contexts; harmless in Electron where the app
+    // process is held alive by other handles).
+    if (typeof this.pollTimer.unref === 'function') this.pollTimer.unref()
   }
 
   private attachWatcher(): void {
@@ -278,56 +328,81 @@ export class ClaudePidfileRegistry {
     }
     if (generation !== this.generation) return
     const seenPids = new Set<number>()
+    let changed = false
     for (const name of entries) {
       if (!name.endsWith('.json')) continue
       const pid = parseInt(name.slice(0, -5), 10)
       if (Number.isNaN(pid) || pid <= 0) continue
       seenPids.add(pid)
-      await this.refreshFile(path.join(this.dir, name), { silent: true, generation })
+      const fileChanged = await this.refreshFile(path.join(this.dir, name), {
+        silent: true,
+        generation
+      })
+      if (fileChanged) changed = true
       if (generation !== this.generation) return
     }
     // Drop any cached snapshots whose file no longer exists.
     for (const pid of [...this.snapshots.keys()]) {
-      if (!seenPids.has(pid)) this.removePid(pid)
+      if (!seenPids.has(pid)) {
+        if (this.removePid(pid)) changed = true
+      }
     }
-    this.notify()
+    // Always notify on the first scan so subscribers receive an initial
+    // seed even when the directory is empty. Subsequent polls only
+    // notify if something actually changed — keeping steady-state polling
+    // free of downstream parseSession/parse work.
+    if (changed || !this.seededSubscribers) {
+      this.seededSubscribers = true
+      this.notify()
+    }
   }
 
+  /**
+   * Read and apply a single pidfile's contents to the in-memory snapshot
+   * map. Returns `true` if applying the file produced an observable change
+   * (snapshot inserted, removed, or replaced with a non-shallow-equal
+   * value); `false` otherwise. The boolean is what lets {@link scanAll}
+   * stay quiet during steady-state polling.
+   */
   private async refreshFile(
     fullPath: string,
     opts: { silent?: boolean; generation?: number } = {}
-  ): Promise<void> {
+  ): Promise<boolean> {
     const gen = opts.generation ?? this.generation
     const base = path.basename(fullPath)
     const pid = parseInt(base.slice(0, -5), 10)
-    if (Number.isNaN(pid) || pid <= 0) return
+    if (Number.isNaN(pid) || pid <= 0) return false
 
     let raw: string
     try {
       raw = await fsp.readFile(fullPath, 'utf-8')
     } catch (err) {
-      if (gen !== this.generation) return
+      if (gen !== this.generation) return false
       if ((err as NodeJS.ErrnoException)?.code === 'ENOENT') {
-        if (this.removePid(pid) && !opts.silent) this.notify()
+        const removed = this.removePid(pid)
+        if (removed && !opts.silent) this.notify()
+        return removed
       }
-      return
+      return false
     }
-    if (gen !== this.generation) return
+    if (gen !== this.generation) return false
     let parsed: unknown
     try {
       parsed = JSON.parse(raw)
     } catch {
       // Truncated/partial write — debounced retry will pick it up.
-      return
+      return false
     }
     const snap = sanitizeSnapshot(pid, parsed)
-    if (!snap) return
+    if (!snap) return false
     if (!this.isLive(snap)) {
-      if (this.removePid(pid) && !opts.silent) this.notify()
-      return
+      const removed = this.removePid(pid)
+      if (removed && !opts.silent) this.notify()
+      return removed
     }
 
     const prev = this.snapshots.get(pid)
+    const changed = !shallowEqualSnapshot(prev, snap)
     this.snapshots.set(pid, snap)
 
     // Maintain bySessionId. Same sessionId may migrate between PIDs across
@@ -338,7 +413,8 @@ export class ClaudePidfileRegistry {
     }
     this.bySessionId.set(snap.sessionId, pid)
 
-    if (!opts.silent && !shallowEqualSnapshot(prev, snap)) this.notify()
+    if (!opts.silent && changed) this.notify()
+    return changed
   }
 
   private removePid(pid: number): boolean {

--- a/tests/unit/claude-pidfile-registry.test.ts
+++ b/tests/unit/claude-pidfile-registry.test.ts
@@ -165,4 +165,87 @@ describe('claudePidfileRegistry', () => {
 
     expect(registry.getBySessionId('sess-fresh')?.sessionId).toBe('sess-fresh')
   })
+
+  it('polling fallback catches status transitions when fs.watch misses an event', async () => {
+    // Repro: a pidfile rewrite is dropped by `fs.watch` (FSEvents coalescing
+    // on macOS is the most common cause in production — Claude's tight
+    // busy→waiting rewrite gets folded into a single FSEvents notification
+    // that the registry's debouncer then ignores). The polling rescan must
+    // still observe the new contents within POLL_MS and notify subscribers.
+    //
+    // To simulate the dropped event deterministically we stop the
+    // {@link fs.FSWatcher} immediately after the registry attaches it,
+    // leaving only the poller in place. If the poller is removed the test
+    // fails — exactly the regression we're guarding against.
+    const events: Array<{ status?: string; waitingFor?: string }> = []
+    registry.subscribe((snaps) => {
+      const s = snaps.find((x) => x.sessionId === 'sess-poll')
+      if (s) events.push({ status: s.status, waitingFor: s.waitingFor })
+    })
+
+    await writePidfile(tmpDir, process.pid, {
+      pid: process.pid,
+      sessionId: 'sess-poll',
+      cwd: '/repo',
+      status: 'busy',
+      detail: 'Bash · npm test'
+    })
+
+    // Let the initial scan + watcher attach complete.
+    await sleep(150)
+
+    // Forcibly close the FSWatcher to simulate FSEvents coalescing /
+    // platform unreliability. The next write therefore CANNOT be observed
+    // through fs.watch; only the poller can recover.
+    const internalWatcher = (registry as unknown as { watcher: { close(): void } | null }).watcher
+    if (internalWatcher) internalWatcher.close()
+    ;(registry as unknown as { watcher: unknown }).watcher = null
+
+    // Write the "missed" transition: busy → waiting (approve Bash).
+    await writePidfile(tmpDir, process.pid, {
+      pid: process.pid,
+      sessionId: 'sess-poll',
+      cwd: '/repo',
+      status: 'waiting',
+      waitingFor: 'approve Bash'
+    })
+
+    // Wait long enough for the 2-second poll to fire at least once.
+    await sleep(2500)
+
+    expect(registry.getBySessionId('sess-poll')?.status).toBe('waiting')
+    expect(registry.getBySessionId('sess-poll')?.waitingFor).toBe('approve Bash')
+    // Subscriber must have observed the transition.
+    expect(events.some((e) => e.status === 'waiting' && e.waitingFor === 'approve Bash')).toBe(
+      true
+    )
+  })
+
+  it('polling fallback stays quiet in steady state (no duplicate notifications)', async () => {
+    // The poll must NOT spam subscribers when nothing changes. Otherwise
+    // every downstream consumer (claudeCodeProvider → parseSession →
+    // attentionService) would re-run every POLL_MS for no reason.
+    await writePidfile(tmpDir, process.pid, {
+      pid: process.pid,
+      sessionId: 'sess-quiet',
+      cwd: '/r',
+      status: 'idle'
+    })
+
+    let notifyCount = 0
+    registry.subscribe(() => {
+      notifyCount++
+    })
+
+    // Wait for initial scan to seed the subscriber.
+    await sleep(150)
+    const afterSeed = notifyCount
+
+    // Sit through 2.5 polling intervals with no pidfile mutations.
+    await sleep(2500)
+
+    // Allow at most one extra notify (defensive — first interval after
+    // seeding may fire if seedSubscribers happens to land at boundary).
+    expect(notifyCount - afterSeed).toBeLessThanOrEqual(1)
+  })
 })


### PR DESCRIPTION
## Summary

Fixes #61 — a Claude Code session waiting on an approval prompt renders with the green pulsing "Running Tool" dot and never fires the attention bell.

`ClaudePidfileRegistry` was 100% event-driven on a single `fs.watch()` watcher with no polling fallback. On macOS, `fs.watch` (FSEvents) is well known to coalesce or drop notifications for in-place rewrites of small files — exactly how Claude Code mutates its pidfile from `status: "busy"` to `status: "waiting", waitingFor: "approve <Tool>"`. When that event is dropped, the in-memory snapshot stays stale forever (until the next subscriber-driven re-scan or app restart), and the entire status / attention pipeline downstream of it (`mapPidfileStatus`, `attentionService.ingestSessionUpdate`, `StatusDot`) silently acts on the wrong state.

### What changed

- **`src/main/services/providers/claudePidfileRegistry.ts`**:
  - Add a 2-second polling rescan as a safety net alongside `fs.watch`. The watcher remains the low-latency primary path; polling guarantees eventual consistency.
  - `scanAll` now tracks whether anything actually changed and only calls `notify()` when changes are observed (or on the very first scan, to seed subscribers) — so steady-state polling does not spam downstream consumers.
  - `refreshFile` returns a boolean indicating whether the snapshot changed, so `scanAll` can aggregate without duplicating shallow-equal logic.
  - The poll `setInterval` is `.unref()`'d to keep CLI/test contexts from being held open.

- **`tests/unit/claude-pidfile-registry.test.ts`**:
  - New: polling fallback catches a `busy → waiting` transition when `fs.watch` is forcibly silenced — this is the direct regression guard for #61.
  - New: polling fallback stays quiet in steady state — guards against accidentally re-introducing per-poll notify storms.

### Behavior

- Worst-case latency for a status transition (when `fs.watch` drops the event): **≤ 2s** (was: never observed until next subscribe / app restart).
- Best-case latency (when `fs.watch` fires): unchanged.
- Steady-state CPU: one `readdir` + N small `readFile`s every 2s. Existing snapshots use `shallowEqualSnapshot` dedup; no work propagates downstream when nothing changed.

## Test plan

- [x] `node node_modules/vitest/dist/cli.js run tests/unit/claude-pidfile-registry.test.ts` — 10/10 pass (8 existing + 2 new)
- [x] Full suite: `node node_modules/vitest/dist/cli.js run` — 330/330 pass
- [x] Typecheck: `tsc --noEmit -p tsconfig.node.json` — clean
- [ ] Manual verification (will follow up with screen recording once dev build is running): trigger a Bash approval prompt and confirm the dot turns red + bell fires within ~2s without restarting the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
