### PR TITLE
feat: inherit working directory from focused terminal (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.22.0] — 2026-06-09
+
+### Features
+
+- New terminals and splits now open in the working directory of the terminal you're currently in, instead of always starting at your home folder — so siblings stay in the same project. Falls back to the focused tab's project when the live directory can't be read (e.g. on Windows).
+
 ## [0.21.0] — 2026-06-08
 
 ### Features
@@ -564,7 +570,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.22.0...HEAD
+[0.22.0]: https://github.com/Ron537/DPlex/compare/v0.21.0...v0.22.0
 [0.21.0]: https://github.com/Ron537/DPlex/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/Ron537/DPlex/compare/v0.19.0...v0.20.0
 [0.19.0]: https://github.com/Ron537/DPlex/compare/v0.18.1...v0.19.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -14,6 +14,7 @@ import {
   destroyPty,
   pausePty,
   resumePty,
+  getPtyCwd,
   destroyAllPtys,
   destroyPtysForWindow,
   getDefaultShellPath,
@@ -417,6 +418,10 @@ function registerIpcHandlers(): void {
 
   ipcMain.on('pty:resume', (_event, id: string) => {
     resumePty(id)
+  })
+
+  ipcMain.handle('pty:getCwd', (_event, id: string) => {
+    return getPtyCwd(id)
   })
 
   // Session discovery — routes through provider registry

--- a/src/main/services/pidCwd.ts
+++ b/src/main/services/pidCwd.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs'
+import { execFile } from 'child_process'
+
+// Resolving another process's cwd should never block terminal creation, so the
+// macOS `lsof` probe is bounded by a short timeout. Linux reads a symlink and
+// returns effectively instantly.
+const LSOF_TIMEOUT_MS = 400
+
+function isDirectory(p: string): boolean {
+  try {
+    return fs.statSync(p).isDirectory()
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Parse the working-directory path out of `lsof -Fn` field output.
+ *
+ * In field-output mode lsof emits one field per line, each prefixed by a single
+ * character (`p<pid>`, `f<fd>`, `n<name>`, …). We requested only the `cwd`
+ * descriptor, so the first `n` line is the cwd path. Returns null when no name
+ * field is present.
+ */
+export function parseLsofCwd(stdout: string): string | null {
+  for (const line of stdout.split('\n')) {
+    if (line.startsWith('n')) {
+      const path = line.slice(1).trim()
+      return path || null
+    }
+  }
+  return null
+}
+
+function readLinuxCwd(pid: number): Promise<string | null> {
+  return fs.promises
+    .readlink(`/proc/${pid}/cwd`)
+    .then((cwd) => (isDirectory(cwd) ? cwd : null))
+    .catch(() => null)
+}
+
+function readMacCwd(pid: number): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile(
+      'lsof',
+      ['-a', '-d', 'cwd', '-Fn', '-p', String(pid)],
+      { timeout: LSOF_TIMEOUT_MS },
+      (err, stdout) => {
+        if (err) {
+          resolve(null)
+          return
+        }
+        const path = parseLsofCwd(stdout)
+        resolve(path && isDirectory(path) ? path : null)
+      }
+    )
+  })
+}
+
+/**
+ * Resolve the current working directory of a live process by PID.
+ *
+ * - Linux: `readlink /proc/<pid>/cwd`
+ * - macOS: `lsof` cwd descriptor (no native addon required)
+ * - Windows: unsupported — there is no `/proc` and no simple unprivileged API,
+ *   so this returns null and callers fall back to other cwd sources.
+ *
+ * Never throws; returns null on any failure or unsupported platform.
+ */
+export function getProcessCwd(pid: number): Promise<string | null> {
+  if (!Number.isInteger(pid) || pid <= 0) return Promise.resolve(null)
+  if (process.platform === 'linux') return readLinuxCwd(pid)
+  if (process.platform === 'darwin') return readMacCwd(pid)
+  return Promise.resolve(null)
+}

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -3,6 +3,7 @@ import { BrowserWindow } from 'electron'
 import * as os from 'os'
 import * as fs from 'fs'
 import { DataBatcher } from './dataBatcher'
