### PR TITLE
fix: correct truecolor rendering for colon-form SGR sequences

### DIFF
--- a/src/renderer/src/hooks/useTerminal.ts
+++ b/src/renderer/src/hooks/useTerminal.ts
@@ -200,7 +200,7 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
           let hadData = false
           for (const item of earlyBuffer) {
             if (item.id === ptyId) {
-              entry.term.write(item.data)
+              entry.term.write(entry.truecolorNormalizer.write(item.data))
               hadData = true
             }
           }

--- a/src/renderer/src/services/terminalRegistry.ts
+++ b/src/renderer/src/services/terminalRegistry.ts
@@ -3,12 +3,14 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { getTheme } from './themes'
 import { FlowController } from './flowControl'
+import { TruecolorSgrNormalizer } from './truecolorSgrNormalizer'
 
 export interface TerminalEntry {
   term: Terminal
   fitAddon: FitAddon
   ptyId: string | null
   wrapperEl: HTMLDivElement
+  truecolorNormalizer: TruecolorSgrNormalizer
   ready: boolean
   creating: boolean
   cleanupIpc: (() => void) | null
@@ -41,7 +43,7 @@ function ensureGlobalListeners(): void {
     const handler = dataHandlers.get(ptyId)
     if (!handler) return
 
-    handler.flowController.write(data)
+    handler.flowController.write(handler.entry.truecolorNormalizer.write(data))
 
     if (!handler.entry.ready) {
       handler.entry.ready = true
@@ -130,6 +132,7 @@ export function getOrCreateTerminal(
     fitAddon,
     ptyId: null,
     wrapperEl,
+    truecolorNormalizer: new TruecolorSgrNormalizer(),
     ready: false,
     creating: false,
     cleanupIpc: null

--- a/src/renderer/src/services/truecolorSgrNormalizer.ts
+++ b/src/renderer/src/services/truecolorSgrNormalizer.ts
@@ -1,6 +1,11 @@
 const CSI_7BIT = '\x1b['
 const CSI_8BIT = '\x9b'
 
+// Hard cap on the pending buffer to bound memory if a PTY ever emits a CSI
+// introducer followed by an unending stream of param bytes. Real SGR params
+// are tens of bytes; xterm.js's own parser has a similar guard.
+const MAX_PENDING = 4096
+
 // Matches the ESC byte literally — recognising CSI/SGR sequences is the
 // whole purpose of this module.
 // eslint-disable-next-line no-control-regex
@@ -14,23 +19,34 @@ function normalizeSgrParams(params: string): string {
 }
 
 function findIncompleteCsiStart(data: string): number {
-  // A lone trailing ESC may begin a CSI sequence whose '[' lands in the next
-  // PTY chunk. Hold it back so a colon-form SGR split exactly at the ESC/'['
-  // boundary still gets rewritten instead of slipping through unchanged.
-  if (data.endsWith('\x1b')) return data.length - 1
+  // Return the earliest position that must be held back to the next chunk.
+  // Two independent heuristics, both expressed as a candidate split point:
+  //   (a) an unterminated CSI introducer (`\x1b[` / `\x9b`) followed by params
+  //       without a final byte (0x40–0x7e);
+  //   (b) a lone trailing ESC, which may grow into a CSI on the next chunk.
+  // We retain from the earlier of the two so that a chunk containing both a
+  // mid-sequence introducer AND a trailing ESC isn't emitted half-raw.
+  let tail = data.length
 
   const escStart = data.lastIndexOf(CSI_7BIT)
   const c1Start = data.lastIndexOf(CSI_8BIT)
   const start = Math.max(escStart, c1Start)
-  if (start === -1) return data.length
-
-  const paramsStart = start === escStart ? start + CSI_7BIT.length : start + CSI_8BIT.length
-  for (let i = paramsStart; i < data.length; i++) {
-    const code = data.charCodeAt(i)
-    if (code >= 0x40 && code <= 0x7e) return data.length
+  if (start !== -1) {
+    const paramsStart = start === escStart ? start + CSI_7BIT.length : start + CSI_8BIT.length
+    let terminated = false
+    for (let i = paramsStart; i < data.length; i++) {
+      const code = data.charCodeAt(i)
+      if (code >= 0x40 && code <= 0x7e) {
+        terminated = true
+        break
+      }
+    }
+    if (!terminated) tail = Math.min(tail, start)
   }
 
-  return start
+  if (data.endsWith('\x1b')) tail = Math.min(tail, data.length - 1)
+
+  return tail
 }
 
 export function normalizeColonTruecolorSgr(data: string): string {
@@ -52,7 +68,13 @@ export class TruecolorSgrNormalizer {
       return normalizeColonTruecolorSgr(input)
     }
 
-    this.pending = input.slice(tailStart)
+    const tail = input.slice(tailStart)
+    if (tail.length > MAX_PENDING) {
+      // Pathological: emit everything we have (best-effort normalized) and
+      // reset, rather than let `pending` grow without bound.
+      return normalizeColonTruecolorSgr(input)
+    }
+    this.pending = tail
     return normalizeColonTruecolorSgr(input.slice(0, tailStart))
   }
 }

--- a/src/renderer/src/services/truecolorSgrNormalizer.ts
+++ b/src/renderer/src/services/truecolorSgrNormalizer.ts
@@ -1,0 +1,53 @@
+const CSI_7BIT = '\x1b['
+const CSI_8BIT = '\x9b'
+
+// Matches the ESC byte literally — recognising CSI/SGR sequences is the
+// whole purpose of this module.
+// eslint-disable-next-line no-control-regex
+const SGR_CSI_PATTERN = /(\x1b\[|\x9b)([0-9:;]*m)/g
+const COLON_TRUECOLOR_PATTERN = /(^|;)(38|48|58):2:(\d{1,3}):(\d{1,3}):(\d{1,3})(?=;|$)/g
+
+function normalizeSgrParams(params: string): string {
+  return params.replace(COLON_TRUECOLOR_PATTERN, (_match, prefix, target, r, g, b) => {
+    return `${prefix}${target};2;${r};${g};${b}`
+  })
+}
+
+function findIncompleteCsiStart(data: string): number {
+  const escStart = data.lastIndexOf(CSI_7BIT)
+  const c1Start = data.lastIndexOf(CSI_8BIT)
+  const start = Math.max(escStart, c1Start)
+  if (start === -1) return data.length
+
+  const paramsStart = start === escStart ? start + CSI_7BIT.length : start + CSI_8BIT.length
+  for (let i = paramsStart; i < data.length; i++) {
+    const code = data.charCodeAt(i)
+    if (code >= 0x40 && code <= 0x7e) return data.length
+  }
+
+  return start
+}
+
+export function normalizeColonTruecolorSgr(data: string): string {
+  return data.replace(SGR_CSI_PATTERN, (_match, csi, paramsWithFinal) => {
+    const params = paramsWithFinal.slice(0, -1)
+    return `${csi}${normalizeSgrParams(params)}m`
+  })
+}
+
+export class TruecolorSgrNormalizer {
+  private pending = ''
+
+  write(data: string): string {
+    const input = this.pending + data
+    this.pending = ''
+
+    const tailStart = findIncompleteCsiStart(input)
+    if (tailStart === input.length) {
+      return normalizeColonTruecolorSgr(input)
+    }
+
+    this.pending = input.slice(tailStart)
+    return normalizeColonTruecolorSgr(input.slice(0, tailStart))
+  }
+}

--- a/src/renderer/src/services/truecolorSgrNormalizer.ts
+++ b/src/renderer/src/services/truecolorSgrNormalizer.ts
@@ -14,6 +14,11 @@ function normalizeSgrParams(params: string): string {
 }
 
 function findIncompleteCsiStart(data: string): number {
+  // A lone trailing ESC may begin a CSI sequence whose '[' lands in the next
+  // PTY chunk. Hold it back so a colon-form SGR split exactly at the ESC/'['
+  // boundary still gets rewritten instead of slipping through unchanged.
+  if (data.endsWith('\x1b')) return data.length - 1
+
   const escStart = data.lastIndexOf(CSI_7BIT)
   const c1Start = data.lastIndexOf(CSI_8BIT)
   const start = Math.max(escStart, c1Start)

--- a/tests/unit/truecolor-sgr-normalizer.test.ts
+++ b/tests/unit/truecolor-sgr-normalizer.test.ts
@@ -47,4 +47,31 @@ describe('TruecolorSgrNormalizer', () => {
     expect(normalizer.write('\x1b[0m\x1b')).toBe('\x1b[0m')
     expect(normalizer.write('[38:2:122:162:247mblue')).toBe('\x1b[38;2;122;162;247mblue')
   })
+
+  it('retains an unterminated colon-SGR when the chunk also ends in a trailing ESC', () => {
+    const normalizer = new TruecolorSgrNormalizer()
+
+    // If the trailing-ESC heuristic short-circuits the unterminated-CSI scan,
+    // the incomplete SGR leaks raw to xterm.js and reintroduces the colon-
+    // form color bug. Both candidates must be considered together and the
+    // earlier split point retained.
+    expect(normalizer.write('hi\x1b[38:2:1:2:3\x1b')).toBe('hi')
+  })
+
+  it('handles a lone trailing 8-bit CSI introducer', () => {
+    const normalizer = new TruecolorSgrNormalizer()
+
+    expect(normalizer.write('a\x9b')).toBe('a')
+    expect(normalizer.write('38:2:122:162:247mblue')).toBe('\x9b38;2;122;162;247mblue')
+  })
+
+  it('flushes and resets when the pending buffer exceeds the cap', () => {
+    const normalizer = new TruecolorSgrNormalizer()
+    const huge = '\x1b[' + '9'.repeat(8192)
+
+    // No final byte ever arrives; the cap forces a flush instead of growing
+    // pending without bound. Subsequent writes start fresh.
+    expect(normalizer.write(huge)).toBe(huge)
+    expect(normalizer.write('\x1b[48:2:30:30:46m b')).toBe('\x1b[48;2;30;30;46m b')
+  })
 })

--- a/tests/unit/truecolor-sgr-normalizer.test.ts
+++ b/tests/unit/truecolor-sgr-normalizer.test.ts
@@ -33,4 +33,18 @@ describe('TruecolorSgrNormalizer', () => {
     expect(normalizer.write('a\x1b[48:2:30')).toBe('a')
     expect(normalizer.write(':30:46m b')).toBe('\x1b[48;2;30;30;46m b')
   })
+
+  it('handles a chunk split exactly between the ESC byte and "["', () => {
+    const normalizer = new TruecolorSgrNormalizer()
+
+    expect(normalizer.write('a\x1b')).toBe('a')
+    expect(normalizer.write('[48:2:30:30:46m b')).toBe('\x1b[48;2;30;30;46m b')
+  })
+
+  it('retains a trailing ESC that follows a complete SGR sequence', () => {
+    const normalizer = new TruecolorSgrNormalizer()
+
+    expect(normalizer.write('\x1b[0m\x1b')).toBe('\x1b[0m')
+    expect(normalizer.write('[38:2:122:162:247mblue')).toBe('\x1b[38;2;122;162;247mblue')
+  })
 })

--- a/tests/unit/truecolor-sgr-normalizer.test.ts
+++ b/tests/unit/truecolor-sgr-normalizer.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeColonTruecolorSgr,
+  TruecolorSgrNormalizer
+} from '../../src/renderer/src/services/truecolorSgrNormalizer'
+
+describe('normalizeColonTruecolorSgr', () => {
+  it('rewrites colon truecolor SGR without a colorspace slot to semicolon form', () => {
+    expect(normalizeColonTruecolorSgr('\x1b[48:2:30:30:46m ')).toBe('\x1b[48;2;30;30;46m ')
+    expect(normalizeColonTruecolorSgr('\x1b[38:2:122:162:247mblue')).toBe(
+      '\x1b[38;2;122;162;247mblue'
+    )
+  })
+
+  it('rewrites foreground, background, and underline colors inside mixed SGR params', () => {
+    expect(
+      normalizeColonTruecolorSgr('\x1b[0;38:2:122:162:247;48:2:30:30:46;58:2:255:158:100m')
+    ).toBe('\x1b[0;38;2;122;162;247;48;2;30;30;46;58;2;255;158;100m')
+  })
+
+  it('leaves already-valid SGR and non-SGR CSI sequences untouched', () => {
+    expect(normalizeColonTruecolorSgr('\x1b[48:2::30:30:46m')).toBe('\x1b[48:2::30:30:46m')
+    expect(normalizeColonTruecolorSgr('\x1b[48;2;30;30;46m')).toBe('\x1b[48;2;30;30;46m')
+    expect(normalizeColonTruecolorSgr('\x1b[38:5:12m')).toBe('\x1b[38:5:12m')
+    expect(normalizeColonTruecolorSgr('\x1b[2J')).toBe('\x1b[2J')
+  })
+})
+
+describe('TruecolorSgrNormalizer', () => {
+  it('handles truecolor SGR sequences split across PTY chunks', () => {
+    const normalizer = new TruecolorSgrNormalizer()
+
+    expect(normalizer.write('a\x1b[48:2:30')).toBe('a')
+    expect(normalizer.write(':30:46m b')).toBe('\x1b[48;2;30;30;46m b')
+  })
+})


### PR DESCRIPTION
## Problem

Any application that emits the colon form of truecolor SGR sequences renders with badly wrong colors inside a DPlex terminal — blue turns green/yellow. The clearest case is Neovim with `termguicolors`: a dark-blue background shows as olive green, bright blues as lime. The same Neovim looks correct in native terminals.

## Cause

There are two ways to encode a truecolor SGR sequence:

| Form | Syntax |
|---|---|
| Semicolon | `ESC[48;2;R;G;Bm` |
| Colon (ITU T.416) | `ESC[48:2::R:G:Bm` (with explicit empty colorspace slot) |

The colorspace slot is **positionally significant** in T.416 — it must be present (empty is fine) for the following params to be read as R/G/B. Neovim's TUI ([`tui.c`](https://github.com/neovim/neovim/blob/master/src/nvim/tui/tui.c)) emits the short form `ESC[48:2:R:G:Bm` without that slot, which violates the spec. xterm.js follows the spec strictly: it reads the first param after `2:` as the colorspace ID, the next two as R and G, and leaves B at 0 — producing the exact channel shift seen above (`#1e1e2e` → `#1e2e00`).

The xterm.js maintainers closed [xtermjs/xterm.js#5792](https://github.com/xtermjs/xterm.js/issues/5792) as not-a-bug for this reason. The fix has to live on the consumer side.

## Change

Adds a normalizer (`truecolorSgrNormalizer.ts`) that rewrites the non-spec short colon form for `38` / `48` / `58` truecolor SGR params to the semicolon form xterm.js parses unambiguously. It is applied where PTY data enters xterm and is stateful so a sequence split mid-stream across PTY chunks is still rewritten. The spec-compliant colorspace-slot form (`38:2::R:G:B`) and the 256-color colon form (`38:5:n`) are both left untouched. The pending buffer is capped at 4 KiB to bound memory if a PTY ever emits an open CSI introducer followed by an unending param stream.

## Tests

`tests/unit/truecolor-sgr-normalizer.test.ts` covers rewriting, mixed params, untouched valid forms, chunk-split sequences (including the ESC/`[` boundary), the 8-bit CSI introducer at chunk end, and the cap-overflow path.

`npm run typecheck`, `npm run lint`, and `npm run test:unit` pass.

## Screenshots

Before:

<img width="1207" height="916" alt="image" src="https://github.com/user-attachments/assets/91c64d18-d92c-4302-ad7c-4b2f27194513" />

After:

<img width="897" height="762" alt="image" src="https://github.com/user-attachments/assets/1e58c9a2-5eb3-4f0c-b15e-af4b1b555406" />