### PR TITLE
feat: add macOS Option-as-Meta terminal setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Features
 
-- Added a **Use ⌥ Option as Meta key** terminal setting (macOS). Turn it
-  off so ⌥ Option composes characters — letting you type `@ # [ ] { }` on
-  Spanish and other non-US keyboard layouts — while ⌥+Arrow keys keep
-  word-wise navigation working.
+- Type `@ # [ ] { } \ |` in the terminal on Spanish, French, German and
+  other non-US macOS keyboards (⌥+Arrow keys keep working).
 
 ## [0.17.2] — 2026-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Features
+
+- Added a **Use ⌥ Option as Meta key** terminal setting (macOS). Turn it
+  off so ⌥ Option composes characters — letting you type `@ # [ ] { }` on
+  Spanish and other non-US keyboard layouts — while ⌥+Arrow keys keep
+  word-wise navigation working.
+
 ## [0.17.2] — 2026-05-21
 
 ### Performance

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -492,9 +492,14 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
                   {isMac && (
                     <SettingItem
-                      label="Use ⌥ Option as Meta key"
+                      label="Option key as Alt"
                       settingId="mac-option-is-meta"
-                      description="When off, ⌥ Option composes characters — needed to type @ # [ ] { } on Spanish and other non-US keyboard layouts. When on (default), it acts as the Alt/Meta key."
+                      description={
+                        'Send the ⌥ Option key to the terminal as Alt (Meta). Turn this off ' +
+                        'to let macOS compose characters with Option — required to type ' +
+                        '@ # [ ] { } \\ | on international keyboard layouts. Word-wise ' +
+                        'navigation with ⌥+←/→ and ⌥+⌫ keeps working either way.'
+                      }
                     >
                       <label className="flex items-center gap-2 cursor-pointer">
                         <input
@@ -504,7 +509,7 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                           className="accent-[var(--dplex-accent)]"
                         />
                         <span className="text-[11px]" style={{ color: 'var(--dplex-text)' }}>
-                          Send ⌥ Option as Alt/Meta to the terminal
+                          Send ⌥ Option as Alt to the shell
                         </span>
                       </label>
                     </SettingItem>

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -6,7 +6,7 @@ import { useUpdateStore } from '../../stores/updateStore'
 import { getThemesByVariant, getTheme } from '../../services/themes'
 import { applyThemeToAll } from '../../services/terminalRegistry'
 import type { ShellInfo, AppSettings } from '../../types'
-import { MOD, SHIFT } from '../../utils/shortcuts'
+import { MOD, SHIFT, isMac } from '../../utils/shortcuts'
 import { timeAgo } from '../../utils/timeAgo'
 
 interface SettingsModalProps {
@@ -489,6 +489,26 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                       }}
                     />
                   </SettingItem>
+
+                  {isMac && (
+                    <SettingItem
+                      label="Use ⌥ Option as Meta key"
+                      settingId="mac-option-is-meta"
+                      description="When off, ⌥ Option composes characters — needed to type @ # [ ] { } on Spanish and other non-US keyboard layouts. When on (default), it acts as the Alt/Meta key."
+                    >
+                      <label className="flex items-center gap-2 cursor-pointer">
+                        <input
+                          type="checkbox"
+                          checked={settings.macOptionIsMeta}
+                          onChange={(e) => applyNow({ macOptionIsMeta: e.target.checked })}
+                          className="accent-[var(--dplex-accent)]"
+                        />
+                        <span className="text-[11px]" style={{ color: 'var(--dplex-text)' }}>
+                          Send ⌥ Option as Alt/Meta to the terminal
+                        </span>
+                      </label>
+                    </SettingItem>
+                  )}
                 </>
               )}
 

--- a/src/renderer/src/hooks/useTerminal.ts
+++ b/src/renderer/src/hooks/useTerminal.ts
@@ -5,6 +5,7 @@ import { useTerminalStore } from '../stores/terminalStore'
 import {
   getOrCreateTerminal,
   updateTerminalFont,
+  updateTerminalMacOptionIsMeta,
   applyThemeToAll,
   fireExitHandler,
   registerPtyDataHandler,
@@ -102,6 +103,7 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
       terminalId,
       settings.fontSize,
       settings.fontFamily,
+      settings.macOptionIsMeta,
       settings.theme
     )
     entryRef.current = entry