+import { getProcessCwd } from './pidCwd'
 
 interface PtyEntry {
   process: pty.IPty
@@ -275,6 +276,17 @@ export function resumePty(id: string): void {
   if (entry) {
     entry.process.resume()
   }
+}
+
+/**
+ * Resolve the live working directory of a PTY's process. Used to inherit the
+ * cwd of the focused terminal when opening a new one. Returns null when the
+ * PTY is unknown or the platform can't introspect the process cwd (Windows).
+ */
+export function getPtyCwd(id: string): Promise<string | null> {
+  const entry = ptys.get(id)
+  if (!entry) return Promise.resolve(null)
+  return getProcessCwd(entry.process.pid)
 }
 
 export function destroyAllPtys(): void {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -68,6 +68,7 @@ export interface DplexAPI {
     destroy: (id: string) => void
     pause: (id: string) => void
     resume: (id: string) => void
+    getCwd: (id: string) => Promise<string | null>
     onData: (callback: (id: string, data: string) => void) => () => void
     onExit: (callback: (id: string, exitCode: number) => void) => () => void
   }
@@ -268,6 +269,7 @@ const dplexAPI: DplexAPI = {
     destroy: (id) => ipcRenderer.send('pty:destroy', id),
     pause: (id) => ipcRenderer.send('pty:pause', id),
     resume: (id) => ipcRenderer.send('pty:resume', id),
+    getCwd: (id) => ipcRenderer.invoke('pty:getCwd', id),
     onData: (callback) => {
       const handler = (
         _event: Electron.IpcRendererEvent,

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -12,14 +12,13 @@ import { requestCloseTab } from './stores/closeConfirmStore'
 import { getFileEditorHandle } from './services/fileEditorRegistry'
 import { isFileEditorTab } from './types'
 import { dispatchOpenSettings } from './utils/openSettings'
+import { openInheritedTerminal, openInheritedSplit } from './utils/inheritCwd'
 
 function App(): React.JSX.Element {
   const loadSettings = useSettingsStore((s) => s.loadSettings)
   const loadProviders = useProvidersStore((s) => s.load)
   const initUpdateStore = useUpdateStore((s) => s.init)
   const toggleSidebar = useSettingsStore((s) => s.toggleSidebar)
-  const createTerminal = useTerminalStore((s) => s.createTerminal)
-  const splitGroup = useTerminalStore((s) => s.splitGroup)
   const setActiveGroup = useTerminalStore((s) => s.setActiveGroup)
   const setActiveTerminalInGroup = useTerminalStore((s) => s.setActiveTerminalInGroup)
 
@@ -48,7 +47,7 @@ function App(): React.JSX.Element {
 
       if (meta && e.key === 't') {
         e.preventDefault()
-        createTerminal(state.activeGroupId ?? undefined)
+        void openInheritedTerminal(state.activeGroupId ?? undefined)
       }
 
       if (meta && e.key === 'w') {
@@ -134,12 +133,12 @@ function App(): React.JSX.Element {
 
       if (meta && !e.shiftKey && e.key === '\\') {
         e.preventDefault()
-        if (state.activeGroupId) splitGroup(state.activeGroupId, 'horizontal')
+        if (state.activeGroupId) void openInheritedSplit(state.activeGroupId, 'horizontal')
       }
 
       if (meta && e.shiftKey && e.key === '\\') {
         e.preventDefault()
-        if (state.activeGroupId) splitGroup(state.activeGroupId, 'vertical')
+        if (state.activeGroupId) void openInheritedSplit(state.activeGroupId, 'vertical')
       }
 
       if (meta && e.key >= '1' && e.key <= '9') {
@@ -170,14 +169,7 @@ function App(): React.JSX.Element {
         }
       }
     },
-    [
-      createTerminal,
-      toggleSidebar,
-      splitGroup,
-      setActiveGroup,
-      setActiveTerminalInGroup,
-      openSidebarSearch
-    ]
+    [toggleSidebar, setActiveGroup, setActiveTerminalInGroup, openSidebarSearch]
   )
 
   useEffect(() => {

--- a/src/renderer/src/components/terminal/GroupTabBar.tsx
+++ b/src/renderer/src/components/terminal/GroupTabBar.tsx
@@ -15,6 +15,7 @@ import { StatusDot } from '../common/StatusDot'
 import { labelForVisual } from '../../utils/sessionStatusVisual'
 import { effectiveSessionVisual } from '../../utils/sessionPairing'
 import { getTabIdentity } from '../../utils/tabProject'
+import { openInheritedTerminal, openInheritedSplit } from '../../utils/inheritCwd'
 import { ShellSelector } from './ShellSelector'
 import type { EditorGroup } from '../../types'
 import { isTerminalTab, isFileDiffTab, isFileEditorTab } from '../../types'
@@ -35,10 +36,8 @@ interface GroupTabBarProps {
 export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.JSX.Element {
   const setActiveGroup = useTerminalStore((s) => s.setActiveGroup)
   const setActiveTerminalInGroup = useTerminalStore((s) => s.setActiveTerminalInGroup)
-  const createTerminal = useTerminalStore((s) => s.createTerminal)
   const renameTerminal = useTerminalStore((s) => s.renameTerminal)
   const promotePreviewTab = useTerminalStore((s) => s.promotePreviewTab)
-  const splitGroup = useTerminalStore((s) => s.splitGroup)
   const moveTerminalToGroup = useTerminalStore((s) => s.moveTerminalToGroup)
   const reorderTab = useTerminalStore((s) => s.reorderTab)
 
@@ -314,7 +313,7 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
         <button
           onClick={() => {
             setActiveGroup(group.id)
-            createTerminal(group.id)
+            void openInheritedTerminal(group.id)
           }}
           className="flex items-center justify-center hover:bg-[var(--dplex-hover)] transition-colors flex-shrink-0"
           style={{ width: 32, height: 36, color: 'var(--dplex-text-muted)' }}
@@ -325,7 +324,7 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
         <ShellSelector
           onSelect={(shell) => {
             setActiveGroup(group.id)
-            createTerminal(group.id, undefined, undefined, shell)
+            void openInheritedTerminal(group.id, shell)
           }}
         />
       </div>
@@ -336,7 +335,7 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
         style={{ borderLeft: '1px solid var(--dplex-border-subtle)', height: 36 }}
       >
         <button
-          onClick={() => splitGroup(group.id, 'horizontal')}
+          onClick={() => void openInheritedSplit(group.id, 'horizontal')}
           className="p-1 hover:bg-[var(--dplex-hover)] rounded transition-colors"
           style={{ color: 'var(--dplex-text-muted)' }}
           title="Split right"
@@ -344,7 +343,7 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
           <SplitSquareHorizontal size={13} />
         </button>
         <button
-          onClick={() => splitGroup(group.id, 'vertical')}
+          onClick={() => void openInheritedSplit(group.id, 'vertical')}
           className="p-1 hover:bg-[var(--dplex-hover)] rounded transition-colors"
           style={{ color: 'var(--dplex-text-muted)' }}
           title="Split down"

--- a/src/renderer/src/services/search/commandsSource.ts
+++ b/src/renderer/src/services/search/commandsSource.ts
@@ -20,6 +20,7 @@ import {
 import type { SearchItem, SearchSource } from './types'
 import { useTerminalStore } from '../../stores/terminalStore'
 import { requestCloseTab } from '../../stores/closeConfirmStore'
+import { openInheritedTerminal, openInheritedSplit } from '../../utils/inheritCwd'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useProjectStore } from '../../stores/projectStore'
@@ -61,7 +62,7 @@ const COMMANDS: readonly CommandEntry[] = [
     Icon: PlusIcon,
     run: () => {
       const ts = useTerminalStore.getState()
-      ts.createTerminal(ts.activeGroupId ?? undefined)
+      void openInheritedTerminal(ts.activeGroupId ?? undefined)
     }
   },
   {
@@ -86,7 +87,7 @@ const COMMANDS: readonly CommandEntry[] = [
     Icon: SplitSquareHorizontal,
     run: () => {
       const ts = useTerminalStore.getState()
-      if (ts.activeGroupId) ts.splitGroup(ts.activeGroupId, 'horizontal')
+      if (ts.activeGroupId) void openInheritedSplit(ts.activeGroupId, 'horizontal')
     }
   },
   {
@@ -98,7 +99,7 @@ const COMMANDS: readonly CommandEntry[] = [
     Icon: SplitSquareVertical,
     run: () => {
       const ts = useTerminalStore.getState()
-      if (ts.activeGroupId) ts.splitGroup(ts.activeGroupId, 'vertical')
+      if (ts.activeGroupId) void openInheritedSplit(ts.activeGroupId, 'vertical')
     }
   },
   {

--- a/src/renderer/src/stores/terminalStore.ts
+++ b/src/renderer/src/stores/terminalStore.ts
@@ -118,7 +118,7 @@ interface TerminalState {
   setActiveGroup: (groupId: string) => void
   setActiveTerminalInGroup: (groupId: string, terminalId: string) => void
   renameTerminal: (terminalId: string, title: string) => void
-  splitGroup: (groupId: string, direction: 'horizontal' | 'vertical') => string
+  splitGroup: (groupId: string, direction: 'horizontal' | 'vertical', cwd?: string) => string
   moveTerminalToGroup: (terminalId: string, targetGroupId: string, insertIndex?: number) => void
   moveTerminalToNewSplit: (
     terminalId: string,
@@ -313,15 +313,30 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     }))
   },
 
-  splitGroup: (groupId, direction) => {
+  splitGroup: (groupId, direction, cwd) => {
     const state = get()
+
+    // cwd inheritance resolves asynchronously before splitGroup is called, so
+    // the target group may have been closed in the meantime. Splitting against
+    // a group that's no longer in the layout would append an orphan group that
+    // insertSplitInLayout can't attach, leaving it unreachable. Redirect to the
+    // active group, or open a standalone terminal if nothing valid remains.
+    const targetGroupId = state.groups.some((g) => g.id === groupId)
+      ? groupId
+      : state.activeGroupId && state.groups.some((g) => g.id === state.activeGroupId)
+        ? state.activeGroupId
+        : null
+    if (!targetGroupId) {
+      return get().createTerminal(undefined, undefined, undefined, undefined, cwd)
+    }
+
     const newGid = makeGroupId()
-    const tab = makeTerminalTab()
+    const tab = makeTerminalTab(undefined, undefined, undefined, cwd)
     const newGroup: EditorGroup = { id: newGid, tabs: [tab], activeTabId: tab.id }
 
     set({
       groups: [...state.groups, newGroup],
-      layout: insertSplitInLayout(state.layout, groupId, newGid, direction),
+      layout: insertSplitInLayout(state.layout, targetGroupId, newGid, direction),
       activeGroupId: newGid
     })
     return tab.id

--- a/src/renderer/src/utils/inheritCwd.ts
+++ b/src/renderer/src/utils/inheritCwd.ts
@@ -1,0 +1,62 @@
+import { useTerminalStore } from '../stores/terminalStore'
+import { useProjectStore } from '../stores/projectStore'
+import { getTerminalEntry } from '../services/terminalRegistry'
+import { getTabProjectPath, findProjectForTab } from './tabProject'
+import { pickInheritedCwd } from './pickInheritedCwd'
+import type { EditorGroup } from '../types'
+
+/**
+ * Resolve the cwd to inherit from the active tab of the given group. Gathers
+ * the three candidate sources (one async IPC probe, two from in-memory state)
+ * and feeds them through {@link pickInheritedCwd}.
+ */
+async function resolveInheritedCwd(group: EditorGroup | undefined): Promise<string | undefined> {
+  if (!group) return undefined
+  const activeTab = group.tabs.find((t) => t.id === group.activeTabId)
+  if (!activeTab) return undefined
+
+  let liveCwd: string | null = null
+  const ptyId = getTerminalEntry(activeTab.id)?.ptyId
+  if (ptyId) {
+    try {
+      liveCwd = await window.dplex.pty.getCwd(ptyId)
+    } catch {
+      // Best-effort — fall through to the synchronous sources.
+    }
+  }
+
+  return pickInheritedCwd({
+    liveCwd,
+    tabOwnPath: getTabProjectPath(activeTab),
+    projectPath: findProjectForTab(activeTab, useProjectStore.getState().projects)?.path
+  })
+}
+
+/** Resolve the group a new terminal/split should inherit from. */
+function inheritSourceGroup(groupId: string | undefined): EditorGroup | undefined {
+  const state = useTerminalStore.getState()
+  const id = groupId ?? state.activeGroupId
+  return state.groups.find((g) => g.id === id)
+}
+
+/**
+ * Open a new terminal that inherits the focused terminal's working directory.
+ * Mirrors {@link useTerminalStore}'s `createTerminal` signature for the args
+ * callers actually use when opening blank terminals.
+ */
+export async function openInheritedTerminal(groupId?: string, shell?: string): Promise<string> {
+  const cwd = await resolveInheritedCwd(inheritSourceGroup(groupId))
+  return useTerminalStore.getState().createTerminal(groupId, undefined, undefined, shell, cwd)
+}
+
+/**
+ * Split the given group into a new terminal that inherits the focused
+ * terminal's working directory.
+ */
+export async function openInheritedSplit(
+  groupId: string,
+  direction: 'horizontal' | 'vertical'
+): Promise<string> {
+  const cwd = await resolveInheritedCwd(inheritSourceGroup(groupId))
+  return useTerminalStore.getState().splitGroup(groupId, direction, cwd)
+}

--- a/src/renderer/src/utils/pickInheritedCwd.ts
+++ b/src/renderer/src/utils/pickInheritedCwd.ts
@@ -1,0 +1,18 @@
+/**
+ * Pick the working directory a newly opened terminal should inherit from the
+ * focused one, in priority order:
+ *   1. Live cwd of the focused PTY's process — tracks `cd` (macOS/Linux only;
+ *      null on Windows where process cwd can't be introspected cheaply).
+ *   2. The focused tab's own path — its worktree path or starting cwd.
+ *   3. The root of the project the focused tab belongs to — cross-platform,
+ *      so Windows users still land in the right project.
+ *
+ * Returns undefined when none apply, letting the caller fall back to $HOME.
+ */
+export function pickInheritedCwd(sources: {
+  liveCwd: string | null
+  tabOwnPath: string | undefined
+  projectPath: string | undefined
+}): string | undefined {
+  return sources.liveCwd || sources.tabOwnPath || sources.projectPath || undefined
+}

--- a/tests/unit/inherit-cwd.test.ts
+++ b/tests/unit/inherit-cwd.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseLsofCwd } from '../../src/main/services/pidCwd'
+import { pickInheritedCwd } from '../../src/renderer/src/utils/pickInheritedCwd'
+
+describe('parseLsofCwd', () => {
+  it('extracts the path from the cwd name field', () => {
+    const stdout = 'p12345\nfcwd\nn/Users/me/projects/dplex\n'
+    expect(parseLsofCwd(stdout)).toBe('/Users/me/projects/dplex')
+  })
+
+  it('returns the first name field when several lines are present', () => {
+    const stdout = 'p12345\nn/Users/me/code\nn/Users/me/other\n'
+    expect(parseLsofCwd(stdout)).toBe('/Users/me/code')
+  })
+
+  it('handles paths containing spaces', () => {
+    const stdout = 'p999\nn/Users/me/My Projects/app\n'
+    expect(parseLsofCwd(stdout)).toBe('/Users/me/My Projects/app')
+  })
+
+  it('returns null when there is no name field', () => {
+    expect(parseLsofCwd('p12345\nfcwd\n')).toBeNull()
+  })
+
+  it('returns null for empty output', () => {
+    expect(parseLsofCwd('')).toBeNull()
+  })
+
+  it('returns null when the name field is empty', () => {
+    expect(parseLsofCwd('p12345\nn\n')).toBeNull()
+  })
+})
+
+describe('pickInheritedCwd', () => {
+  it('prefers the live process cwd above all', () => {
+    expect(
+      pickInheritedCwd({
+        liveCwd: '/live/path',
+        tabOwnPath: '/tab/path',
+        projectPath: '/project/path'
+      })
+    ).toBe('/live/path')
+  })
+
+  it('falls back to the tab own path when there is no live cwd', () => {
+    expect(
+      pickInheritedCwd({
+        liveCwd: null,
+        tabOwnPath: '/tab/path',
+        projectPath: '/project/path'
+      })
+    ).toBe('/tab/path')
+  })
+
+  it('falls back to the project root when only the project is known', () => {
+    expect(
+      pickInheritedCwd({
+        liveCwd: null,
+        tabOwnPath: undefined,
+        projectPath: '/project/path'
+      })
+    ).toBe('/project/path')
+  })
+
+  it('returns undefined when no source applies (caller falls back to $HOME)', () => {
+    expect(
+      pickInheritedCwd({ liveCwd: null, tabOwnPath: undefined, projectPath: undefined })
+    ).toBeUndefined()
+  })
+
+  it('treats an empty-string live cwd as absent and falls through', () => {
+    expect(pickInheritedCwd({ liveCwd: '', tabOwnPath: '/tab/path', projectPath: undefined })).toBe(
+      '/tab/path'
+    )
+  })
+})

--- a/tests/unit/terminal-split-cwd.test.ts
+++ b/tests/unit/terminal-split-cwd.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Unit tests for `terminalStore.splitGroup` cwd inheritance and the guard that
+ * prevents an orphaned, unreachable group when the source group is closed
+ * during the async cwd-resolution gap (issue #73).
+ *
+ * Runs in node env. We stub the `window.dplex` surface the store touches.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTerminalStore } from '../../src/renderer/src/stores/terminalStore'
+import type { LayoutNode } from '../../src/renderer/src/types'
+
+function setupWindow(): void {
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: {
+      sessions: {
+        saveWorkspace: vi.fn().mockResolvedValue(undefined),
+        saveWorkspaceSync: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined)
+      },
+      pty: { destroy: vi.fn() }
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}
+
+beforeEach(() => {
+  setupWindow()
+  useTerminalStore.setState({
+    groups: [],
+    layout: { type: 'group', groupId: '' },
+    activeGroupId: null,
+    restored: false
+  } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/** Collect every groupId referenced by the layout tree. */
+function layoutGroupIds(node: LayoutNode, acc: string[] = []): string[] {
+  if (node.type === 'group' && node.groupId) acc.push(node.groupId)
+  if (node.children) for (const c of node.children) layoutGroupIds(c, acc)
+  return acc
+}
+
+describe('terminalStore.splitGroup — cwd inheritance', () => {
+  it('passes the inherited cwd onto the new split tab', () => {
+    useTerminalStore.getState().createTerminal()
+    const sourceGroup = useTerminalStore.getState().activeGroupId!
+
+    const tabId = useTerminalStore.getState().splitGroup(sourceGroup, 'horizontal', '/code/dplex')
+
+    const tab = useTerminalStore
+      .getState()
+      .groups.flatMap((g) => g.tabs)
+      .find((t) => t.id === tabId)!
+    expect(tab.kind).not.toBe('fileDiff')
+    if (tab.kind !== 'fileDiff') expect(tab.cwd).toBe('/code/dplex')
+  })
+
+  it('attaches the new split group to the layout tree', () => {
+    useTerminalStore.getState().createTerminal()
+    const sourceGroup = useTerminalStore.getState().activeGroupId!
+
+    useTerminalStore.getState().splitGroup(sourceGroup, 'horizontal')
+
+    const state = useTerminalStore.getState()
+    const ids = layoutGroupIds(state.layout)
+    // Every live group must be reachable from the layout tree.
+    for (const g of state.groups) expect(ids).toContain(g.id)
+    expect(ids).toContain(state.activeGroupId)
+  })
+})
+
+describe('terminalStore.splitGroup — stale source group guard (issue #73)', () => {
+  it('does not create an orphan group when the target group no longer exists', () => {
+    useTerminalStore.getState().createTerminal()
+    const liveGroup = useTerminalStore.getState().activeGroupId!
+
+    // Simulate the async race: split a group id that was closed during the
+    // cwd-resolution wait while another group is still active.
+    const tabId = useTerminalStore.getState().splitGroup('group-gone', 'vertical', '/x')
+
+    const state = useTerminalStore.getState()
+    const ids = layoutGroupIds(state.layout)
+    // No group is left dangling outside the layout.
+    for (const g of state.groups) expect(ids).toContain(g.id)
+    // The active group is reachable and the new tab exists somewhere live.
+    expect(ids).toContain(state.activeGroupId)
+    const tab = state.groups.flatMap((g) => g.tabs).find((t) => t.id === tabId)
+    expect(tab).toBeDefined()
+    expect(state.groups.some((g) => g.id === liveGroup)).toBe(true)
+  })
+
+  it('falls back to a standalone terminal when no groups remain', () => {
+    // No groups at all — the guard should still produce a reachable terminal.
+    const tabId = useTerminalStore.getState().splitGroup('group-gone', 'horizontal', '/y')
+
+    const state = useTerminalStore.getState()
+    expect(state.groups.length).toBe(1)
+    const ids = layoutGroupIds(state.layout)
+    expect(ids).toContain(state.activeGroupId)
+    const tab = state.groups.flatMap((g) => g.tabs).find((t) => t.id === tabId)
+    expect(tab).toBeDefined()
+    if (tab && tab.kind !== 'fileDiff') expect(tab.cwd).toBe('/y')
+  })
+})


### PR DESCRIPTION
## Summary

Implements #73. Opening a new terminal (**Ctrl+T** / command palette) or **split** now starts in the focused terminal's working directory instead of always `$HOME`, so sibling shells stay in the same project — matching iTerm2 / kitty / WezTerm / tmux behavior.

## How it works

cwd is resolved via a cascade, async in the main process so terminal creation never blocks:

1. **Live cwd of the focused PTY's process** — tracks `cd`. macOS via `lsof`, Linux via `/proc/<pid>/cwd`, Windows unsupported (falls through). Bounded by a 400 ms timeout.
2. **The focused tab's own path** — worktree path / cwd for terminals, repo root for diff tabs, project root for editor tabs.
3. **The focused tab's project root** — cross-platform, so Windows users still land in the right project.
4. **`$HOME`** — last-resort fallback (existing `ptyManager` behavior).

Tiers 2–4 are synchronous and platform-agnostic, so inheritance works everywhere from day one; the native PID probe is a pure enhancement for live `cd`-tracking on macOS/Linux.

We chose **always-on, no setting** (the behavior users coming from other terminals expect). OSC 7 was intentionally **not** used — the issue's plan discards its only real advantage (remote/SSH awareness), and bare login shells rarely emit it, so it would add parser/cache/validation cost for little gain.

## Files

- `src/main/services/pidCwd.ts` *(new)* — `getProcessCwd(pid)`, platform-specific, never throws.
- `ptyManager.ts` `getPtyCwd`, `index.ts` `pty:getCwd` IPC, `preload` `getCwd`.
- `utils/inheritCwd.ts` + `pickInheritedCwd.ts` *(new)* — cascade + orchestrators.
- `terminalStore.splitGroup` gains a `cwd` param **and a guard** so the async wait can't orphan a group if the source group closes mid-resolution.
- Wired all blank-terminal entry points (Ctrl+T, splits, GroupTabBar new/shell/split buttons, command palette). AI-session creators untouched.

## Testing

- **Unit**: +15 tests (`inherit-cwd.test.ts`, `terminal-split-cwd.test.ts`); full suite 491 passing.
- **e2e**: `app.e2e.spec.ts` passing, incl. *"creates a terminal and splits groups"*.
- Typecheck, lint, build all clean. Verified working on macOS.
- ⚠️ Linux/Windows not yet manually smoke-tested — both fall through safely, but live `cd`-tracking on Linux (`/proc`) would benefit from a quick check.

## Review

Dual-model code review (opus-4.7 + gpt-5.5) run twice (pre- and post-rebase onto the Explorer feature); both clean. One race (orphan group during async wait) was caught and fixed with the `splitGroup` guard + regression tests.

Closes #73
