### PR TITLE
fix: don't swallow Ctrl+R so reverse-i-search reaches the shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -518,7 +518,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.18.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.18.1...HEAD
+[0.18.1]: https://github.com/Ron537/DPlex/compare/v0.18.0...v0.18.1
 [0.18.0]: https://github.com/Ron537/DPlex/compare/v0.17.2...v0.18.0
 [0.17.2]: https://github.com/Ron537/DPlex/compare/v0.17.1...v0.17.2
 [0.17.1]: https://github.com/Ron537/DPlex/compare/v0.17.0...v0.17.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.1] — 2026-05-25
+
+### Bug Fixes
+
+- Reverse-i-search (`Ctrl+R`) works in the terminal again.
+
 ## [0.18.0] — 2026-05-24
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dplex",
-  "version": "0.15.0",
+  "version": "0.18.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dplex",
-      "version": "0.15.0",
+      "version": "0.18.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,10 +10,11 @@ import {
 import { join } from 'path'
 import * as path from 'path'
 import { randomUUID } from 'crypto'
-import { electronApp, optimizer, is } from '@electron-toolkit/utils'
+import { electronApp, is } from '@electron-toolkit/utils'
 import * as fs from 'fs'
 import * as os from 'os'
 import icon from '../../resources/icon.png?asset'
+import { shouldBlockShortcut } from './windowShortcuts'
 import {
   createPty,
   writePty,
@@ -1089,7 +1090,9 @@ app.whenReady().then(() => {
   }
 
   app.on('browser-window-created', (_, window) => {
-    optimizer.watchWindowShortcuts(window)
+    window.webContents.on('before-input-event', (event, input) => {
+      if (shouldBlockShortcut(input, { isDev: is.dev })) event.preventDefault()
+    })
   })
 
   registerIpcHandlers()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -239,7 +239,12 @@ function createWindow(): void {
       preload: join(__dirname, '../preload/index.js'),
       sandbox: false,
       contextIsolation: true,
-      nodeIntegration: false
+      nodeIntegration: false,
+      // Disable DevTools entirely in packaged builds. This covers every entry
+      // point — F12, the Cmd+Alt+I / Ctrl+Shift+I accelerator, right-click →
+      // Inspect, webContents.openDevTools() — at the Electron level, so the
+      // shortcut policy doesn't need to intercept those keys for the PTY.
+      devTools: is.dev
     }
   })
 
