### PR TITLE
Project tags, color picker, and command palette polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.0] — 2026-05-13
+
+### Features
+
+- Tag your projects to group related ones together, then filter the
+  projects sidebar with one click on a tag chip. Right-click a project
+  → **Tags…** to add, remove, or create tags.
+- Pick a color for each tag from an 8-swatch palette (or let DPlex
+  assign one automatically). Tag colors are shared across the sidebar
+  and command palette, so the same tag always looks the same.
+- Global search (⌘P) now matches projects by tag — type `#infra` to
+  filter, or just type a tag name. Each project result shows its
+  avatar and tag pills so you can see why it matched.
+- New **Search** button in the status bar opens the command palette,
+  with its ⌘P shortcut shown right on the button.
+
+### Improvements
+
+- Filtering projects by tag keeps a parent's worktree branches visible
+  underneath it, so a tag on the origin pulls the whole tree along.
+- Project rows fit as many tag pills as actually have room, then
+  surface the rest as a `+N` chip whose tooltip lists what's hidden —
+  nothing is silently clipped.
+
 ## [0.15.0] — 2026-05-12
 
 ### Features
@@ -445,7 +469,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.16.0...HEAD
+[0.16.0]: https://github.com/Ron537/DPlex/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/Ron537/DPlex/compare/v0.14.2...v0.15.0
 [0.14.2]: https://github.com/Ron537/DPlex/compare/v0.14.1...v0.14.2
 [0.14.1]: https://github.com/Ron537/DPlex/compare/v0.14.0...v0.14.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/renderer/src/components/layout/SidePanel.tsx
+++ b/src/renderer/src/components/layout/SidePanel.tsx
@@ -15,6 +15,7 @@ import { useProvidersStore } from '../../stores/providersStore'
 import { useProjectStore } from '../../stores/projectStore'
 import { SessionList } from '../sessions/SessionList'
 import { ProjectList } from '../projects/ProjectList'
+import { TagFilterBar } from '../projects/TagFilterBar'
 import { ProjectPanelFooter } from '../projects/ProjectPanelFooter'
 import { SessionPanelFooter } from '../sessions/SessionPanelFooter'
 import { GitSidePanelView } from '../git/GitSidePanelView'