@@ -299,6 +301,11 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
   useEffect(() => {
     updateTerminalFont(terminalId, settings.fontSize, settings.fontFamily)
   }, [terminalId, settings.fontSize, settings.fontFamily])
+
+  // Apply the Option-as-Meta preference live to this terminal
+  useEffect(() => {
+    updateTerminalMacOptionIsMeta(terminalId, settings.macOptionIsMeta)
+  }, [terminalId, settings.macOptionIsMeta])
 
   // Apply theme changes to this terminal
   useEffect(() => {

--- a/src/renderer/src/services/terminalRegistry.ts
+++ b/src/renderer/src/services/terminalRegistry.ts
@@ -3,6 +3,8 @@ import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { getTheme } from './themes'
 import { FlowController } from './flowControl'
+import { isMac } from '../utils/shortcuts'
+import { wordMotionSequence } from '../utils/terminalKeys'
 
 export interface TerminalEntry {
   term: Terminal
@@ -95,6 +97,7 @@ export function getOrCreateTerminal(
   terminalId: string,
   fontSize: number,
   fontFamily: string,
+  macOptionIsMeta: boolean,
   themeId?: string
 ): TerminalEntry {
   const existing = registry.get(terminalId)
@@ -109,13 +112,28 @@ export function getOrCreateTerminal(
     cursorBlink: true,
     cursorStyle: 'block',
     allowProposedApi: true,
-    macOptionIsMeta: true,
+    macOptionIsMeta,
     scrollback: 10000
   })
 
   const fitAddon = new FitAddon()
   term.loadAddon(fitAddon)
   term.loadAddon(new WebLinksAddon())
+
+  // macOS-only: when ⌥ Option is left to compose characters (macOptionIsMeta
+  // off), restore word-wise navigation by translating ⌥+Arrow / ⌥+Backspace
+  // to readline escape sequences. The Option-as-Meta conflict does not exist
+  // on Windows/Linux, where non-US layouts compose symbols via AltGr.
+  if (isMac) {
+    term.attachCustomKeyEventHandler((e) => {
+      if (term.options.macOptionIsMeta) return true
+      const seq = wordMotionSequence(e)
+      if (seq === null) return true
+      e.preventDefault()
+      term.input(seq)
+      return false
+    })
+  }
 
   // Create a persistent wrapper element for the xterm DOM
   const wrapperEl = document.createElement('div')
@@ -217,6 +235,12 @@ export function updateTerminalFont(terminalId: string, fontSize: number, fontFam
   } catch {
     // ignore
   }
+}
+
+export function updateTerminalMacOptionIsMeta(terminalId: string, macOptionIsMeta: boolean): void {
+  const entry = registry.get(terminalId)
+  if (!entry) return
+  entry.term.options.macOptionIsMeta = macOptionIsMeta
 }
 
 export function applyThemeToAll(themeId: string): void {

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -127,6 +127,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   defaultAITool: 'copilot-cli',
   fontSize: 14,
   fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+  macOptionIsMeta: true,
   theme: cachedTheme,
   sidebarWidth: 260,
   sidebarVisible: true,

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -104,6 +104,14 @@ export interface AppSettings {
   defaultAITool: string
   fontSize: number
   fontFamily: string
+  /**
+   * Treat the macOS ⌥ Option key as the Meta key inside terminals. When true
+   * (default), Option is sent to the shell as Alt/Meta. When false, Option is
+   * left to the OS so it can compose characters — required to type
+   * @ # [ ] { } \ | on Spanish and other non-US layouts; word navigation is
+   * still available via ⌥+Arrow keys. Ignored on Windows and Linux.
+   */
+  macOptionIsMeta: boolean
   theme: string
   sidebarWidth: number
   sidebarVisible: boolean

--- a/src/renderer/src/utils/terminalKeys.ts
+++ b/src/renderer/src/utils/terminalKeys.ts
@@ -1,9 +1,10 @@
 /**
  * Word-wise navigation for terminals on macOS. When ⌥ Option is left to the
  * OS so it can compose characters (macOptionIsMeta off) rather than acting as
- * the Meta key, ⌥+Arrow / ⌥+Backspace would emit CSI sequences the shell
- * ignores. This maps them to the readline escape sequences bash/zsh bind to
- * word motions — the same translation iTerm2's "Natural Text Editing" applies.
+ * the Meta key, ⌥+Arrow / ⌥+Backspace / ⌥+Delete would emit CSI sequences the
+ * shell ignores. This maps them to the readline escape sequences bash/zsh
+ * bind to word motions — the same translation iTerm2's "Natural Text Editing"
+ * applies.
  */
 
 /** The subset of a DOM KeyboardEvent this translation depends on. */
@@ -17,9 +18,9 @@ export interface WordMotionKeyEvent {
 }
 
 /**
- * Returns the escape sequence an ⌥+Arrow / ⌥+Backspace keystroke should send
- * to the PTY, or `null` when the event is not one of those keystrokes and
- * should be handled by xterm normally.
+ * Returns the escape sequence an ⌥+Arrow / ⌥+Backspace / ⌥+Delete keystroke
+ * should send to the PTY, or `null` when the event is not one of those
+ * keystrokes and should be handled by xterm normally.
  *
  * Shifted combinations are excluded so Shift+⌥+Arrow falls through to xterm
  * untouched rather than being collapsed into a plain word motion.
@@ -35,6 +36,8 @@ export function wordMotionSequence(e: WordMotionKeyEvent): string | null {
       return '\x1bf' // ESC f — forward-word
     case 'Backspace':
       return '\x1b\x7f' // ESC DEL — backward-kill-word
+    case 'Delete':
+      return '\x1bd' // ESC d — kill-word forward
     default:
       return null
   }

--- a/src/renderer/src/utils/terminalKeys.ts
+++ b/src/renderer/src/utils/terminalKeys.ts
@@ -1,0 +1,41 @@
+/**
+ * Word-wise navigation for terminals on macOS. When ⌥ Option is left to the
+ * OS so it can compose characters (macOptionIsMeta off) rather than acting as
+ * the Meta key, ⌥+Arrow / ⌥+Backspace would emit CSI sequences the shell
+ * ignores. This maps them to the readline escape sequences bash/zsh bind to
+ * word motions — the same translation iTerm2's "Natural Text Editing" applies.
+ */
+
+/** The subset of a DOM KeyboardEvent this translation depends on. */
+export interface WordMotionKeyEvent {
+  type: string
+  altKey: boolean
+  ctrlKey: boolean
+  metaKey: boolean
+  shiftKey: boolean
+  key: string
+}
+
+/**
+ * Returns the escape sequence an ⌥+Arrow / ⌥+Backspace keystroke should send
+ * to the PTY, or `null` when the event is not one of those keystrokes and
+ * should be handled by xterm normally.
+ *
+ * Shifted combinations are excluded so Shift+⌥+Arrow falls through to xterm
+ * untouched rather than being collapsed into a plain word motion.
+ */
+export function wordMotionSequence(e: WordMotionKeyEvent): string | null {
+  if (e.type !== 'keydown' || !e.altKey || e.ctrlKey || e.metaKey || e.shiftKey) {
+    return null
+  }
+  switch (e.key) {
+    case 'ArrowLeft':
+      return '\x1bb' // ESC b — backward-word
+    case 'ArrowRight':
+      return '\x1bf' // ESC f — forward-word
+    case 'Backspace':
+      return '\x1b\x7f' // ESC DEL — backward-kill-word
+    default:
+      return null
+  }
+}

--- a/tests/unit/terminal-keys.test.ts
+++ b/tests/unit/terminal-keys.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+import {
+  wordMotionSequence,
+  type WordMotionKeyEvent
+} from '../../src/renderer/src/utils/terminalKeys'
+
+/** Builds an ⌥+ArrowLeft keydown event, overridable per test. */
+function keyEvent(overrides: Partial<WordMotionKeyEvent> = {}): WordMotionKeyEvent {
+  return {
+    type: 'keydown',
+    altKey: true,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    key: 'ArrowLeft',
+    ...overrides
+  }
+}
+
+describe('wordMotionSequence', () => {
+  it('maps ⌥+ArrowLeft to backward-word (ESC b)', () => {
+    expect(wordMotionSequence(keyEvent({ key: 'ArrowLeft' }))).toBe('\x1bb')
+  })
+
+  it('maps ⌥+ArrowRight to forward-word (ESC f)', () => {
+    expect(wordMotionSequence(keyEvent({ key: 'ArrowRight' }))).toBe('\x1bf')
+  })
+
+  it('maps ⌥+Backspace to backward-kill-word (ESC DEL)', () => {
+    expect(wordMotionSequence(keyEvent({ key: 'Backspace' }))).toBe('\x1b\x7f')
+  })
+
+  it('returns null without the Alt modifier', () => {
+    expect(wordMotionSequence(keyEvent({ altKey: false }))).toBeNull()
+  })
+
+  it('returns null when Ctrl or Meta is also held', () => {
+    expect(wordMotionSequence(keyEvent({ ctrlKey: true }))).toBeNull()
+    expect(wordMotionSequence(keyEvent({ metaKey: true }))).toBeNull()
+  })
+
+  it('returns null when Shift is held so xterm handles the combination', () => {
+    expect(wordMotionSequence(keyEvent({ shiftKey: true }))).toBeNull()
+  })
+
+  it('returns null for non-keydown events', () => {
+    expect(wordMotionSequence(keyEvent({ type: 'keyup' }))).toBeNull()
+    expect(wordMotionSequence(keyEvent({ type: 'keypress' }))).toBeNull()
+  })
+
+  it('returns null for keys without a word motion', () => {
+    expect(wordMotionSequence(keyEvent({ key: 'ArrowUp' }))).toBeNull()
+    expect(wordMotionSequence(keyEvent({ key: 'a' }))).toBeNull()
+  })
+})

--- a/tests/unit/terminal-keys.test.ts
+++ b/tests/unit/terminal-keys.test.ts
@@ -30,6 +30,10 @@ describe('wordMotionSequence', () => {
     expect(wordMotionSequence(keyEvent({ key: 'Backspace' }))).toBe('\x1b\x7f')
   })
 
+  it('maps ⌥+Delete to kill-word forward (ESC d)', () => {
+    expect(wordMotionSequence(keyEvent({ key: 'Delete' }))).toBe('\x1bd')
+  })
+
   it('returns null without the Alt modifier', () => {
     expect(wordMotionSequence(keyEvent({ altKey: false }))).toBeNull()
   })


### PR DESCRIPTION
## Problem

DPlex hard-codes xterm.js's `macOptionIsMeta: true` for every terminal. On macOS that makes the ⌥ Option key behave as Meta, which prevents the OS from composing characters. On Spanish — and French, German, Italian, and most other non-US layouts — common programming symbols require Option:

| Symbol | Keystroke (ES layout) |
|--------|-----------------------|
| `@`    | ⌥+2 |
| `#`    | ⌥+3 |
| `[` `]`| ⌥+ç |
| `{` `}`| ⌥+( / ⌥+) |
| `\`    | ⌥+ç |

So users on those layouts currently cannot type these characters in a DPlex terminal.

## Change

- Exposes `macOptionIsMeta` as a setting under **Settings → Terminal** (macOS only — the conflict does not exist on Windows/Linux, where non-US layouts compose via AltGr).
- **Default stays `true`** — no behaviour change for existing users. Turning it off restores character composition.
- Adds a macOS-only key handler so word-wise navigation keeps working when the setting is off: `⌥+←/→` and `⌥+⌫` are translated to the readline escape sequences (`ESC b` / `ESC f` / `ESC DEL`) bash/zsh bind to word motions — the same translation iTerm2's "Natural Text Editing" applies. Inert while `macOptionIsMeta` is on.
- The setting applies live to open terminals.

## Defaults / compatibility

No user-facing default changes — `macOptionIsMeta` defaults to `true`, matching today's hard-coded value. Existing persisted settings without the key fall back to `true` via the settings-store merge.

## Tests

- The `wordMotionSequence` translation logic is extracted into a pure module (`utils/terminalKeys.ts`) and unit-tested (`tests/unit/terminal-keys.test.ts`, 8 cases).
- `npm run typecheck`, `npm run lint`, `npm run test:unit` pass.

## Screenshots

<img width="904" height="558" alt="image" src="https://github.com/user-attachments/assets/25fddf17-793e-4a21-aa0c-d9322a42032e" />