@@ -1091,7 +1096,7 @@ app.whenReady().then(() => {
 
   app.on('browser-window-created', (_, window) => {
     window.webContents.on('before-input-event', (event, input) => {
-      if (shouldBlockShortcut(input, { isDev: is.dev })) event.preventDefault()
+      if (shouldBlockShortcut(input)) event.preventDefault()
     })
   })
 

--- a/src/main/windowShortcuts.ts
+++ b/src/main/windowShortcuts.ts
@@ -1,0 +1,44 @@
+import type { Input } from 'electron'
+
+/**
+ * Subset of `Electron.Input` consumed by {@link shouldBlockShortcut}. Derived
+ * with `Pick` so the type tracks Electron's definition automatically.
+ */
+export type ShortcutInput = Pick<Input, 'type' | 'code' | 'control' | 'meta' | 'alt' | 'shift'>
+
+export interface ShortcutPolicyOptions {
+  isDev: boolean
+}
+
+/**
+ * Returns `true` when an input event should be `preventDefault`ed before it
+ * reaches the renderer (i.e. before xterm sees it).
+ *
+ * Replaces `optimizer.watchWindowShortcuts` from `@electron-toolkit/utils`,
+ * which preventDefaulted `KeyR + (control || meta)` in packaged builds and
+ * broke reverse-i-search inside the terminal. DPlex is a terminal: Ctrl+R
+ * belongs to the PTY, so this policy intentionally never blocks `KeyR`.
+ *
+ * What we still block (matching the toolkit's defaults):
+ *   - The DevTools accelerator in production (Cmd+Alt+I / Ctrl+Shift+I).
+ *   - Chromium's zoom shortcuts — DPlex exposes its own font-size setting.
+ */
+export function shouldBlockShortcut(input: ShortcutInput, opts: ShortcutPolicyOptions): boolean {
+  if (input.type !== 'keyDown') return false
+
+  const mod = input.control || input.meta
+
+  if (!opts.isDev) {
+    if (
+      input.code === 'KeyI' &&
+      ((input.alt && input.meta) || (input.control && input.shift))
+    ) {
+      return true
+    }
+  }
+
+  if (input.code === 'Minus' && mod) return true
+  if (input.code === 'Equal' && input.shift && mod) return true
+
+  return false
+}

--- a/src/main/windowShortcuts.ts
+++ b/src/main/windowShortcuts.ts
@@ -4,11 +4,7 @@ import type { Input } from 'electron'
  * Subset of `Electron.Input` consumed by {@link shouldBlockShortcut}. Derived
  * with `Pick` so the type tracks Electron's definition automatically.
  */
-export type ShortcutInput = Pick<Input, 'type' | 'code' | 'control' | 'meta' | 'alt' | 'shift'>
-
-export interface ShortcutPolicyOptions {
-  isDev: boolean
-}
+export type ShortcutInput = Pick<Input, 'type' | 'code' | 'control' | 'meta' | 'shift'>
 
 /**
  * Returns `true` when an input event should be `preventDefault`ed before it
@@ -16,26 +12,19 @@ export interface ShortcutPolicyOptions {
  *
  * Replaces `optimizer.watchWindowShortcuts` from `@electron-toolkit/utils`,
  * which preventDefaulted `KeyR + (control || meta)` in packaged builds and
- * broke reverse-i-search inside the terminal. DPlex is a terminal: Ctrl+R
- * belongs to the PTY, so this policy intentionally never blocks `KeyR`.
+ * broke reverse-i-search inside the terminal. DPlex is a terminal: every key
+ * the main process intercepts is a key the PTY can't see, so this policy
+ * blocks as little as possible.
  *
- * What we still block (matching the toolkit's defaults):
- *   - The DevTools accelerator in production (Cmd+Alt+I / Ctrl+Shift+I).
- *   - Chromium's zoom shortcuts — DPlex exposes its own font-size setting.
+ * Only Chromium's zoom shortcuts are blocked — DPlex exposes its own
+ * font-size setting and accidental zoom desyncs the terminal grid. DevTools
+ * is handled at the Electron level via `webPreferences.devTools` rather than
+ * by intercepting keys here.
  */
-export function shouldBlockShortcut(input: ShortcutInput, opts: ShortcutPolicyOptions): boolean {
+export function shouldBlockShortcut(input: ShortcutInput): boolean {
   if (input.type !== 'keyDown') return false
 
   const mod = input.control || input.meta
-
-  if (!opts.isDev) {
-    if (
-      input.code === 'KeyI' &&
-      ((input.alt && input.meta) || (input.control && input.shift))
-    ) {
-      return true
-    }
-  }
 
   if (input.code === 'Minus' && mod) return true
   if (input.code === 'Equal' && input.shift && mod) return true

--- a/tests/unit/window-shortcuts.test.ts
+++ b/tests/unit/window-shortcuts.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { shouldBlockShortcut, type ShortcutInput } from '../../src/main/windowShortcuts'
+
+function input(overrides: Partial<ShortcutInput> = {}): ShortcutInput {
+  return {
+    type: 'keyDown',
+    code: '',
+    control: false,
+    meta: false,
+    alt: false,
+    shift: false,
+    ...overrides
+  }
+}
+
+describe('shouldBlockShortcut', () => {
+  it('allows Ctrl+R through to the terminal in packaged builds', () => {
+    expect(shouldBlockShortcut(input({ code: 'KeyR', control: true }), { isDev: false })).toBe(
+      false
+    )
+  })
+
+  it('allows Cmd+R through to the terminal in packaged builds', () => {
+    expect(shouldBlockShortcut(input({ code: 'KeyR', meta: true }), { isDev: false })).toBe(false)
+  })
+
+  it('allows Ctrl+R through in dev builds too', () => {
+    expect(shouldBlockShortcut(input({ code: 'KeyR', control: true }), { isDev: true })).toBe(false)
+  })
+
+  it('blocks the DevTools accelerator (Cmd+Alt+I) in production', () => {
+    expect(
+      shouldBlockShortcut(input({ code: 'KeyI', alt: true, meta: true }), { isDev: false })
+    ).toBe(true)
+  })
+
+  it('blocks the DevTools accelerator (Ctrl+Shift+I) in production', () => {
+    expect(
+      shouldBlockShortcut(input({ code: 'KeyI', control: true, shift: true }), { isDev: false })
+    ).toBe(true)
+  })
+
+  it('lets the DevTools accelerator through in dev mode', () => {
+    expect(
+      shouldBlockShortcut(input({ code: 'KeyI', control: true, shift: true }), { isDev: true })
+    ).toBe(false)
+  })
+
+  it("blocks Chromium's zoom-out (Cmd/Ctrl + -)", () => {
+    expect(shouldBlockShortcut(input({ code: 'Minus', control: true }), { isDev: false })).toBe(
+      true
+    )
+    expect(shouldBlockShortcut(input({ code: 'Minus', meta: true }), { isDev: false })).toBe(true)
+  })
+
+  it("blocks Chromium's zoom-in (Cmd/Ctrl + Shift + =)", () => {
+    expect(
+      shouldBlockShortcut(input({ code: 'Equal', control: true, shift: true }), { isDev: false })
+    ).toBe(true)
+  })
+
+  it('does not block non-keyDown events', () => {
+    expect(
+      shouldBlockShortcut(input({ type: 'keyUp', code: 'KeyI', control: true, shift: true }), {
+        isDev: false
+      })
+    ).toBe(false)
+  })
+
+  it('does not block plain typing', () => {
+    expect(shouldBlockShortcut(input({ code: 'KeyA' }), { isDev: false })).toBe(false)
+    expect(shouldBlockShortcut(input({ code: 'Enter' }), { isDev: false })).toBe(false)
+  })
+})

--- a/tests/unit/window-shortcuts.test.ts
+++ b/tests/unit/window-shortcuts.test.ts
@@ -7,7 +7,6 @@ function input(overrides: Partial<ShortcutInput> = {}): ShortcutInput {
     code: '',
     control: false,
     meta: false,
-    alt: false,
     shift: false,
     ...overrides
   }
@@ -15,60 +14,28 @@ function input(overrides: Partial<ShortcutInput> = {}): ShortcutInput {
 
 describe('shouldBlockShortcut', () => {
   it('allows Ctrl+R through to the terminal in packaged builds', () => {
-    expect(shouldBlockShortcut(input({ code: 'KeyR', control: true }), { isDev: false })).toBe(
-      false
-    )
+    expect(shouldBlockShortcut(input({ code: 'KeyR', control: true }))).toBe(false)
   })
 
   it('allows Cmd+R through to the terminal in packaged builds', () => {
-    expect(shouldBlockShortcut(input({ code: 'KeyR', meta: true }), { isDev: false })).toBe(false)
-  })
-
-  it('allows Ctrl+R through in dev builds too', () => {
-    expect(shouldBlockShortcut(input({ code: 'KeyR', control: true }), { isDev: true })).toBe(false)
-  })
-
-  it('blocks the DevTools accelerator (Cmd+Alt+I) in production', () => {
-    expect(
-      shouldBlockShortcut(input({ code: 'KeyI', alt: true, meta: true }), { isDev: false })
-    ).toBe(true)
-  })
-
-  it('blocks the DevTools accelerator (Ctrl+Shift+I) in production', () => {
-    expect(
-      shouldBlockShortcut(input({ code: 'KeyI', control: true, shift: true }), { isDev: false })
-    ).toBe(true)
-  })
-
-  it('lets the DevTools accelerator through in dev mode', () => {
-    expect(
-      shouldBlockShortcut(input({ code: 'KeyI', control: true, shift: true }), { isDev: true })
-    ).toBe(false)
+    expect(shouldBlockShortcut(input({ code: 'KeyR', meta: true }))).toBe(false)
   })
 
   it("blocks Chromium's zoom-out (Cmd/Ctrl + -)", () => {
-    expect(shouldBlockShortcut(input({ code: 'Minus', control: true }), { isDev: false })).toBe(
-      true
-    )
-    expect(shouldBlockShortcut(input({ code: 'Minus', meta: true }), { isDev: false })).toBe(true)
+    expect(shouldBlockShortcut(input({ code: 'Minus', control: true }))).toBe(true)
+    expect(shouldBlockShortcut(input({ code: 'Minus', meta: true }))).toBe(true)
   })
 
   it("blocks Chromium's zoom-in (Cmd/Ctrl + Shift + =)", () => {
-    expect(
-      shouldBlockShortcut(input({ code: 'Equal', control: true, shift: true }), { isDev: false })
-    ).toBe(true)
+    expect(shouldBlockShortcut(input({ code: 'Equal', control: true, shift: true }))).toBe(true)
   })
 
   it('does not block non-keyDown events', () => {
-    expect(
-      shouldBlockShortcut(input({ type: 'keyUp', code: 'KeyI', control: true, shift: true }), {
-        isDev: false
-      })
-    ).toBe(false)
+    expect(shouldBlockShortcut(input({ type: 'keyUp', code: 'Minus', control: true }))).toBe(false)
   })
 
   it('does not block plain typing', () => {
-    expect(shouldBlockShortcut(input({ code: 'KeyA' }), { isDev: false })).toBe(false)
-    expect(shouldBlockShortcut(input({ code: 'Enter' }), { isDev: false })).toBe(false)
+    expect(shouldBlockShortcut(input({ code: 'KeyA' }))).toBe(false)
+    expect(shouldBlockShortcut(input({ code: 'Enter' }))).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

In packaged builds, `Ctrl+R` (and `Cmd+R` on macOS) is silently swallowed before xterm sees it, so `bash`/`zsh` never enters reverse-i-search.

`@electron-toolkit/utils.optimizer.watchWindowShortcuts` installs a `before-input-event` handler that calls `event.preventDefault()` on `KeyR + (control || meta)` when `!is.dev` ([source][optimizer-src]). `preventDefault` on `before-input-event` kills the event for everyone — menu and renderer — so the shell never receives the `0x12` byte.

That default is reasonable for general Electron apps (where Cmd+R = unwanted page reload), but DPlex is a terminal: Ctrl+R belongs to the PTY.

[optimizer-src]: https://github.com/alex8088/electron-toolkit/blob/master/packages/utils/src/index.ts

## Related issues

None — happy to file one retroactively if preferred.

## Changes

- New `src/main/windowShortcuts.ts` exposing a pure `shouldBlockShortcut(input)` policy function. Replaces the toolkit helper. **Intentionally never blocks `KeyR`** — that's the whole point of the fix.
- Following review: the policy now blocks **only** Chromium's zoom shortcuts (`Cmd/Ctrl + −` / `Cmd/Ctrl + Shift + =`). DevTools is disabled at the Electron level instead — `webPreferences.devTools = is.dev` covers every entry point (F12, right-click → Inspect, `openDevTools()`), so those keys can fall through to the PTY with nothing to open.
- `src/main/index.ts`: drops `optimizer` from the `@electron-toolkit/utils` import, sets `webPreferences.devTools = is.dev`, and routes `before-input-event` through the new policy.
- `tests/unit/window-shortcuts.test.ts`: 6 cases. The headline is `allows Ctrl+R through to the terminal in packaged builds` — a regression guard so this can't silently come back.
- `package.json` / `package-lock.json`: bump to `0.18.1` (PATCH — bug fix); lockfile version fields refreshed (were stale at `0.15.0`).
- `CHANGELOG.md`: customer-facing one-liner under `[0.18.1] — 2026-05-25 → Bug Fixes`, plus the `[0.18.1]` comparison links.

## Screenshots / recordings

N/A — no UI changes.

## How was this tested?

Manually in packaged-preview mode (`npm run build && npm start`):

- Fresh terminal: ran `ls`, `pwd`, `echo hello`. Pressing `Ctrl+R` (and `Cmd+R`) switches the prompt to `` (reverse-i-search)`': `` and accepts characters as expected.
- `Cmd+−` / `Cmd+=` still no-op (zoom still blocked).
- DevTools still unavailable in production — now disabled via `webPreferences.devTools = is.dev` rather than by a keyboard block.

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:unit` (418 passing, +6 from this PR)
- [ ] `npm run test:e2e` — no UI/integration behavior changed
- [x] Tested on macOS
- [ ] Tested on Windows — no machine available, but the affected code path (`input.control || input.meta`) is identical across platforms; the existing `Ctrl+P` / `Ctrl+Shift+P` / `Ctrl+Shift+F` global shortcuts continue to work via the existing `globalShortcut` path.
- [ ] Tested on Linux — same as Windows.

## Checklist

- [x] New behavior has tests.
- [x] IPC contract changes update main, preload, **and** renderer. *(N/A — no IPC changes.)*
- [x] No hardcoded path separators, shell invocations, or APIs that only work on one OS. *(Fix benefits all three platforms equally.)*
- [x] Docs (README, CONTRIBUTING, inline comments) updated where relevant. *(JSDoc on `shouldBlockShortcut` explains the why; inline comment on `webPreferences.devTools` explains the DevTools approach.)*
- [x] No secrets, tokens, or personal information added to source or history.