@@ -54,6 +55,7 @@ export function SidePanel(): React.JSX.Element | null {
   const [showFilterMenu, setShowFilterMenu] = useState(false)
   const [projectSearchQuery, setProjectSearchQuery] = useState('')
   const [projectActiveOnly, setProjectActiveOnly] = useState(false)
+  const [projectTagFilter, setProjectTagFilter] = useState<string | null>(null)
   const [showProjectFilterMenu, setShowProjectFilterMenu] = useState(false)
   // Collapse-all signal for SessionList groups. The nonce bumps each time
   // the user clicks the toolbar button so each <CollapsibleGroup> can react
@@ -460,7 +462,14 @@ export function SidePanel(): React.JSX.Element | null {
 
           <div className="flex-1 overflow-y-auto dplex-scroll-autohide">
             {activeTab === 'projects' ? (
-              <ProjectList searchQuery={projectSearchQuery} activeOnly={projectActiveOnly} />
+              <>
+                <TagFilterBar value={projectTagFilter} onChange={setProjectTagFilter} />
+                <ProjectList
+                  searchQuery={projectSearchQuery}
+                  activeOnly={projectActiveOnly}
+                  tagFilter={projectTagFilter}
+                />
+              </>
             ) : (
               <SessionList
                 groupMode={groupMode}

--- a/src/renderer/src/components/layout/StatusBar.tsx
+++ b/src/renderer/src/components/layout/StatusBar.tsx
@@ -1,7 +1,8 @@
-import { Terminal, PanelLeftOpen, PanelLeftClose, Settings } from 'lucide-react'
+import { Terminal, PanelLeftOpen, PanelLeftClose, Settings, Search } from 'lucide-react'
 import { useTerminalStore } from '../../stores/terminalStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useSessionStore } from '../../stores/sessionStore'
+import { useCommandPaletteStore } from '../../stores/commandPaletteStore'
 import { MOD } from '../../utils/shortcuts'
 
 interface StatusBarProps {
@@ -40,6 +41,30 @@ export function StatusBar({ onOpenSettings }: StatusBarProps): React.JSX.Element
           title={panelCollapsed ? `Show panel (${MOD}B)` : `Hide panel (${MOD}B)`}
         >
           {panelCollapsed ? <PanelLeftOpen size={13} /> : <PanelLeftClose size={13} />}
+        </button>
+        <button
+          onClick={() => useCommandPaletteStore.getState().toggle('all')}
+          className="inline-flex items-center gap-1.5 px-2 rounded-full hover:bg-[var(--dplex-hover)] transition-colors flex-shrink-0"
+          style={{ height: 18, color: 'var(--dplex-text-muted)' }}
+          title="Search projects, sessions, settings (try #tag)"
+          aria-label={`Open command palette (${MOD}P)`}
+        >
+          <Search size={11} />
+          <span>Search</span>
+          <kbd
+            className="font-medium"
+            style={{
+              fontSize: 10,
+              padding: '0 4px',
+              borderRadius: 3,
+              border: '1px solid var(--dplex-border)',
+              color: 'var(--dplex-text-dim)',
+              backgroundColor: 'var(--dplex-bg-input)',
+              fontFamily: 'inherit'
+            }}
+          >
+            {MOD}P
+          </kbd>
         </button>
       </div>
       <div className="flex items-center gap-3 pr-1 min-w-0">

--- a/src/renderer/src/components/projects/InlineTagList.tsx
+++ b/src/renderer/src/components/projects/InlineTagList.tsx
@@ -1,0 +1,150 @@
+import { useLayoutEffect, useRef, useState } from 'react'
+import { TagPill } from './TagPill'
+
+interface InlineTagListProps {
+  tags: readonly string[]
+}
+
+/** Gap between tag pills, in px. Mirrors the Tailwind `gap-1` we apply to
+ *  the row so width math matches what flex actually lays out. */
+const GAP_PX = 4
+
+/**
+ * Renders project tag pills inline, fitting as many as actually fit in the
+ * available row width. Anything that doesn't fit is rolled into a neutral
+ * `+N` chip with a tooltip listing the hidden tags.
+ *
+ * Strategy:
+ *   1. Render an invisible measurement layer containing every tag pill plus
+ *      a `+N` sample chip. The layer is absolutely-positioned inside the
+ *      container so it doesn't influence layout but its children still get
+ *      real widths from the browser.
+ *   2. After layout, compute the largest prefix that fits (including the
+ *      `+N` chip's width whenever there will be overflow).
+ *   3. Render the visible row from that prefix; rerun on container resize.
+ *
+ * Two renders per resize is fine — the second one is cheap (same DOM, just
+ * fewer visible nodes) and only happens when the container actually changes
+ * size. The measurement layer is keyed on the tag list so adding/removing a
+ * tag re-runs measurement automatically.
+ */
+export function InlineTagList({ tags }: InlineTagListProps): React.JSX.Element | null {
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const measureRef = useRef<HTMLDivElement | null>(null)
+  const [visibleCount, setVisibleCount] = useState(tags.length)
+
+  useLayoutEffect(() => {
+    const container = containerRef.current
+    const measure = measureRef.current
+    if (!container || !measure) return
+
+    const recompute = (): void => {
+      const available = container.clientWidth
+      const measureChildren = Array.from(
+        measure.querySelectorAll<HTMLElement>('[data-tag-measure]')
+      )
+      const plusEl = measure.querySelector<HTMLElement>('[data-tag-plus]')
+      if (measureChildren.length !== tags.length) return
+      const widths = measureChildren.map((el) => el.offsetWidth)
+      const plusWidth = plusEl?.offsetWidth ?? 0
+
+      // Fast path: does the entire list fit?
+      const totalAll =
+        widths.reduce((s, w) => s + w, 0) + Math.max(0, widths.length - 1) * GAP_PX
+      if (totalAll <= available) {
+        setVisibleCount((prev) => (prev === tags.length ? prev : tags.length))
+        return
+      }
+
+      // Otherwise find the largest k such that the first k pills plus a
+      // `+N` chip fit. The `+N` chip itself needs space, so we always
+      // account for its width + a gap before it.
+      let acc = 0
+      let k = 0
+      for (let i = 0; i < widths.length; i++) {
+        const candidate = acc + (k > 0 ? GAP_PX : 0) + widths[i] + GAP_PX + plusWidth
+        if (candidate > available) break
+        acc += (k > 0 ? GAP_PX : 0) + widths[i]
+        k++
+      }
+      setVisibleCount((prev) => (prev === k ? prev : k))
+    }
+
+    recompute()
+    const ro = new ResizeObserver(recompute)
+    ro.observe(container)
+    return () => ro.disconnect()
+  }, [tags])
+
+  if (tags.length === 0) return null
+
+  const hiddenCount = Math.max(0, tags.length - visibleCount)
+  const visibleTags = tags.slice(0, visibleCount)
+  const hiddenTags = tags.slice(visibleCount)
+
+  return (
+    <div
+      ref={containerRef}
+      className="flex items-center gap-1 min-w-0 relative w-full overflow-hidden"
+    >
+      {/* Invisible measurement layer — same pills + a sample `+N` chip used
+          only for width readings. Absolute so it doesn't affect layout. */}
+      <div
+        ref={measureRef}
+        aria-hidden
+        className="flex items-center gap-1"
+        style={{
+          position: 'absolute',
+          left: 0,
+          top: 0,
+          visibility: 'hidden',
+          pointerEvents: 'none',
+          whiteSpace: 'nowrap'
+        }}
+      >
+        {tags.map((t) => (
+          <span key={t} data-tag-measure>
+            <TagPill tag={t} compact />
+          </span>
+        ))}
+        <span data-tag-plus>
+          <PlusBadge count={Math.max(1, tags.length)} />
+        </span>
+      </div>
+
+      {/* Visible row */}
+      {visibleTags.map((t) => (
+        <TagPill key={t} tag={t} compact />
+      ))}
+      {hiddenCount > 0 && (
+        <PlusBadge count={hiddenCount} tooltipTags={hiddenTags} />
+      )}
+    </div>
+  )
+}
+
+function PlusBadge({
+  count,
+  tooltipTags
+}: {
+  count: number
+  tooltipTags?: readonly string[]
+}): React.JSX.Element {
+  return (
+    <span
+      title={tooltipTags ? tooltipTags.map((t) => `#${t}`).join(', ') : undefined}
+      className="inline-flex items-center rounded-full font-medium leading-none whitespace-nowrap"
+      style={{
+        fontSize: 9.5,
+        padding: '1px 5px',
+        backgroundColor: 'var(--dplex-bg-input)',
+        color: 'var(--dplex-text-muted)',
+        border: '1px solid var(--dplex-border)',
+        userSelect: 'none',
+        flexShrink: 0
+      }}
+    >
+      +{count}
+    </span>
+  )
+}

--- a/src/renderer/src/components/projects/ProjectAvatar.tsx
+++ b/src/renderer/src/components/projects/ProjectAvatar.tsx
@@ -1,0 +1,42 @@
+import { memo } from 'react'
+import { getAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
+
+interface ProjectAvatarProps {
+  /** Stable id used to derive the deterministic avatar color. */
+  projectId: string
+  /** Project name used to derive the 1-2 letter glyph. */
+  name: string
+  /** Square size in px. Defaults to 22 — the size used in the command palette. */
+  size?: number
+}
+
+/**
+ * Small square project avatar — deterministic color + initials glyph derived
+ * from the project's id/name. Used in surfaces that aren't `ProjectItem`
+ * (e.g. the command palette) so they share the same visual identity as the
+ * sidebar without duplicating the styling logic.
+ */
+export const ProjectAvatar = memo(function ProjectAvatar({
+  projectId,
+  name,
+  size = 22
+}: ProjectAvatarProps): React.JSX.Element {
+  const color = getAvatarColor(projectId)
+  const initials = getAvatarInitials(name)
+  return (
+    <span
+      aria-hidden
+      className="inline-flex items-center justify-center rounded-md font-bold leading-none"
+      style={{
+        width: size,
+        height: size,
+        backgroundColor: color.bg,
+        color: color.fg,
+        fontSize: Math.max(9, Math.round(size * 0.42)),
+        flexShrink: 0
+      }}
+    >
+      {initials}
+    </span>
+  )
+})

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -14,7 +14,8 @@ import {
   PinOff,
   ArrowUp,
   ArrowDown,
-  GitCompare
+  GitCompare,
+  Tag as TagIcon
 } from 'lucide-react'
 import type { Project, AISession, ProviderInfo, WorktreeDefaults } from '../../types'
 import { useProjectStore } from '../../stores/projectStore'
@@ -29,6 +30,8 @@ import { isMixedProviderList } from '../../utils/providerHelpers'
 import { aggregateVisual } from '../../utils/aggregateVisual'
 import { PromptsDialog } from '../sessions/PromptsDialog'
 import { ProjectSessionList, selectRecentSessions } from './ProjectSessionList'
+import { InlineTagList } from './InlineTagList'
+import { TagPickerPopover } from './TagPickerPopover'
 import { WorktreeSection } from './WorktreeSection'
 import type { ProjectActivity } from '../../hooks/useProjectSessions'
 import { focusFirstTabForPaths } from '../../utils/sessionTabs'
@@ -52,6 +55,10 @@ interface ProjectItemProps {
   moveUpTargetId?: string | null
   /** Id of the next top-level sibling in the same pinned group (for "Move down"). */
   moveDownTargetId?: string | null
+  /** Render the expanded body regardless of the user's persisted expansion
+   *  state. Used by `ProjectList` in filter mode so a matched parent shows
+   *  its full worktree subtree even when the user had it collapsed. */
+  forceExpanded?: boolean
 }
 
 /**
@@ -78,7 +85,8 @@ export function ProjectItem({
   childProjects,
   getActivity,
   moveUpTargetId = null,
-  moveDownTargetId = null
+  moveDownTargetId = null,
+  forceExpanded = false
 }: ProjectItemProps): React.JSX.Element {
   const expandedIds = useProjectStore((s) => s.expandedProjectIds)
   const toggleExpanded = useProjectStore((s) => s.toggleExpanded)
@@ -107,6 +115,8 @@ export function ProjectItem({
   const [manageOpen, setManageOpen] = useState(false)
   const [defaultsOpen, setDefaultsOpen] = useState(false)
   const [removeWtOpen, setRemoveWtOpen] = useState(false)
+  const [tagPickerOpen, setTagPickerOpen] = useState(false)
+  const tagPickerAnchorRef = useRef<HTMLDivElement>(null)
   const menuAnchorRef = useRef<HTMLButtonElement>(null)
   // Virtual anchor for right-click context menu — positioned at the cursor
   // so the menu opens where the user clicked (not next to the ⋯ button).
@@ -129,7 +139,7 @@ export function ProjectItem({
   const watchPath = isWorktreeProject ? (project.parentRepoPath ?? project.path) : project.path
   const { repoRoot } = useWorktrees(needWtWatch ? watchPath : undefined)
 
-  const isExpanded = expandedIds.has(project.id)
+  const isExpanded = forceExpanded || expandedIds.has(project.id)
   // The project row reads as "active" when it's the directly-active project
   // OR when one of its worktree-child projects is active. The latter case
   // is the "ambient parent highlight" — selecting a worktree section under
@@ -205,6 +215,7 @@ export function ProjectItem({
           alone, and the expanded body hangs below with an indent + dashed
           guide line (matches the mockup's `.proj-children`). */}
       <div
+        ref={tagPickerAnchorRef}
         data-project-id={project.id}
         className="group flex items-center gap-2.5 pl-3 pr-2.5 py-2 cursor-pointer relative rounded-lg transition-colors"
         style={{
@@ -233,9 +244,7 @@ export function ProjectItem({
           // store state after that would mis-classify a freshly-clicked
           // collapsed project as "already expanded" and immediately
           // collapse it again.
-          const wasExpandedBefore = useProjectStore
-            .getState()
-            .expandedProjectIds.has(project.id)
+          const wasExpandedBefore = useProjectStore.getState().expandedProjectIds.has(project.id)
           const wasEmphasizedBefore =
             useProjectStore.getState().lastExpandedProjectId === project.id
 
@@ -366,6 +375,14 @@ export function ProjectItem({
                 )
               })()}
           </div>
+          {/* Line 3 (tags) — rendered on its own row so the hover-revealed
+              action buttons (absolute, vertically-centered) only mask the
+              branch+time line and leave tags fully visible. `InlineTagList`
+              measures actual pill widths and surfaces overflow as a `+N`
+              chip whose tooltip lists the hidden tags. */}
+          {project.tags && project.tags.length > 0 && (
+            <InlineTagList tags={project.tags} />
+          )}
         </div>
 
         {/* Chevron — right-aligned, grey. Clicking always toggles expansion,
@@ -561,6 +578,20 @@ export function ProjectItem({
             </button>
           )}
 
+          <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+          <button
+            onClick={(e) => {
+              e.stopPropagation()
+              setShowMenu(false)
+              setContextMenuPos(null)
+              setTagPickerOpen(true)
+            }}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            <TagIcon size={11} /> Tags…
+          </button>
+
           {canPin && (
             <>
               <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
@@ -627,6 +658,13 @@ export function ProjectItem({
             <Trash2 size={11} /> {isWorktreeProject ? 'Remove worktree…' : 'Remove Project'}
           </button>
         </PopoverMenu>
+
+        <TagPickerPopover
+          projectId={project.id}
+          open={tagPickerOpen}
+          onClose={() => setTagPickerOpen(false)}
+          anchorRef={tagPickerAnchorRef}
+        />
       </div>
 
       {/* Expanded body — nested under the project row with a dashed left

--- a/src/renderer/src/components/projects/ProjectList.tsx
+++ b/src/renderer/src/components/projects/ProjectList.tsx
@@ -26,6 +26,9 @@ const EMPTY_ATTENTION: AttentionEvent[] = []
 interface ProjectListProps {
   searchQuery?: string
   activeOnly?: boolean
+  /** Single tag to filter by. A project matches if it carries this tag OR
+   *  has a worktree child that carries it. Null/undefined means no tag filter. */
+  tagFilter?: string | null
   /** Render the rail-style avatar-only column instead of full rows. */
   compact?: boolean
 }
@@ -38,6 +41,7 @@ interface ProjectEntry {
 export function ProjectList({
   searchQuery,
   activeOnly,
+  tagFilter,
   compact
 }: ProjectListProps): React.JSX.Element {
   const projects = useProjectStore((s) => s.projects)
@@ -104,7 +108,7 @@ export function ProjectList({
     return m
   }, [projects])
 
-  const hasFilter = Boolean(searchQuery) || Boolean(activeOnly)
+  const hasFilter = Boolean(searchQuery) || Boolean(activeOnly) || Boolean(tagFilter)
 
   // Render-order projects. Only top-level origins render directly here — their
   // worktree children render INSIDE the parent's expanded body (so they share
@@ -119,6 +123,7 @@ export function ProjectList({
     const matchesFilter = (p: Project): boolean => {
       if (q && !p.name.toLowerCase().includes(q)) return false
       if (activeOnly && !sessionIndex.get(p.path)?.hasActive) return false
+      if (tagFilter && !(p.tags?.includes(tagFilter) ?? false)) return false
       return true
     }
 
@@ -134,13 +139,22 @@ export function ProjectList({
       if (!isTopLevel(p)) continue
 
       const kids = childrenByParent.get(p.id) ?? []
-      const visibleKids = kids.filter(matchesFilter)
       const parentMatches = matchesFilter(p)
 
       if (hasFilter) {
-        // Flat match list while filtering — pinning ignored for clarity.
-        if (parentMatches) restOut.push({ project: p })
-        for (const kid of visibleKids) restOut.push({ project: kid })
+        if (parentMatches) {
+          // Parent matches → render with the FULL worktree subtree, even if
+          // individual worktrees don't satisfy the filter. A matching parent
+          // is a strong "I want this project" signal, and worktrees inherit
+          // that context (a tag like `#client-acme` on the origin clearly
+          // applies to its branches too).
+          restOut.push({ project: p, children: kids })
+        } else {
+          // Parent doesn't match → surface any worktree children that DO
+          // match as top-level rows so a matching branch isn't hidden
+          // behind a non-matching origin.
+          for (const kid of kids.filter(matchesFilter)) restOut.push({ project: kid })
+        }
       } else {
         const entry: ProjectEntry = { project: p, children: kids }
         if (p.pinned) pinnedOut.push(entry)
@@ -148,7 +162,7 @@ export function ProjectList({
       }
     }
     return { pinned: pinnedOut, rest: restOut }
-  }, [projects, childrenByParent, searchQuery, activeOnly, sessionIndex, hasFilter])
+  }, [projects, childrenByParent, searchQuery, activeOnly, tagFilter, sessionIndex, hasFilter])
 
   const totalVisible = pinned.length + rest.length
 
@@ -206,6 +220,7 @@ export function ProjectList({
       providers={providers}
       moveUpTargetId={index > 0 ? list[index - 1].project.id : null}
       moveDownTargetId={index < list.length - 1 ? list[index + 1].project.id : null}
+      forceExpanded={hasFilter && children !== undefined && children.length > 0}
     />
   )
 

--- a/src/renderer/src/components/projects/TagFilterBar.tsx
+++ b/src/renderer/src/components/projects/TagFilterBar.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useMemo } from 'react'
+import { useProjectStore } from '../../stores/projectStore'
+import { collectTagCounts } from '../../utils/projectTags'
+import { TagPill } from './TagPill'
+
+interface TagFilterBarProps {
+  /** Currently selected tag, or null for "All". */
+  value: string | null
+  onChange: (next: string | null) => void
+}
+
+/**
+ * Horizontal strip of tag-filter chips rendered between the projects search
+ * input and the project list. Renders nothing when no project has any tag —
+ * keeps the panel uncluttered for users who don't use tags.
+ *
+ * Single-select for now: clicking a tag activates it; clicking it again (or
+ * clicking "All") clears. Multi-select / AND-composition is a future slice.
+ */
+export function TagFilterBar({ value, onChange }: TagFilterBarProps): React.JSX.Element | null {
+  const projects = useProjectStore((s) => s.projects)
+  const tagCounts = useMemo(() => collectTagCounts(projects), [projects])
+
+  // Self-heal a stale filter: if the active tag no longer exists on any
+  // project (last project carrying it was removed or untagged), clear the
+  // filter so the user isn't left with an empty list and no visible reset
+  // affordance. Done in an effect so the parent owns the state.
+  const tagExists = !value || tagCounts.some((t) => t.tag === value)
+  useEffect(() => {
+    if (!tagExists) onChange(null)
+  }, [tagExists, onChange])
+
+  if (tagCounts.length === 0) return null
+
+  const totalCount = projects.length
+
+  return (
+    <div
+      className="flex flex-wrap gap-1.5 px-3 pt-1 pb-2.5"
+      style={{ borderBottom: '1px solid var(--dplex-border)' }}
+      role="tablist"
+      aria-label="Filter projects by tag"
+    >
+      <button
+        type="button"
+        onClick={() => onChange(null)}
+        role="tab"
+        aria-selected={value === null}
+        className="inline-flex items-center gap-1 rounded-full font-medium leading-none whitespace-nowrap transition-colors"
+        style={{
+          fontSize: 11,
+          padding: '2px 8px',
+          backgroundColor: value === null ? 'var(--dplex-accent-soft)' : 'var(--dplex-bg-input)',
+          color: value === null ? 'var(--dplex-accent)' : 'var(--dplex-text-muted)',
+          border:
+            value === null ? '1px solid var(--dplex-accent)' : '1px solid var(--dplex-border)',
+          cursor: 'pointer',
+          userSelect: 'none'
+        }}
+      >
+        All
+        <span style={{ opacity: 0.7, fontSize: 10 }}>{totalCount}</span>
+      </button>
+      {tagCounts.map(({ tag, count }) => (
+        <TagPill
+          key={tag}
+          tag={tag}
+          count={count}
+          active={value === tag}
+          onClick={() => onChange(value === tag ? null : tag)}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/projects/TagPickerPopover.tsx
+++ b/src/renderer/src/components/projects/TagPickerPopover.tsx
@@ -1,0 +1,369 @@
+import { useMemo, useRef, useState, useEffect, type RefObject } from 'react'
+import { Check, Plus, Tag, X } from 'lucide-react'
+import { PopoverMenu } from '../common/PopoverMenu'
+import { useProjectStore } from '../../stores/projectStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { normalizeTag, collectTagCounts, TAG_PALETTE, getTagColor } from '../../utils/projectTags'
+import { TagPill } from './TagPill'
+
+interface TagPickerPopoverProps {
+  projectId: string
+  open: boolean
+  onClose: () => void
+  anchorRef: RefObject<HTMLElement | null>
+}
+
+/**
+ * Multi-select tag editor for a single project. Opens from the project's
+ * context menu and lets the user toggle existing tags or create new ones.
+ *
+ * Suggestions come from the union of all tags across all projects so users
+ * can pick from a shared vocabulary without retyping. The input doubles as
+ * a filter for that list and as a "create tag" affordance — pressing Enter
+ * commits the normalized input as a new tag on this project.
+ */
+export function TagPickerPopover({
+  projectId,
+  open,
+  onClose,
+  anchorRef
+}: TagPickerPopoverProps): React.JSX.Element | null {
+  const projects = useProjectStore((s) => s.projects)
+  const addProjectTag = useProjectStore((s) => s.addProjectTag)
+  const removeProjectTag = useProjectStore((s) => s.removeProjectTag)
+  const tagColors = useSettingsStore((s) => s.settings.tagColors)
+  const updateSettings = useSettingsStore((s) => s.updateSettings)
+  const project = projects.find((p) => p.id === projectId)
+
+  const [input, setInput] = useState('')
+  /** Which tag currently has its swatch row expanded. Single-target so the
+   *  popover height stays predictable; clicking another tag's swatch swap
+   *  closes the previous one. */
+  const [colorTarget, setColorTarget] = useState<string | null>(null)
+  /** Color the user has picked for the tag they're about to create. While
+   *  typing, the create preview pill is locked to this color so it doesn't
+   *  shimmer between palette entries as the hash of the input changes on
+   *  every keystroke. Defaults to the first palette entry; resets when the
+   *  popover closes or after a successful commit. */
+  const [draftColor, setDraftColor] = useState<string>(TAG_PALETTE[0].id)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  // Reset & focus when the popover opens; on close, reset transient picker
+  // state. Both branches defer their setState calls through a timeout so the
+  // effect body itself stays free of synchronous setState (satisfies
+  // react-hooks/set-state-in-effect) and so the close-time resets run after
+  // the PopoverMenu has unmounted.
+  useEffect(() => {
+    if (!open) {
+      const t0 = setTimeout(() => {
+        setColorTarget(null)
+        setDraftColor(TAG_PALETTE[0].id)
+      }, 0)
+      return () => clearTimeout(t0)
+    }
+    const t = setTimeout(() => {
+      setInput('')
+      inputRef.current?.focus()
+    }, 30)
+    return () => clearTimeout(t)
+  }, [open])
+
+  const allTags = useMemo(() => collectTagCounts(projects).map((c) => c.tag), [projects])
+
+  const currentTags = useMemo(() => project?.tags ?? [], [project?.tags])
+  const currentSet = useMemo(() => new Set(currentTags), [currentTags])
+
+  const normalizedInput = normalizeTag(input)
+  // Filter using the normalized input so typing `#infra` matches the stored
+  // tag `infra`. Falling back to the raw lowercased input would hide every
+  // existing suggestion the moment the user types `#`.
+  const filterKey = normalizedInput ?? input.trim().toLowerCase()
+  const filtered = useMemo(() => {
+    if (!filterKey) return allTags
+    return allTags.filter((t) => t.includes(filterKey))
+  }, [allTags, filterKey])
+
+  const canCreate = normalizedInput !== null && !allTags.includes(normalizedInput)
+
+  const commit = (tag: string): void => {
+    addProjectTag(projectId, tag)
+    // Only persist a color when creating a brand-new tag — pressing Enter
+    // on an existing tag (whose Create row isn't shown) must not silently
+    // overwrite its globally-shared color.
+    if (canCreate) {
+      const autoId = getTagColor(tag).id
+      if (draftColor !== autoId) {
+        setTagColor(tag, draftColor)
+      }
+    }
+    setInput('')
+    setDraftColor(TAG_PALETTE[0].id)
+    inputRef.current?.focus()
+  }
+
+  // Color picker writes to the shared `tagColors` settings record (a tag's
+  // color is global, not per-project). Passing `null` removes the override
+  // and the tag falls back to the deterministic hash color.
+  const setTagColor = (tag: string, colorId: string | null): void => {
+    const next: Record<string, string> = { ...(tagColors ?? {}) }
+    if (colorId === null) delete next[tag]
+    else next[tag] = colorId
+    void updateSettings({ tagColors: next })
+  }
+
+  if (!project) return null
+
+  return (
+    <PopoverMenu
+      anchorRef={anchorRef}
+      open={open}
+      onClose={onClose}
+      align="left"
+      className="min-w-[240px]"
+    >
+      <div className="px-3 py-2">
+        <div
+          className="flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider mb-2"
+          style={{ color: 'var(--dplex-text-dim)' }}
+        >
+          <Tag size={10} />
+          Tags for {project.name}
+        </div>
+
+        {currentTags.length > 0 && (
+          <div className="flex flex-wrap gap-1 mb-2">
+            {currentTags.map((t) => (
+              <TagPill
+                key={t}
+                tag={t}
+                onClick={(e) => {
+                  e.stopPropagation()
+                  removeProjectTag(projectId, t)
+                }}
+                title={`Remove #${t}`}
+              />
+            ))}
+          </div>
+        )}
+
+        <input
+          ref={inputRef}
+          type="text"
+          value={input}
+          placeholder="Find or create tag…"
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              e.preventDefault()
+              if (normalizedInput) commit(normalizedInput)
+            } else if (e.key === 'Escape') {
+              e.preventDefault()
+              onClose()
+            }
+          }}
+          className="w-full text-[12px] outline-none"
+          style={{
+            backgroundColor: 'var(--dplex-bg-input)',
+            border: '1px solid var(--dplex-border)',
+            borderRadius: 6,
+            color: 'var(--dplex-text)',
+            padding: '5px 8px',
+            fontFamily: 'inherit'
+          }}
+        />
+      </div>
+
+      <div className="max-h-[260px] overflow-y-auto">
+        {filtered.length === 0 && !canCreate && (
+          <div className="px-3 py-2 text-[11px]" style={{ color: 'var(--dplex-text-muted)' }}>
+            No tags yet. Type to create one.
+          </div>
+        )}
+        {filtered.map((tag) => {
+          const isOn = currentSet.has(tag)
+          const isColorOpen = colorTarget === tag
+          const currentColorId = tagColors?.[tag] ?? null
+          return (
+            <div key={tag}>
+              <div className="flex items-stretch group">
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    if (isOn) removeProjectTag(projectId, tag)
+                    else addProjectTag(projectId, tag)
+                  }}
+                  className="flex items-center gap-2 flex-1 min-w-0 px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+                  style={{ color: 'var(--dplex-text)' }}
+                >
+                  <span
+                    style={{
+                      width: 12,
+                      display: 'inline-flex',
+                      justifyContent: 'center',
+                      color: isOn ? 'var(--dplex-accent)' : 'transparent'
+                    }}
+                  >
+                    <Check size={11} />
+                  </span>
+                  <TagPill tag={tag} />
+                </button>
+                <button
+                  type="button"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setColorTarget(isColorOpen ? null : tag)
+                  }}
+                  title={`Change color for #${tag}`}
+                  aria-label={`Change color for #${tag}`}
+                  className="px-2 hover:bg-[var(--dplex-hover)] flex items-center"
+                >
+                  <span
+                    style={{
+                      width: 12,
+                      height: 12,
+                      borderRadius: 999,
+                      backgroundColor: getTagColor(tag, currentColorId).fg,
+                      border: '1px solid var(--dplex-border)',
+                      opacity: isColorOpen ? 1 : 0.7
+                    }}
+                  />
+                </button>
+              </div>
+              {isColorOpen && (
+                <div
+                  className="flex items-center gap-1 px-3 py-2"
+                  style={{
+                    backgroundColor: 'var(--dplex-bg-alt)',
+                    borderTop: '1px solid var(--dplex-border)',
+                    borderBottom: '1px solid var(--dplex-border)'
+                  }}
+                >
+                  {TAG_PALETTE.map((c) => {
+                    const selected = currentColorId === c.id
+                    return (
+                      <button
+                        key={c.id}
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation()
+                          setTagColor(tag, c.id)
+                        }}
+                        title={c.label}
+                        aria-label={`Set #${tag} color to ${c.label}`}
+                        aria-pressed={selected}
+                        className="flex items-center justify-center"
+                        style={{
+                          width: 20,
+                          height: 20,
+                          borderRadius: 999,
+                          padding: 0,
+                          backgroundColor: c.bg,
+                          border: `2px solid ${selected ? c.fg : 'transparent'}`,
+                          cursor: 'pointer'
+                        }}
+                      >
+                        <span
+                          style={{
+                            width: 10,
+                            height: 10,
+                            borderRadius: 999,
+                            backgroundColor: c.fg
+                          }}
+                        />
+                      </button>
+                    )
+                  })}
+                  <button
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setTagColor(tag, null)
+                    }}
+                    title="Reset to default (auto)"
+                    aria-label={`Reset #${tag} color to default`}
+                    className="ml-1 flex items-center justify-center hover:bg-[var(--dplex-hover)]"
+                    style={{
+                      width: 20,
+                      height: 20,
+                      borderRadius: 999,
+                      border: '1px dashed var(--dplex-border)',
+                      color: 'var(--dplex-text-muted)',
+                      backgroundColor: 'transparent',
+                      cursor: 'pointer'
+                    }}
+                  >
+                    <X size={10} />
+                  </button>
+                </div>
+              )}
+            </div>
+          )
+        })}
+        {canCreate && normalizedInput && (
+          <div
+            style={{
+              borderTop: filtered.length > 0 ? '1px solid var(--dplex-border)' : 'none'
+            }}
+          >
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                commit(normalizedInput)
+              }}
+              className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+              style={{ color: 'var(--dplex-accent)' }}
+            >
+              <Plus size={11} />
+              Create <TagPill tag={normalizedInput} colorOverride={draftColor} />
+            </button>
+            <div
+              className="flex items-center gap-1 px-3 py-2"
+              style={{ backgroundColor: 'var(--dplex-bg-alt)' }}
+            >
+              {TAG_PALETTE.map((c) => {
+                const selected = draftColor === c.id
+                return (
+                  <button
+                    key={c.id}
+                    type="button"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      setDraftColor(c.id)
+                      // Keep focus on the text input so the user can press
+                      // Enter to commit immediately after picking a colour.
+                      inputRef.current?.focus()
+                    }}
+                    title={c.label}
+                    aria-label={`Use ${c.label} for the new tag`}
+                    aria-pressed={selected}
+                    className="flex items-center justify-center"
+                    style={{
+                      width: 20,
+                      height: 20,
+                      borderRadius: 999,
+                      padding: 0,
+                      backgroundColor: c.bg,
+                      border: `2px solid ${selected ? c.fg : 'transparent'}`,
+                      cursor: 'pointer'
+                    }}
+                  >
+                    <span
+                      style={{
+                        width: 10,
+                        height: 10,
+                        borderRadius: 999,
+                        backgroundColor: c.fg
+                      }}
+                    />
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </PopoverMenu>
+  )
+}

--- a/src/renderer/src/components/projects/TagPill.tsx
+++ b/src/renderer/src/components/projects/TagPill.tsx
@@ -1,0 +1,80 @@
+import { memo } from 'react'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { getTagColor } from '../../utils/projectTags'
+
+interface TagPillProps {
+  tag: string
+  /** When true, render in selected/filter-active style (accent ring). */
+  active?: boolean
+  /** Optional count rendered as a small suffix — used by the filter strip. */
+  count?: number
+  /** Render the leading `#` so chips read as `#infra`. Default true. */
+  showHash?: boolean
+  /** Click handler — when present, the chip is rendered as a real button
+   *  with hover/focus affordances. */
+  onClick?: (e: React.MouseEvent) => void
+  /** Optional title for hover/accessibility. */
+  title?: string
+  /** Compact mode shrinks padding & font for inline rendering on project rows. */
+  compact?: boolean
+  /** Force a specific palette colour. When omitted, the user's saved override
+   *  is used; if no override exists, falls back to a hash of the tag name. */
+  colorOverride?: string | null
+}
+
+/**
+ * Pill used both on project rows (compact) and in the sidebar filter strip
+ * (regular). Colour comes from the shared TAG_PALETTE so it reads on both
+ * light and dark themes; users can change it via the tag picker.
+ */
+export const TagPill = memo(function TagPill({
+  tag,
+  active,
+  count,
+  showHash = true,
+  onClick,
+  title,
+  compact,
+  colorOverride
+}: TagPillProps): React.JSX.Element {
+  const savedOverride = useSettingsStore((s) => s.settings.tagColors?.[tag])
+  const effectiveOverride = colorOverride !== undefined ? colorOverride : savedOverride
+  const { bg, fg } = getTagColor(tag, effectiveOverride)
+  const fontSize = compact ? 9.5 : 11
+  const padding = compact ? '1px 5px' : '2px 8px'
+  const Cmp = (onClick ? 'button' : 'span') as 'button' | 'span'
+  return (
+    <Cmp
+      onClick={onClick}
+      title={title ?? `#${tag}`}
+      className="inline-flex items-center gap-1 rounded-full font-medium leading-none whitespace-nowrap"
+      style={{
+        fontSize,
+        padding,
+        backgroundColor: bg,
+        color: fg,
+        border: `1px solid ${active ? fg : 'transparent'}`,
+        cursor: onClick ? 'pointer' : 'default',
+        userSelect: 'none',
+        maxWidth: compact ? 90 : 140,
+        minWidth: 0,
+        flexShrink: 0
+      }}
+    >
+      <span
+        style={{
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          display: 'inline-block',
+          maxWidth: '100%'
+        }}
+      >
+        {showHash ? '#' : ''}
+        {tag}
+      </span>
+      {typeof count === 'number' && (
+        <span style={{ opacity: 0.7, fontSize: fontSize - 1 }}>{count}</span>
+      )}
+    </Cmp>
+  )
+})

--- a/src/renderer/src/components/search/CommandPalette.tsx
+++ b/src/renderer/src/components/search/CommandPalette.tsx
@@ -70,7 +70,9 @@ export function CommandPalette(): React.JSX.Element | null {
   }
 
   const placeholder =
-    mode === 'commands' ? 'Type a command…' : 'Search projects, sessions, settings…'
+    mode === 'commands'
+      ? 'Type a command…'
+      : 'Search projects, sessions, settings… (try #tag)'
 
   // Compute the active descendant id for the input.
   let active: string | undefined

--- a/src/renderer/src/components/search/SearchResultsList.tsx
+++ b/src/renderer/src/components/search/SearchResultsList.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import type { MatchRange, RankedItem, SearchResultGroup } from '../../services/search/types'
+import { TagPill } from '../projects/TagPill'
 
 interface SearchResultsListProps {
   groups: SearchResultGroup[]
@@ -120,6 +121,9 @@ export function SearchResultsList({
                 data-testid="search-result"
                 data-search-item-id={ranked.item.id}
               >
+                {ranked.item.icon && (
+                  <span className="flex-shrink-0 flex items-center">{ranked.item.icon}</span>
+                )}
                 <div className="flex-1 min-w-0">
                   <div className="text-[12.5px] truncate">
                     <HighlightedText text={ranked.item.label} ranges={ranked.ranges} />
@@ -130,6 +134,13 @@ export function SearchResultsList({
                       style={{ color: 'var(--dplex-text-muted)' }}
                     >
                       {ranked.item.description}
+                    </div>
+                  )}
+                  {ranked.item.tags && ranked.item.tags.length > 0 && (
+                    <div className="flex items-center gap-1 mt-0.5 flex-wrap">
+                      {ranked.item.tags.map((t) => (
+                        <TagPill key={t} tag={t} compact />
+                      ))}
                     </div>
                   )}
                 </div>

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -33,7 +33,7 @@ const SHORTCUTS: { category: string; items: { keys: string; description: string 
       { keys: `${MOD}B`, description: 'Toggle sidebar' },
       { keys: `${MOD}F`, description: 'Focus panel search' },
       { keys: `${MOD}${SHIFT}F`, description: 'Open Search side panel' },
-      { keys: `${MOD}P`, description: 'Global search' },
+      { keys: `${MOD}P`, description: 'Global search — projects, sessions, tabs, settings (try #tag)' },
       { keys: `${MOD}${SHIFT}P`, description: 'Run a command' }
     ]
   },

--- a/src/renderer/src/services/search/projectsSource.ts
+++ b/src/renderer/src/services/search/projectsSource.ts
@@ -1,8 +1,10 @@
+import { createElement } from 'react'
 import type { SearchItem, SearchSource } from './types'
 import { useProjectStore } from '../../stores/projectStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { focusFirstTabForPaths } from '../../utils/sessionTabs'
 import { pathBasename } from './pathUtils'
+import { ProjectAvatar } from '../../components/projects/ProjectAvatar'
 
 /** Activate a project: ensure the Projects view is visible, set it active,
  *  and focus any existing terminal tab in its directory. Mirrors what
@@ -33,12 +35,18 @@ export const projectsSource: SearchSource = {
     return ctx.projects.map((p) => {
       const isWorktree = p.parentProjectId !== undefined
       const description = isWorktree ? `Worktree · ${p.path}` : p.path
+      // Tag keywords are emitted both bare (`infra`) and with a leading `#`
+      // so users can type `#infra` to filter the palette and have it match.
+      const tagKeywords =
+        p.tags && p.tags.length > 0 ? [...p.tags, ...p.tags.map((t) => `#${t}`)] : []
       const item: SearchItem = {
         id: `project:${p.id}`,
         category: 'projects',
         label: p.name,
         description,
-        keywords: [pathBasename(p.path), p.path, ...(p.pinned ? ['pinned'] : [])],
+        keywords: [pathBasename(p.path), p.path, ...(p.pinned ? ['pinned'] : []), ...tagKeywords],
+        ...(p.tags && p.tags.length > 0 ? { tags: [...p.tags] } : {}),
+        icon: createElement(ProjectAvatar, { projectId: p.id, name: p.name }),
         run: () => openProject(p.id)
       }
       if (p.parentRepoName) {

--- a/src/renderer/src/services/search/types.ts
+++ b/src/renderer/src/services/search/types.ts
@@ -54,6 +54,13 @@ export interface SearchItem {
   /** Optional keywords that the matcher considers in addition to `label`.
    *  Used to make settings findable by synonyms (e.g. "color" → theme). */
   keywords?: string[]
+  /** Optional list of tag names to render as colored pills next to the
+   *  result row. Used for project items so users can see which tags caused
+   *  a match (and so the palette doubles as a tag browser). */
+  tags?: string[]
+  /** Optional leading icon node (e.g. project avatar, lucide icon). Sources
+   *  pass arbitrary JSX so they aren't constrained to a single icon shape. */
+  icon?: React.ReactNode
   /** Action invoked when the user picks this item. May be async. */
   run: () => void | Promise<void>
 }

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -3,6 +3,7 @@ import type { Project, ProjectGitPanelState, ProjectWorktreeOverrides } from '..
 import { useSettingsStore } from './settingsStore'
 import { useTerminalStore } from './terminalStore'
 import { normalizePath } from '../hooks/useProjectSessions'
+import { normalizeTag, normalizeTags } from '../utils/projectTags'
 
 function generateId(): string {
   return `proj-${Date.now()}-${Math.random().toString(36).slice(2, 7)}`
@@ -57,6 +58,14 @@ interface ProjectState {
   setActiveProject: (id: string | null) => void
   setProjectGitState: (id: string, patch: ProjectGitPanelState) => void
   togglePin: (id: string) => void
+  /** Replace this project's tags with the given list (will be normalized).
+   *  Use this from the tag picker after committing edits. */
+  setProjectTags: (id: string, tags: readonly string[]) => void
+  /** Convenience: add a single tag (idempotent). Returns nothing; callers
+   *  read the next render. */
+  addProjectTag: (id: string, tag: string) => void
+  /** Convenience: remove a single tag. No-op if not present. */
+  removeProjectTag: (id: string, tag: string) => void
   startAISession: (project: Project, providerId?: string) => Promise<string | null>
   updateProjectWorktreeOverrides: (
     projectId: string,
@@ -261,6 +270,49 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       return { projects: [pinnedTarget, ...without] }
     })
     get().persistProjects()
+  },
+
+  setProjectTags: (id, tags) => {
+    const normalized = normalizeTags(tags)
+    let changed = false
+    set((state) => {
+      const idx = state.projects.findIndex((p) => p.id === id)
+      if (idx === -1) return state
+      const current = state.projects[idx]
+      const before = current.tags ?? []
+      if (before.length === normalized.length && before.every((t, i) => t === normalized[i])) {
+        return state
+      }
+      changed = true
+      const next: Project =
+        normalized.length === 0 ? { ...current, tags: undefined } : { ...current, tags: normalized }
+      const newProjects = [...state.projects]
+      newProjects[idx] = next
+      return { projects: newProjects }
+    })
+    if (changed) get().persistProjects()
+  },
+
+  addProjectTag: (id, tag) => {
+    const t = normalizeTag(tag)
+    if (!t) return
+    const { projects, setProjectTags } = get()
+    const current = projects.find((p) => p.id === id)
+    if (!current) return
+    if (current.tags?.includes(t)) return
+    setProjectTags(id, [...(current.tags ?? []), t])
+  },
+
+  removeProjectTag: (id, tag) => {
+    const t = normalizeTag(tag)
+    if (!t) return
+    const { projects, setProjectTags } = get()
+    const current = projects.find((p) => p.id === id)
+    if (!current || !current.tags?.includes(t)) return
+    setProjectTags(
+      id,
+      current.tags.filter((x) => x !== t)
+    )
   },
 
   reorderProject: (draggedId, targetId, position) => {

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -150,6 +150,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   attentionClickClearsWaiting: false,
   worktreeDefaults: DEFAULT_WORKTREE_DEFAULTS,
   projectPanelShowFooter: true,
+  tagColors: {},
   gitPanel: {
     open: false,
     width: 300,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -147,6 +147,11 @@ export interface AppSettings {
   worktreeDefaults: WorktreeDefaults
   /** Show the health footer bar at the bottom of the Projects panel. */
   projectPanelShowFooter: boolean
+  /** Per-tag color overrides keyed by the normalized tag name. Value is a
+   *  `TAG_PALETTE` token id (e.g. `"violet"`). Tags without an entry fall
+   *  back to a deterministic hash of the tag name, so existing tags keep
+   *  their visual identity until the user picks an explicit color. */
+  tagColors?: Record<string, string>
   /** Right-side Git panel UI state. */
   gitPanel: GitPanelSettings
   /**
@@ -203,6 +208,10 @@ export interface Project {
   createdByDplexWorktree?: boolean
   /** Pinned projects render in a dedicated section at the top of the panel. */
   pinned?: boolean
+  /** Free-form user-defined tags. Normalized lowercase, leading `#` stripped,
+   *  deduped. Used for filtering the projects sidebar and for fuzzy matching
+   *  in the command palette. Absent / empty array both mean "no tags". */
+  tags?: string[]
   /** Git panel UI state scoped to this project. Persists across sessions
    *  so the user lands back on the file they last opened. Validated on
    *  each refresh — stale paths fall back to the first changed file. */

--- a/src/renderer/src/utils/projectTags.ts
+++ b/src/renderer/src/utils/projectTags.ts
@@ -1,0 +1,120 @@
+import type { Project } from '../types'
+
+/** Maximum length of a single normalized tag. Keeps storage bounded and
+ *  prevents pathological UI overflow from pasted text. */
+export const MAX_TAG_LENGTH = 32
+
+/**
+ * Theme-safe palette used by tag pills. Same pattern as `AVATAR_PALETTE` in
+ * `projectStatus.ts` — translucent background so the pill tints any panel
+ * color cleanly, plus a saturated foreground that reads on both light and
+ * dark themes. Each entry's `id` is what gets persisted in `tagColors`.
+ *
+ * Order is the order shown in the color picker swatch grid; keep it stable
+ * because users will memorize positions ("third swatch = my client tag").
+ */
+export interface TagColorToken {
+  id: string
+  label: string
+  bg: string
+  fg: string
+}
+
+export const TAG_PALETTE: readonly TagColorToken[] = [
+  { id: 'blue', label: 'Blue', bg: 'rgba(124,156,255,0.20)', fg: '#7c9cff' },
+  { id: 'violet', label: 'Violet', bg: 'rgba(167,139,250,0.20)', fg: '#a78bfa' },
+  { id: 'green', label: 'Green', bg: 'rgba(60,207,145,0.20)', fg: '#3ccf91' },
+  { id: 'amber', label: 'Amber', bg: 'rgba(240,179,90,0.22)', fg: '#d9921f' },
+  { id: 'red', label: 'Red', bg: 'rgba(239,106,106,0.20)', fg: '#ef6a6a' },
+  { id: 'teal', label: 'Teal', bg: 'rgba(93,209,206,0.20)', fg: '#2db8b4' },
+  { id: 'pink', label: 'Pink', bg: 'rgba(236,112,176,0.20)', fg: '#ec70b0' },
+  { id: 'lime', label: 'Lime', bg: 'rgba(176,196,120,0.22)', fg: '#7c9f30' }
+]
+
+const TAG_PALETTE_BY_ID = new Map(TAG_PALETTE.map((c) => [c.id, c]))
+
+function hashString(s: string): number {
+  let h = 0
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) | 0
+  return Math.abs(h)
+}
+
+/**
+ * Resolve the rendered colors for a tag.
+ *
+ * - If the user explicitly chose a palette entry (via the color picker)
+ *   `overrideId` will be the palette token id and we return that entry.
+ * - Otherwise we deterministically hash the tag name to a palette entry,
+ *   so the same tag string always renders with the same colour without
+ *   the user having to set one.
+ *
+ * Unknown override ids (from older builds or hand-edited settings) fall
+ * back to the hashed default.
+ */
+export function getTagColor(tag: string, overrideId?: string | null): TagColorToken {
+  if (overrideId) {
+    const hit = TAG_PALETTE_BY_ID.get(overrideId)
+    if (hit) return hit
+  }
+  return TAG_PALETTE[hashString(tag) % TAG_PALETTE.length]
+}
+
+/**
+ * Normalize a single user-typed tag into the canonical stored form.
+ *
+ * - Strips any leading `#` characters (users can type `#infra` or `infra`).
+ * - Replaces whitespace with `-` so multi-word tags survive copy/paste.
+ * - Lowercases.
+ * - Removes characters outside `[a-z0-9._-]`.
+ * - Trims leading/trailing separators.
+ * - Truncates to {@link MAX_TAG_LENGTH}.
+ *
+ * Returns `null` for inputs that normalize to empty — callers should treat
+ * `null` as "skip / not a valid tag" rather than storing it.
+ */
+export function normalizeTag(raw: string): string | null {
+  if (typeof raw !== 'string') return null
+  let s = raw.trim().toLowerCase()
+  while (s.startsWith('#')) s = s.slice(1)
+  s = s.replace(/\s+/g, '-')
+  s = s.replace(/[^a-z0-9._-]/g, '')
+  s = s.replace(/^[-._]+|[-._]+$/g, '')
+  if (s.length === 0) return null
+  if (s.length > MAX_TAG_LENGTH) s = s.slice(0, MAX_TAG_LENGTH)
+  return s
+}
+
+/**
+ * Normalize an arbitrary list of raw tags into a deduped, sorted array of
+ * canonical tags. Order is alphabetical so persisted JSON is stable.
+ */
+export function normalizeTags(raw: readonly string[] | undefined | null): string[] {
+  if (!raw || raw.length === 0) return []
+  const out = new Set<string>()
+  for (const r of raw) {
+    const t = normalizeTag(r)
+    if (t) out.add(t)
+  }
+  return [...out].sort()
+}
+
+/** Aggregate tag → usage count across the given projects, sorted by count
+ *  desc then alphabetical. Used to drive the sidebar filter strip. */
+export function collectTagCounts(projects: readonly Project[]): { tag: string; count: number }[] {
+  const counts = new Map<string, number>()
+  for (const p of projects) {
+    const tags = p.tags
+    if (!tags || tags.length === 0) continue
+    for (const t of tags) {
+      counts.set(t, (counts.get(t) ?? 0) + 1)
+    }
+  }
+  const out = [...counts.entries()].map(([tag, count]) => ({ tag, count }))
+  out.sort((a, b) => b.count - a.count || a.tag.localeCompare(b.tag))
+  return out
+}
+
+/** True when `project` carries `tag` exactly (already normalized). */
+export function projectHasTag(project: Project, tag: string): boolean {
+  return Array.isArray(project.tags) && project.tags.includes(tag)
+}

--- a/tests/unit/project-tags.test.ts
+++ b/tests/unit/project-tags.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  MAX_TAG_LENGTH,
+  TAG_PALETTE,
+  collectTagCounts,
+  getTagColor,
+  normalizeTag,
+  normalizeTags,
+  projectHasTag
+} from '../../src/renderer/src/utils/projectTags'
+import { useProjectStore } from '../../src/renderer/src/stores/projectStore'
+import type { Project } from '../../src/renderer/src/types'
+
+interface SettingsMock {
+  getAll: ReturnType<typeof vi.fn>
+  merge: ReturnType<typeof vi.fn>
+}
+
+let settingsMock: SettingsMock
+
+function installWindow(): void {
+  settingsMock = {
+    getAll: vi.fn().mockResolvedValue({}),
+    merge: vi.fn().mockResolvedValue(undefined)
+  }
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: { settings: settingsMock }
+  }
+}
+
+function makeProject(id: string, tags?: string[]): Project {
+  return {
+    id,
+    name: id,
+    path: `/p/${id}`,
+    addedAt: new Date().toISOString(),
+    ...(tags ? { tags } : {})
+  } as Project
+}
+
+beforeEach(() => {
+  installWindow()
+  useProjectStore.setState({ projects: [], activeProjectId: null, loaded: false } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('normalizeTag', () => {
+  it('strips leading `#`, lowercases, and trims', () => {
+    expect(normalizeTag('  #Infra ')).toBe('infra')
+  })
+
+  it('replaces whitespace with `-`', () => {
+    expect(normalizeTag('client acme')).toBe('client-acme')
+  })
+
+  it('drops disallowed characters', () => {
+    expect(normalizeTag('foo/bar!')).toBe('foobar')
+  })
+
+  it('keeps dots, underscores, dashes', () => {
+    expect(normalizeTag('node.js_v18-lts')).toBe('node.js_v18-lts')
+  })
+
+  it('returns null for empty and whitespace-only input', () => {
+    expect(normalizeTag('')).toBeNull()
+    expect(normalizeTag('   ')).toBeNull()
+    expect(normalizeTag('###')).toBeNull()
+  })
+
+  it('truncates to MAX_TAG_LENGTH', () => {
+    const long = 'a'.repeat(MAX_TAG_LENGTH + 20)
+    expect(normalizeTag(long)).toHaveLength(MAX_TAG_LENGTH)
+  })
+
+  it('handles non-string input gracefully', () => {
+    expect(normalizeTag(undefined as unknown as string)).toBeNull()
+  })
+})
+
+describe('normalizeTags', () => {
+  it('dedupes and sorts alphabetically', () => {
+    expect(normalizeTags(['#B', 'a', 'A', 'b'])).toEqual(['a', 'b'])
+  })
+
+  it('returns [] for empty/undefined/null', () => {
+    expect(normalizeTags(undefined)).toEqual([])
+    expect(normalizeTags(null)).toEqual([])
+    expect(normalizeTags([])).toEqual([])
+  })
+
+  it('skips entries that normalize to empty', () => {
+    expect(normalizeTags(['', '#', 'real'])).toEqual(['real'])
+  })
+})
+
+describe('collectTagCounts', () => {
+  it('aggregates counts and sorts by frequency then alpha', () => {
+    const projects: Project[] = [
+      makeProject('a', ['infra', 'backend']),
+      makeProject('b', ['infra']),
+      makeProject('c', ['frontend', 'infra']),
+      makeProject('d')
+    ]
+    expect(collectTagCounts(projects)).toEqual([
+      { tag: 'infra', count: 3 },
+      { tag: 'backend', count: 1 },
+      { tag: 'frontend', count: 1 }
+    ])
+  })
+
+  it('returns [] when no project has tags', () => {
+    expect(collectTagCounts([makeProject('a'), makeProject('b')])).toEqual([])
+  })
+})
+
+describe('projectHasTag', () => {
+  it('matches exact stored tag', () => {
+    expect(projectHasTag(makeProject('a', ['infra']), 'infra')).toBe(true)
+    expect(projectHasTag(makeProject('a', ['infra']), 'frontend')).toBe(false)
+    expect(projectHasTag(makeProject('a'), 'infra')).toBe(false)
+  })
+})
+
+describe('getTagColor', () => {
+  it('returns the override entry when it exists in the palette', () => {
+    const violet = TAG_PALETTE.find((c) => c.id === 'violet')!
+    expect(getTagColor('anything', 'violet')).toEqual(violet)
+  })
+
+  it('falls back to a hashed default when no override is set', () => {
+    const a = getTagColor('infra')
+    const b = getTagColor('infra')
+    expect(a).toBe(b)
+    // Different tags should be free to hash to different swatches; the
+    // important invariant is that a tag is stable across calls (above).
+    expect(TAG_PALETTE).toContain(a)
+  })
+
+  it('ignores unknown override ids and falls back to default', () => {
+    const fallback = getTagColor('infra')
+    expect(getTagColor('infra', 'no-such-color')).toBe(fallback)
+  })
+
+  it('treats null/undefined override the same as no override', () => {
+    const def = getTagColor('infra')
+    expect(getTagColor('infra', null)).toBe(def)
+    expect(getTagColor('infra', undefined)).toBe(def)
+  })
+})
+
+describe('projectStore tag actions', () => {
+  it('setProjectTags normalizes and persists', () => {
+    useProjectStore.setState({
+      projects: [makeProject('p1')]
+    } as never)
+
+    useProjectStore.getState().setProjectTags('p1', ['#Infra', 'backend', 'Infra'])
+
+    const p = useProjectStore.getState().projects[0]
+    expect(p.tags).toEqual(['backend', 'infra'])
+    expect(settingsMock.merge).toHaveBeenCalledWith({
+      projects: expect.arrayContaining([expect.objectContaining({ tags: ['backend', 'infra'] })])
+    })
+  })
+
+  it('setProjectTags with empty list clears the tags field', () => {
+    useProjectStore.setState({
+      projects: [makeProject('p1', ['infra'])]
+    } as never)
+
+    useProjectStore.getState().setProjectTags('p1', [])
+
+    const p = useProjectStore.getState().projects[0]
+    expect(p.tags).toBeUndefined()
+  })
+
+  it('setProjectTags is a no-op when normalized result is unchanged', () => {
+    // Tags are already stored in the normalized (sorted) form that
+    // setProjectTags produces, so re-applying equivalent input should not
+    // touch the projects array or trigger a persist call.
+    useProjectStore.setState({
+      projects: [makeProject('p1', ['backend', 'infra'])]
+    } as never)
+    const before = useProjectStore.getState().projects
+
+    settingsMock.merge.mockClear()
+    useProjectStore.getState().setProjectTags('p1', ['Backend', '#infra'])
+
+    expect(useProjectStore.getState().projects).toBe(before)
+    expect(settingsMock.merge).not.toHaveBeenCalled()
+  })
+
+  it('addProjectTag is idempotent', () => {
+    useProjectStore.setState({
+      projects: [makeProject('p1', ['infra'])]
+    } as never)
+
+    useProjectStore.getState().addProjectTag('p1', '#infra')
+    useProjectStore.getState().addProjectTag('p1', 'backend')
+
+    expect(useProjectStore.getState().projects[0].tags).toEqual(['backend', 'infra'])
+  })
+
+  it('removeProjectTag removes a tag and clears the field if last', () => {
+    useProjectStore.setState({
+      projects: [makeProject('p1', ['infra'])]
+    } as never)
+
+    useProjectStore.getState().removeProjectTag('p1', '#Infra')
+
+    expect(useProjectStore.getState().projects[0].tags).toBeUndefined()
+  })
+
+  it('addProjectTag with garbage input is a no-op', () => {
+    useProjectStore.setState({
+      projects: [makeProject('p1')]
+    } as never)
+
+    useProjectStore.getState().addProjectTag('p1', '   ')
+
+    expect(useProjectStore.getState().projects[0].tags).toBeUndefined()
+  })
+
+  it('tag actions on a missing project are no-ops', () => {
+    useProjectStore.setState({ projects: [] } as never)
+    expect(() => useProjectStore.getState().setProjectTags('missing', ['x'])).not.toThrow()
+    expect(() => useProjectStore.getState().addProjectTag('missing', 'x')).not.toThrow()
+    expect(() => useProjectStore.getState().removeProjectTag('missing', 'x')).not.toThrow()
+  })
+})


### PR DESCRIPTION
Adds free-form **project tags** so a large project list can be grouped by relationship (clients, infra, OSS, etc.), with a color picker, dynamic-fit row rendering, and a polish pass on the command palette so tags are first-class there too.

## What's new

### Tagging
- New `tags?: string[]` field on `Project`, persisted through the existing settings round-trip.
- Right-click a project → **Tags…** opens a multi-select picker that suggests existing tags from across the workspace and creates new ones inline (typing `#infra` and `infra` both normalize to the same canonical tag).
- Tag filter strip at the top of the projects sidebar — single-select, auto-hides when no project has any tag, self-heals when the active tag disappears.

### Color picker
- Each tag carries a globally-shared color users can pick from an 8-swatch theme-safe palette (`TAG_PALETTE`). Same palette on both light and dark themes.
- The Create row in the picker shows a stable-color preview that doesn't shimmer as the user types; existing tags can be recolored from a per-row swatch strip.
- Defaults to a deterministic hash of the tag name, so first-time tags already have a consistent look.

### Dynamic-fit rendering
- New `InlineTagList` measures pill widths via `ResizeObserver` against container width and shows as many tags as actually fit. Overflow surfaces as a `+N` chip whose tooltip lists the hidden tags — nothing is silently clipped.
- Long tag names truncate with ellipsis instead of pushing siblings off-screen.

### Worktree-with-parent filtering
- Filtering by tag (or any other filter) keeps a matched parent's worktree subtree visible underneath it; matching parents are force-expanded without touching the user's persisted expand/collapse state.

### Command palette (⌘P)
- Project results render with the **project avatar** and **tag pills** inline, so users can see at a glance why a result matched.
- Tag keywords are emitted both bare (`infra`) and prefixed (`#infra`) so `#infra` filters projects directly.
- Placeholder hints `(try #tag)`.

### Discoverability
- Status bar gets a persistent **Search ⌘P** button.
- Settings → Shortcuts entry for ⌘P now reads *"Global search — projects, sessions, tabs, settings (try #tag)"*.

## Tests

11 new unit tests for tag normalization, the store actions, color resolution, and dedupe — total suite now 352 passing.

## Review

Ran the dual review policy (claude-opus-4.7 + gpt-5.5). All findings from both rounds addressed:
- Anchor for the tag picker is the row div (not the whole expanded wrapper)
- Stale tag filter self-heals when the active tag is removed
- `#`-prefixed typing in the picker still matches existing tags
- Enter on an existing tag no longer overwrites its global color
- Collapsed matched parents force-expand in filter mode
- All lint rules pass

## Version

Bumped to **0.16.0** (MINOR — new user-visible features). CHANGELOG updated.