### PR TITLE
feat(dashboard): add Overview dashboard for AI sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] — 2026-06-23
+
+### Features
+
+- New **Dashboard** for an at-a-glance overview of your AI sessions: open it from the sidebar or the command palette to see what's running, what needs you, the repositories you work in most, when you tend to work, and your recent sessions. It also surfaces housekeeping at a glance — the oldest request waiting on you, sessions that have gone stale, your longest-running session, and uncommitted changes across your repos — plus activity trends, an active-day streak, and your Copilot/Claude mix. Click any card, repo, or session to jump straight to it.
+
 ## [0.27.1] — 2026-06-20
 
 ### Improvements
@@ -620,7 +626,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.27.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.28.0...HEAD
+[0.28.0]: https://github.com/Ron537/DPlex/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/Ron537/DPlex/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/Ron537/DPlex/compare/v0.26.0...v0.27.0
 [0.26.0]: https://github.com/Ron537/DPlex/compare/v0.25.0...v0.26.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.27.1",
+  "version": "0.28.0",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -31,6 +31,7 @@ import {
 } from './services/ptyManager'
 import { createDefaultRegistry } from './services/providers'
 import { BaseSessionProvider } from './services/providers/baseProvider'
+import { computeDashboardMetrics } from './services/dashboard/dashboardAggregator'
 import { ClaudePidfileRegistry } from './services/providers/claudePidfileRegistry'
 import {
   loadWorkspace,
@@ -475,6 +476,17 @@ function registerIpcHandlers(): void {
 
   ipcMain.handle('sessions:getProviders', () => {
     return providerRegistry.getProviderInfoList()
+  })
+
+  // Overview Dashboard — long-window historical aggregation. Computed on
+  // demand (tab open / debounced invalidation / manual refresh); no polling.
+  ipcMain.handle('dashboard:getMetrics', async (_event, windowDays?: number) => {
+    const days = Number.isFinite(windowDays) && windowDays! >= 1 ? Math.floor(windowDays!) : 30
+    // Fetch two windows of history so the aggregator can compute
+    // period-over-period deltas (current vs the immediately preceding window).
+    const cutoffMs = Date.now() - 2 * days * 86_400_000
+    const history = await providerRegistry.getSessionHistory(cutoffMs)
+    return computeDashboardMetrics(history, { windowDays: days, nowMs: Date.now() })
   })
 
   // Session watching — start/stop watchers, push events to renderer

--- a/src/main/services/dashboard/dashboardAggregator.ts
+++ b/src/main/services/dashboard/dashboardAggregator.ts
@@ -1,0 +1,171 @@
+import type {
+  DashboardMetrics,
+  HeatCell,
+  HistoricalSession,
+  ProviderSplit,
+  RepoUsage,
+  TimeBucket
+} from './types'
+
+/** Default number of top repositories surfaced. */
+const DEFAULT_TOP_REPOS = 8
+
+/** Basename of a filesystem path, tolerating both `/` and `\` separators. */
+function basename(p: string): string {
+  const parts = p.replace(/\\/g, '/').replace(/\/+$/, '').split('/')
+  return parts[parts.length - 1] || p
+}
+
+/**
+ * Derive a stable repo label for a session. Prefers the provider-supplied
+ * `repository`, then the cwd basename, then a sentinel.
+ */
+function repoLabel(s: HistoricalSession): string {
+  if (s.repository && s.repository.trim()) return s.repository.trim()
+  if (s.cwd && s.cwd.trim()) return basename(s.cwd.trim())
+  return 'unknown'
+}
+
+/** Local midnight (ms) for a given timestamp. */
+function startOfLocalDay(ms: number): number {
+  const d = new Date(ms)
+  d.setHours(0, 0, 0, 0)
+  return d.getTime()
+}
+
+/** Weekday index with Monday=0 … Sunday=6 (JS getDay is Sunday=0). */
+function mondayFirstWeekday(ms: number): number {
+  const js = new Date(ms).getDay()
+  return (js + 6) % 7
+}
+
+/**
+ * Aggregate a flat list of historical sessions into a dashboard snapshot.
+ * Pure — no I/O, no Date.now() unless `nowMs` is omitted. Safe to unit test.
+ */
+export function computeDashboardMetrics(
+  sessions: HistoricalSession[],
+  opts: { windowDays: number; nowMs?: number; topRepos?: number }
+): DashboardMetrics {
+  const nowMs = opts.nowMs ?? Date.now()
+  const windowDays = Math.max(1, Math.floor(opts.windowDays))
+  const topReposN = opts.topRepos ?? DEFAULT_TOP_REPOS
+  const windowMs = windowDays * 86_400_000
+  const cutoffMs = nowMs - windowMs
+  const prevCutoffMs = nowMs - 2 * windowMs
+
+  // Defensive: only consider sessions created within the window.
+  const inWindow = sessions.filter((s) => s.createdAtMs >= cutoffMs && s.createdAtMs <= nowMs)
+
+  // Previous equal-length window `[now-2w, now-w)` for period-over-period deltas.
+  const previousTotals = { sessions: 0, messages: 0, toolCalls: 0 }
+  for (const s of sessions) {
+    if (s.createdAtMs >= prevCutoffMs && s.createdAtMs < cutoffMs) {
+      previousTotals.sessions += 1
+      previousTotals.messages += s.messageCount
+      previousTotals.toolCalls += s.toolCallCount
+    }
+  }
+
+  // ── Totals & provider split ──────────────────────────────────────
+  const totals = { sessions: inWindow.length, messages: 0, toolCalls: 0 }
+  const providerCounts = new Map<string, number>()
+  for (const s of inWindow) {
+    totals.messages += s.messageCount
+    totals.toolCalls += s.toolCallCount
+    providerCounts.set(s.providerId, (providerCounts.get(s.providerId) ?? 0) + 1)
+  }
+  const providerSplit: ProviderSplit[] = Array.from(providerCounts, ([providerId, count]) => ({
+    providerId,
+    sessions: count
+  })).sort((a, b) => b.sessions - a.sessions)
+
+  // ── Top repos ────────────────────────────────────────────────────
+  const repoMap = new Map<string, RepoUsage & { branchSeen: Map<string, number> }>()
+  for (const s of inWindow) {
+    const repo = repoLabel(s)
+    let r = repoMap.get(repo)
+    if (!r) {
+      r = {
+        repo,
+        cwd: s.cwd,
+        sessions: 0,
+        messages: 0,
+        toolCalls: 0,
+        lastActiveMs: 0,
+        branches: [],
+        branchSeen: new Map()
+      }
+      repoMap.set(repo, r)
+    }
+    r.sessions += 1
+    r.messages += s.messageCount
+    r.toolCalls += s.toolCallCount
+    r.lastActiveMs = Math.max(r.lastActiveMs, s.updatedAtMs)
+    if (s.branch && s.branch.trim()) {
+      const b = s.branch.trim()
+      r.branchSeen.set(b, Math.max(r.branchSeen.get(b) ?? 0, s.updatedAtMs))
+    }
+  }
+  const topRepos: RepoUsage[] = Array.from(repoMap.values())
+    .map(({ branchSeen, ...rest }) => ({
+      ...rest,
+      branches: Array.from(branchSeen.entries())
+        .sort((a, b) => b[1] - a[1])
+        .map(([b]) => b)
+    }))
+    .sort((a, b) => b.sessions - a.sessions || b.lastActiveMs - a.lastActiveMs)
+    .slice(0, topReposN)
+
+  // ── Over-time buckets (one per day, oldest → newest) ─────────────
+  const bucketByDay = new Map<number, TimeBucket>()
+  // Seed every day in the window so the chart has no gaps. Advance by
+  // re-normalizing to local midnight each step (adding ~26h then snapping
+  // back) so DST transitions — where consecutive local midnights are 23h or
+  // 25h apart — don't drift the seeded keys off `startOfLocalDay`, which would
+  // otherwise double-count or skip days for the rest of the window.
+  const firstDay = startOfLocalDay(cutoffMs)
+  const lastDay = startOfLocalDay(nowMs)
+  for (let day = firstDay; day <= lastDay; day = startOfLocalDay(day + 26 * 3_600_000)) {
+    bucketByDay.set(day, { dateMs: day, byProvider: {}, total: 0 })
+  }
+  for (const s of inWindow) {
+    const day = startOfLocalDay(s.createdAtMs)
+    let bucket = bucketByDay.get(day)
+    if (!bucket) {
+      bucket = { dateMs: day, byProvider: {}, total: 0 }
+      bucketByDay.set(day, bucket)
+    }
+    bucket.byProvider[s.providerId] = (bucket.byProvider[s.providerId] ?? 0) + 1
+    bucket.total += 1
+  }
+  const overTime: TimeBucket[] = Array.from(bucketByDay.values()).sort(
+    (a, b) => a.dateMs - b.dateMs
+  )
+
+  // ── Heatmap (7×24, Monday-first) ─────────────────────────────────
+  const heatIndex = new Map<number, HeatCell>()
+  for (let wd = 0; wd < 7; wd++) {
+    for (let h = 0; h < 24; h++) {
+      heatIndex.set(wd * 24 + h, { weekday: wd, hour: h, count: 0 })
+    }
+  }
+  for (const s of inWindow) {
+    const wd = mondayFirstWeekday(s.createdAtMs)
+    const hour = new Date(s.createdAtMs).getHours()
+    const cell = heatIndex.get(wd * 24 + hour)
+    if (cell) cell.count += 1
+  }
+  const heatmap: HeatCell[] = Array.from(heatIndex.values())
+
+  return {
+    windowDays,
+    generatedAtMs: nowMs,
+    totals,
+    previousTotals,
+    providerSplit,
+    topRepos,
+    overTime,
+    heatmap
+  }
+}

--- a/src/main/services/dashboard/types.ts
+++ b/src/main/services/dashboard/types.ts
@@ -1,0 +1,84 @@
+/**
+ * Shared types for the Overview Dashboard.
+ *
+ * `HistoricalSession` is the lightweight, provider-agnostic row each provider
+ * yields from {@link SessionProvider.getSessionHistory}. The aggregator turns a
+ * flat list of these into a {@link DashboardMetrics} snapshot. These types flow
+ * main → preload → renderer, so they must stay JSON-serializable (no Dates).
+ */
+
+/** A single past session, reduced to the fields the dashboard needs. */
+export interface HistoricalSession {
+  id: string
+  providerId: string
+  cwd: string | null
+  /** Repo identity (provider-supplied, else derived from cwd). */
+  repository: string | null
+  branch: string | null
+  createdAtMs: number
+  updatedAtMs: number
+  /** Best-effort; 0 when the provider can't supply it cheaply. */
+  messageCount: number
+  /** Best-effort; 0 when the provider can't supply it cheaply. */
+  toolCallCount: number
+}
+
+/** Per-repository usage rollup. */
+export interface RepoUsage {
+  repo: string
+  cwd: string | null
+  sessions: number
+  messages: number
+  toolCalls: number
+  lastActiveMs: number
+  /** Distinct branches seen for this repo, most-recent first. */
+  branches: string[]
+}
+
+/** One calendar day in the window (local time). */
+export interface TimeBucket {
+  /** Local midnight of the day, in ms. */
+  dateMs: number
+  /** Sessions started that day, keyed by providerId. */
+  byProvider: Record<string, number>
+  total: number
+}
+
+/** One hour×weekday heatmap cell. weekday: 0=Mon … 6=Sun. hour: 0–23. */
+export interface HeatCell {
+  weekday: number
+  hour: number
+  count: number
+}
+
+/** Per-provider session count. */
+export interface ProviderSplit {
+  providerId: string
+  sessions: number
+}
+
+/** The full historical snapshot returned by the aggregation IPC. */
+export interface DashboardMetrics {
+  windowDays: number
+  generatedAtMs: number
+  totals: {
+    sessions: number
+    messages: number
+    toolCalls: number
+  }
+  /**
+   * Totals for the immediately preceding window of equal length (i.e. the
+   * window `[now-2w, now-w]`). Used to render period-over-period deltas.
+   */
+  previousTotals: {
+    sessions: number
+    messages: number
+    toolCalls: number
+  }
+  providerSplit: ProviderSplit[]
+  topRepos: RepoUsage[]
+  /** One bucket per day across the window, oldest → newest. */
+  overTime: TimeBucket[]
+  /** 168 cells (7 weekdays × 24 hours). */
+  heatmap: HeatCell[]
+}

--- a/src/main/services/providers/baseProvider.ts
+++ b/src/main/services/providers/baseProvider.ts
@@ -9,6 +9,7 @@ import type {
   SessionPrompt,
   ParsedSessionData
 } from './types'
+import type { HistoricalSession } from '../dashboard/types'
 import { killProcess, isProcessAlive, waitForProcessesToExit } from './processUtils'
 
 // Filesystems on macOS and Windows are case-insensitive by default; Linux is case-sensitive.
@@ -317,6 +318,33 @@ export abstract class BaseSessionProvider implements SessionProvider {
     return sessions.sort(
       (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
     )
+  }
+
+  /**
+   * Cheap, default history: one row per on-disk entry created at/after the
+   * cutoff. Uses only filesystem timestamps — no per-session event parsing —
+   * so cwd/repository/branch are unknown and counts are 0. Providers with a
+   * richer store (e.g. Copilot's Chronicle) should override this.
+   */
+  async getSessionHistory(cutoffMs: number): Promise<HistoricalSession[]> {
+    const entries = await this.listSessionEntries()
+    const out: HistoricalSession[] = []
+    for (const entry of entries) {
+      if (!this.validateSessionId(entry.id)) continue
+      if (entry.birthtimeMs < cutoffMs) continue
+      out.push({
+        id: entry.id,
+        providerId: this.id,
+        cwd: null,
+        repository: null,
+        branch: null,
+        createdAtMs: entry.birthtimeMs,
+        updatedAtMs: entry.mtimeMs,
+        messageCount: 0,
+        toolCallCount: 0
+      })
+    }
+    return out
   }
 
   // ── Session Lifecycle ────────────────────────────────────────────

--- a/src/main/services/providers/claudeCodeProvider.ts
+++ b/src/main/services/providers/claudeCodeProvider.ts
@@ -9,6 +9,7 @@ import type {
   SessionStatus,
   WatcherCallbacks
 } from './types'
+import type { HistoricalSession } from '../dashboard/types'
 import { BaseSessionProvider, type SessionEntry } from './baseProvider'
 import {
   parseClaudeEvents,
@@ -181,6 +182,36 @@ export class ClaudeCodeProvider extends BaseSessionProvider {
 
   protected parseEventsIncremental(filePath: string): Promise<ParsedSessionData> {
     return parseClaudeEvents(filePath)
+  }
+
+  /**
+   * Cheap history for the dashboard: one row per `.jsonl` session file created
+   * at/after the cutoff. The cwd is decoded from the project-folder slug (or
+   * the cached JSONL `cwd` when available) and the repo label is its basename.
+   * Counts are left at 0 — deriving them would require parsing every JSONL,
+   * which is too expensive for a 30-day window.
+   */
+  async getSessionHistory(cutoffMs: number): Promise<HistoricalSession[]> {
+    const entries = await this.listSessionEntries()
+    const out: HistoricalSession[] = []
+    for (const entry of entries) {
+      if (!this.validateSessionId(entry.id)) continue
+      if (entry.birthtimeMs < cutoffMs) continue
+      const extras = getCachedExtras(entry.path)
+      const cwd = extras.cwd ?? decodeCwdFromSlug(path.basename(path.dirname(entry.path))) ?? null
+      out.push({
+        id: entry.id,
+        providerId: this.id,
+        cwd,
+        repository: cwd ? path.basename(cwd) : null,
+        branch: extras.gitBranch ?? null,
+        createdAtMs: entry.birthtimeMs,
+        updatedAtMs: entry.mtimeMs,
+        messageCount: 0,
+        toolCallCount: 0
+      })
+    }
+    return out
   }
 
   protected extractPromptsFromEvents(entryPath: string, limit: number): Promise<SessionPrompt[]> {

--- a/src/main/services/providers/copilotChronicle.ts
+++ b/src/main/services/providers/copilotChronicle.ts
@@ -204,9 +204,39 @@ export class CopilotChronicle {
     }
   }
 
-  /** Returns `Map<sessionId, messageCount>` for every session that has turns. */
-  getMessageCounts(): Map<string, number> {
+  /**
+   * Returns `Map<sessionId, messageCount>`. When `sessionIds` is provided,
+   * counts turns only for those sessions (chunked `WHERE session_id IN (...)`)
+   * — so callers like the dashboard pay a cost bounded by their window rather
+   * than scanning the entire `turns` table. With no argument, returns counts
+   * for every session (used by the live discovery path).
+   */
+  getMessageCounts(sessionIds?: readonly string[]): Map<string, number> {
     const map = new Map<string, number>()
+
+    if (sessionIds) {
+      if (sessionIds.length === 0) return map
+      if (!this.db || !this.hasTurnsCols.has('session_id')) return map
+      const CHUNK = 500
+      try {
+        for (let i = 0; i < sessionIds.length; i += CHUNK) {
+          const chunk = sessionIds.slice(i, i + CHUNK)
+          const placeholders = chunk.map(() => '?').join(',')
+          const stmt = this.db.prepare(
+            `SELECT session_id AS sid, COUNT(*) AS n FROM turns
+             WHERE session_id IN (${placeholders}) GROUP BY session_id`
+          )
+          const rows = stmt.all(...chunk) as unknown as Array<{ sid: string; n: number }>
+          for (const r of rows) {
+            if (typeof r.sid === 'string' && typeof r.n === 'number') map.set(r.sid, r.n)
+          }
+        }
+      } catch {
+        // ignore
+      }
+      return map
+    }
+
     if (!this.stmts.countTurns) return map
     try {
       const rows = this.stmts.countTurns.all() as unknown as Array<{

--- a/src/main/services/providers/copilotProvider.ts
+++ b/src/main/services/providers/copilotProvider.ts
@@ -8,6 +8,7 @@ import type {
   SessionPrompt,
   WatcherCallbacks
 } from './types'
+import type { HistoricalSession } from '../dashboard/types'
 import { BaseSessionProvider, normalizePathForCompare, type SessionEntry } from './baseProvider'
 import {
   parseCopilotEvents,
@@ -144,10 +145,7 @@ export class CopilotProvider extends BaseSessionProvider {
     // user-deleted ids the Chronicle still remembers, and rows whose
     // on-disk dir has been removed since.
     const rows = allRows.filter(
-      (r) =>
-        this.validateSessionId(r.id) &&
-        !this.deletedIds.has(r.id) &&
-        existingDirs.has(r.id)
+      (r) => this.validateSessionId(r.id) && !this.deletedIds.has(r.id) && existingDirs.has(r.id)
     )
     if (rows.length === 0) {
       // DB exists but empty (very fresh install). Fall back so the user
@@ -208,7 +206,41 @@ export class CopilotProvider extends BaseSessionProvider {
     )
   }
 
-  /** Fast cwd → active session lookup using the Chronicle's indexed `cwd` column. */
+  /**
+   * Chronicle-backed history for the dashboard. The Chronicle indexes every
+   * session with repository/branch/timestamps and exact turn (message) counts,
+   * so this is both rich and cheap (two prepared queries, no event parsing).
+   * Falls back to the filesystem-only base implementation when the Chronicle
+   * isn't available (older CLI / fresh install / locked DB).
+   */
+  async getSessionHistory(cutoffMs: number): Promise<HistoricalSession[]> {
+    if (!this.chronicle.tryOpen()) {
+      return super.getSessionHistory(cutoffMs)
+    }
+    const rows = this.chronicle.listSessions({ cutoffMs })
+    // Gate on on-disk existence — same guard discoverSessions uses — so rows
+    // for sessions deleted from disk in a previous run (the Chronicle is
+    // read-only to us and outlives the dir) don't resurrect in dashboard
+    // totals after a restart, when the in-memory deletedIds set is empty.
+    const existingDirs = await this.listExistingSessionDirs()
+    const kept = rows.filter(
+      (r) => this.validateSessionId(r.id) && !this.deletedIds.has(r.id) && existingDirs.has(r.id)
+    )
+    // Count turns only for the windowed sessions — cost scales with the
+    // dashboard window, not the entire Chronicle history.
+    const messageCounts = this.chronicle.getMessageCounts(kept.map((r) => r.id))
+    return kept.map((r) => ({
+      id: r.id,
+      providerId: this.id,
+      cwd: r.cwd,
+      repository: r.repository,
+      branch: r.branch,
+      createdAtMs: r.createdAtMs,
+      updatedAtMs: r.updatedAtMs,
+      messageCount: messageCounts.get(r.id) ?? 0,
+      toolCallCount: 0
+    }))
+  }
   async resolveSessionByCwd(cwd: string): Promise<ResolvedSession | null> {
     if (!this.chronicle.tryOpen()) return super.resolveSessionByCwd(cwd)
 

--- a/src/main/services/providers/registry.ts
+++ b/src/main/services/providers/registry.ts
@@ -1,4 +1,5 @@
 import type { SessionProvider, DiscoveredSession, ResolvedSession, ProviderInfo } from './types'
+import type { HistoricalSession } from '../dashboard/types'
 
 /**
  * Central registry of AI tool providers.
@@ -42,6 +43,24 @@ export class ProviderRegistry {
       results.push(...sessions)
     }
     return results.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime())
+  }
+
+  /**
+   * Collect lightweight historical rows from every provider for sessions
+   * created at/after `cutoffMs`. Used by the Overview Dashboard aggregator.
+   * Provider failures are isolated so one bad provider can't blank the board.
+   */
+  async getSessionHistory(cutoffMs: number): Promise<HistoricalSession[]> {
+    const results: HistoricalSession[] = []
+    for (const provider of this.providers.values()) {
+      try {
+        const rows = await provider.getSessionHistory(cutoffMs)
+        results.push(...rows)
+      } catch {
+        // Skip a failing provider rather than failing the whole snapshot.
+      }
+    }
+    return results
   }
 
   /** Close a session — tries the specified provider, or searches all. */

--- a/src/main/services/providers/types.ts
+++ b/src/main/services/providers/types.ts
@@ -3,6 +3,8 @@
  * Each AI CLI tool (Copilot, Claude, Codex, etc.) implements SessionProvider.
  */
 
+import type { HistoricalSession } from '../dashboard/types'
+
 /** Granular session status derived from JSONL event parsing. */
 export type SessionStatus =
   | 'idle'
@@ -74,6 +76,14 @@ export interface SessionProvider {
 
   /** Discover all sessions for this provider from disk/filesystem. */
   discoverSessions(): Promise<DiscoveredSession[]>
+
+  /**
+   * Return lightweight historical rows for sessions created at/after
+   * `cutoffMs`. Used by the Overview Dashboard for long-window aggregation,
+   * independent of the (shorter) live-discovery age cap. Must stay cheap —
+   * no deep per-session event parsing.
+   */
+  getSessionHistory(cutoffMs: number): Promise<HistoricalSession[]>
 
   /** Close an active session by killing its process. Returns true if a process was killed. */
   closeSession(sessionId: string): Promise<boolean>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -28,6 +28,16 @@ import type {
   WriteFileResult,
   FsMutationResult
 } from '../main/services/fsExplorer/types'
+import type { DashboardMetrics } from '../main/services/dashboard/types'
+
+export type {
+  DashboardMetrics,
+  HistoricalSession,
+  RepoUsage,
+  TimeBucket,
+  HeatCell,
+  ProviderSplit
+} from '../main/services/dashboard/types'
 
 export type {
   FsEntry,
@@ -271,6 +281,10 @@ export interface DplexAPI {
     unsubscribe: (token: string) => void
     onTreeChanged: (callback: (payload: { rootFs: string; dirs: string[] }) => void) => () => void
   }
+  dashboard: {
+    /** Compute the historical metrics snapshot over the given window (days). */
+    getMetrics: (windowDays?: number) => Promise<DashboardMetrics>
+  }
 }
 
 const dplexAPI: DplexAPI = {
@@ -488,6 +502,9 @@ const dplexAPI: DplexAPI = {
       ipcRenderer.on('files:tree-changed', handler)
       return () => ipcRenderer.removeListener('files:tree-changed', handler)
     }
+  },
+  dashboard: {
+    getMetrics: (windowDays) => ipcRenderer.invoke('dashboard:getMetrics', windowDays)
   }
 }
 

--- a/src/renderer/src/components/dashboard/ActivityChart.tsx
+++ b/src/renderer/src/components/dashboard/ActivityChart.tsx
@@ -1,0 +1,149 @@
+import { useMemo } from 'react'
+import { useProvidersStore } from '../../stores/providersStore'
+import { useChartTooltip } from './useChartTooltip'
+import type { DashboardMetrics } from '../../../../preload'
+
+interface ActivityChartProps {
+  overTime: DashboardMetrics['overTime']
+  providerSplit: DashboardMetrics['providerSplit']
+}
+
+/** Deterministic provider color ramp (theme tokens + fixed brand hues). */
+const PROVIDER_COLORS = [
+  'var(--dplex-accent)',
+  '#C084FC',
+  'var(--dplex-accent-alt)',
+  'var(--dplex-status-success)',
+  'var(--dplex-status-warning)'
+]
+
+const PLOT_HEIGHT = 150
+
+function dayLabel(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, { weekday: 'short' })
+}
+
+function fullDate(ms: number): string {
+  return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' })
+}
+
+/**
+ * Stacked daily-activity bars, split by provider. The x-axis labels live in a
+ * dedicated row beneath the plot (never over the bars), spacing adapts to the
+ * day count so 90-day windows still render visible bars, and each bar shows an
+ * instant tooltip with the per-provider breakdown.
+ */
+export function ActivityChart({ overTime, providerSplit }: ActivityChartProps): React.JSX.Element {
+  const getLabel = useProvidersStore((s) => s.getLabel)
+  const tip = useChartTooltip()
+
+  const providerOrder = useMemo(() => providerSplit.map((p) => p.providerId), [providerSplit])
+  const colorFor = useMemo(() => {
+    const map = new Map<string, string>()
+    providerOrder.forEach((id, i) => map.set(id, PROVIDER_COLORS[i % PROVIDER_COLORS.length]))
+    return map
+  }, [providerOrder])
+
+  const maxTotal = useMemo(() => Math.max(1, ...overTime.map((b) => b.total)), [overTime])
+
+  // Spacing adapts to bucket count: dense windows (90d) get a 1px gap so bars
+  // don't collapse to zero width; sparse windows breathe with a wider gap.
+  const n = overTime.length
+  const gap = n > 60 ? 1 : n > 30 ? 2 : n > 14 ? 3 : 5
+  // Label only ~10 ticks so the axis never crowds.
+  const tickEvery = Math.max(1, Math.ceil(n / 10))
+
+  return (
+    <div>
+      <div className="flex items-end" style={{ height: PLOT_HEIGHT, gap }}>
+        {overTime.map((bucket) => {
+          const heightPct = (bucket.total / maxTotal) * 100
+          const onMove = (e: React.MouseEvent): void => {
+            tip.show(
+              e,
+              <span>
+                <b>{fullDate(bucket.dateMs)}</b> · {bucket.total} session
+                {bucket.total === 1 ? '' : 's'}
+                {bucket.total > 0 &&
+                  providerOrder
+                    .filter((pid) => (bucket.byProvider[pid] ?? 0) > 0)
+                    .map((pid) => (
+                      <span
+                        key={pid}
+                        style={{ display: 'block', color: 'var(--dplex-text-muted)' }}
+                      >
+                        {getLabel(pid)}: {bucket.byProvider[pid]}
+                      </span>
+                    ))}
+              </span>
+            )
+          }
+          return (
+            <div
+              key={bucket.dateMs}
+              className="flex-1 h-full flex flex-col justify-end min-w-0"
+              onMouseEnter={onMove}
+              onMouseMove={onMove}
+              onMouseLeave={tip.hide}
+            >
+              <div
+                className="w-full flex flex-col justify-end rounded-t-[3px] overflow-hidden"
+                style={{ height: `${heightPct}%` }}
+              >
+                {bucket.total === 0 ? (
+                  <div
+                    className="w-full"
+                    style={{ height: 2, backgroundColor: 'var(--dplex-bg-elev-3)' }}
+                  />
+                ) : (
+                  providerOrder.map((pid) => {
+                    const v = bucket.byProvider[pid] ?? 0
+                    if (v <= 0) return null
+                    return (
+                      <div
+                        key={pid}
+                        style={{
+                          height: `${(v / bucket.total) * 100}%`,
+                          backgroundColor: colorFor.get(pid)
+                        }}
+                      />
+                    )
+                  })
+                )}
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Dedicated x-axis row — labels sit under the bars, never over them. */}
+      <div className="flex mt-1.5" style={{ gap }}>
+        {overTime.map((bucket, i) => (
+          <span
+            key={bucket.dateMs}
+            className="flex-1 text-center font-mono min-w-0 truncate"
+            style={{ fontSize: 9, color: 'var(--dplex-text-faint)' }}
+          >
+            {i % tickEvery === 0 ? dayLabel(bucket.dateMs) : ''}
+          </span>
+        ))}
+      </div>
+
+      <div
+        className="flex flex-wrap gap-4 mt-3 text-[11px] font-mono"
+        style={{ color: 'var(--dplex-text-muted)' }}
+      >
+        {providerOrder.map((pid) => (
+          <span key={pid} className="flex items-center gap-1.5">
+            <i
+              className="inline-block w-2.5 h-2.5 rounded-sm"
+              style={{ backgroundColor: colorFor.get(pid) }}
+            />
+            {getLabel(pid)}
+          </span>
+        ))}
+      </div>
+      {tip.node}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/AttentionFeed.tsx
+++ b/src/renderer/src/components/dashboard/AttentionFeed.tsx
@@ -1,0 +1,110 @@
+import { useMemo } from 'react'
+import { AlertTriangle, MessageSquare, CheckCircle2 } from 'lucide-react'
+import { useAttentionStore } from '../../stores/attentionStore'
+import { useSessionStore } from '../../stores/sessionStore'
+import { focusSessionTab } from '../../utils/sessionTabs'
+import { resumeSessionGuarded } from '../../stores/externalResumeConfirmStore'
+import { timeAgo } from '../../utils/dashboardMetrics'
+import { EmptyState } from './EmptyState'
+import type { AttentionEvent, AttentionKind } from '../../../../preload/attentionTypes'
+
+const KIND_META: Record<
+  AttentionKind,
+  { Icon: typeof AlertTriangle; color: string; verb: string }
+> = {
+  waitingForApproval: {
+    Icon: AlertTriangle,
+    color: 'var(--dplex-status-approval)',
+    verb: 'needs approval'
+  },
+  waitingForInput: {
+    Icon: MessageSquare,
+    color: 'var(--dplex-status-waiting)',
+    verb: 'is waiting for you'
+  },
+  finished: {
+    Icon: CheckCircle2,
+    color: 'var(--dplex-status-success)',
+    verb: 'finished its turn'
+  }
+}
+
+/** Sort order: approval → input → finished, then most-recent first. */
+const KIND_RANK: Record<AttentionKind, number> = {
+  waitingForApproval: 0,
+  waitingForInput: 1,
+  finished: 2
+}
+
+/** Live feed of sessions that need the user, straight from the attention inbox. */
+export function AttentionFeed(): React.JSX.Element {
+  const active = useAttentionStore((s) => s.active)
+  const sessions = useSessionStore((s) => s.sessions)
+
+  const events = useMemo(
+    () =>
+      [...active]
+        .filter((e) => !e.suppressed)
+        .sort((a, b) => KIND_RANK[a.kind] - KIND_RANK[b.kind] || b.createdAt - a.createdAt)
+        .slice(0, 8),
+    [active]
+  )
+
+  const openEvent = (e: AttentionEvent): void => {
+    if (focusSessionTab(e.sessionId, e.providerId)) return
+    const session = sessions.find((s) => s.id === e.sessionId && s.aiTool === e.providerId)
+    if (session) resumeSessionGuarded(session)
+  }
+
+  if (events.length === 0) {
+    return (
+      <EmptyState
+        Icon={CheckCircle2}
+        title="You're all caught up"
+        subtitle="No sessions are waiting on your input or approval."
+      />
+    )
+  }
+
+  return (
+    <div className="flex flex-col">
+      {events.map((e) => {
+        const meta = KIND_META[e.kind]
+        const { Icon } = meta
+        return (
+          <button
+            key={e.compositeId + e.createdAt}
+            type="button"
+            onClick={() => openEvent(e)}
+            className="flex items-start gap-3 p-2 rounded-lg text-left hover:bg-[var(--dplex-hover)] transition-colors"
+          >
+            <span
+              className="w-7 h-7 rounded-lg grid place-items-center flex-shrink-0"
+              style={{ backgroundColor: `color-mix(in srgb, ${meta.color} 14%, transparent)` }}
+            >
+              <Icon size={15} style={{ color: meta.color }} />
+            </span>
+            <div className="flex-1 min-w-0">
+              <div className="text-[13px] truncate" style={{ color: 'var(--dplex-text-2)' }}>
+                <b style={{ color: 'var(--dplex-text)', fontWeight: 600 }}>{e.displayName}</b>{' '}
+                {meta.verb}
+              </div>
+              <div
+                className="text-[11px] font-mono mt-0.5"
+                style={{ color: 'var(--dplex-text-dim)' }}
+              >
+                {e.providerId}
+              </div>
+            </div>
+            <span
+              className="text-[11px] font-mono flex-shrink-0 whitespace-nowrap"
+              style={{ color: 'var(--dplex-text-faint)' }}
+            >
+              {timeAgo(e.createdAt)}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/CadenceCard.tsx
+++ b/src/renderer/src/components/dashboard/CadenceCard.tsx
@@ -1,0 +1,89 @@
+import { useMemo } from 'react'
+import { Flame, CalendarClock, Gauge } from 'lucide-react'
+import { activeStreak, busiestSlot, weekdayName } from '../../utils/dashboardMetrics'
+import type { DashboardMetrics } from '../../../../preload'
+
+interface CadenceCardProps {
+  overTime: DashboardMetrics['overTime']
+  heatmap: DashboardMetrics['heatmap']
+  avgPrompts: number
+}
+
+function hourRange(hour: number): string {
+  const pad = (h: number): string => String((h + 24) % 24).padStart(2, '0')
+  return `${pad(hour)}:00–${pad(hour + 1)}:00`
+}
+
+/** Engagement callouts derived from the activity buckets + heatmap. */
+export function CadenceCard({
+  overTime,
+  heatmap,
+  avgPrompts
+}: CadenceCardProps): React.JSX.Element {
+  const streak = useMemo(() => activeStreak(overTime), [overTime])
+  const busiest = useMemo(() => busiestSlot(heatmap), [heatmap])
+
+  const rows = [
+    {
+      Icon: Flame,
+      t1:
+        streak > 0 ? (
+          <>
+            <b>{streak}-day streak</b> with at least one session
+          </>
+        ) : (
+          <>No active streak yet</>
+        ),
+      t2: 'consecutive recent days with activity'
+    },
+    {
+      Icon: CalendarClock,
+      t1: busiest ? (
+        <>
+          Busiest on <b>{weekdayName(busiest.weekday)}s</b>, peak <b>{hourRange(busiest.hour)}</b>
+        </>
+      ) : (
+        <>Not enough data to spot a pattern</>
+      ),
+      t2: 'from your work-time heatmap'
+    },
+    {
+      Icon: Gauge,
+      t1: (
+        <>
+          <b>{avgPrompts}</b> prompts per session on average
+        </>
+      ),
+      t2: 'prompts ÷ sessions in window'
+    }
+  ]
+
+  return (
+    <div className="flex flex-col gap-3.5">
+      {rows.map((r, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <span
+            className="w-8 h-8 rounded-lg grid place-items-center flex-shrink-0"
+            style={{
+              backgroundColor: 'var(--dplex-bg-elev-2)',
+              border: '1px solid var(--dplex-border)'
+            }}
+          >
+            <r.Icon size={15} style={{ color: 'var(--dplex-accent)' }} />
+          </span>
+          <div className="min-w-0">
+            <div className="text-[13px]" style={{ color: 'var(--dplex-text-2)' }}>
+              {r.t1}
+            </div>
+            <div
+              className="text-[11px] font-mono mt-0.5"
+              style={{ color: 'var(--dplex-text-dim)' }}
+            >
+              {r.t2}
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/DashboardCard.tsx
+++ b/src/renderer/src/components/dashboard/DashboardCard.tsx
@@ -1,0 +1,56 @@
+import type { ReactNode } from 'react'
+
+interface DashboardCardProps {
+  title?: string
+  meta?: ReactNode
+  /** Tailwind grid-column span class, e.g. 'lg:col-span-8'. */
+  className?: string
+  children: ReactNode
+  /** Optional action node rendered on the right of the header. */
+  action?: ReactNode
+}
+
+/**
+ * Shared surface for every dashboard tile. Owns the panel chrome (border,
+ * radius, padding) so the individual metric components stay focused on
+ * content. Uses theme tokens only — adapts to light/dark automatically.
+ */
+export function DashboardCard({
+  title,
+  meta,
+  className = '',
+  children,
+  action
+}: DashboardCardProps): React.JSX.Element {
+  return (
+    <div
+      className={`rounded-xl p-4 min-w-0 flex flex-col ${className}`}
+      style={{
+        backgroundColor: 'var(--dplex-bg-elev)',
+        border: '1px solid var(--dplex-border)'
+      }}
+    >
+      {(title || meta || action) && (
+        <div className="flex items-center justify-between mb-3 gap-2">
+          {title && (
+            <h3
+              className="text-[14px] font-semibold truncate"
+              style={{ color: 'var(--dplex-text)' }}
+            >
+              {title}
+            </h3>
+          )}
+          <div className="flex items-center gap-2 flex-shrink-0">
+            {meta && (
+              <span className="text-[11px] font-mono" style={{ color: 'var(--dplex-text-dim)' }}>
+                {meta}
+              </span>
+            )}
+            {action}
+          </div>
+        </div>
+      )}
+      <div className="flex-1 min-h-0">{children}</div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/DashboardTabView.tsx
+++ b/src/renderer/src/components/dashboard/DashboardTabView.tsx
@@ -100,7 +100,6 @@ export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX
   const avgPrompts = m ? average(m.totals.messages, m.totals.sessions) : 0
 
   // Reveal the Sessions sidebar, optionally pre-filtered by status and/or a
-  // Reveal the Sessions sidebar, optionally pre-filtered by status and/or a
   // search term. The status request goes through the session store (consumed
   // by the panel on its next render) so it survives the panel not being
   // mounted at click time.
@@ -112,6 +111,15 @@ export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX
     })
     setSearchQuery(opts.search ?? '')
     requestStatusFilter(opts.status ?? ['all'])
+  }
+
+  // Focus a single, specific session in the panel by searching its (unique)
+  // session id and clearing any status filter so it can't be filtered out.
+  // Used by the single-session housekeeping cards (oldest-waiting / longest-
+  // active). No-op when the id is unknown.
+  const focusSession = (sessionId: string | null): void => {
+    if (!sessionId) return
+    revealSessions({ search: sessionId, status: ['all'] })
   }
 
   const selectRepo = (repo: DashboardMetrics['topRepos'][number]): void => {
@@ -258,7 +266,11 @@ export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX
                 ? 'var(--dplex-status-approval)'
                 : 'var(--dplex-text)'
             }
-            onClick={() => revealSessions({ status: ['waiting'] })}
+            onClick={
+              housekeeping.oldestWaitingSessionId
+                ? () => focusSession(housekeeping.oldestWaitingSessionId)
+                : undefined
+            }
             sub={housekeeping.oldestWaitingLabel ?? 'Nothing waiting'}
           />
           <KpiCard
@@ -285,7 +297,11 @@ export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX
             }
             Icon={Timer}
             accent="var(--dplex-status-success)"
-            onClick={() => revealSessions({ status: ['active'] })}
+            onClick={
+              housekeeping.longestActiveSessionId
+                ? () => focusSession(housekeeping.longestActiveSessionId)
+                : undefined
+            }
             sub={housekeeping.longestActiveName ?? 'No active sessions'}
           />
           <KpiCard

--- a/src/renderer/src/components/dashboard/DashboardTabView.tsx
+++ b/src/renderer/src/components/dashboard/DashboardTabView.tsx
@@ -146,9 +146,16 @@ export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX
             </p>
           </div>
           <div className="flex items-center gap-2">
+            <span
+              className="text-[11px] font-mono uppercase tracking-wider hidden @md:inline"
+              style={{ color: 'var(--dplex-text-dim)' }}
+            >
+              History
+            </span>
             <div
               className="flex items-center rounded-lg overflow-hidden"
               style={{ border: '1px solid var(--dplex-border)' }}
+              title="Time range for the historical cards (live cards are unaffected)"
             >
               {WINDOW_OPTIONS.map((d) => (
                 <button
@@ -331,7 +338,7 @@ export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX
               <Placeholder loading={loading} />
             )}
           </DashboardCard>
-          <DashboardCard className="@3xl:col-span-4" title="Status right now">
+          <DashboardCard className="@3xl:col-span-4" title="Status right now" meta="live">
             <StatusDonut counts={kpis.statusCounts} />
           </DashboardCard>
 

--- a/src/renderer/src/components/dashboard/DashboardTabView.tsx
+++ b/src/renderer/src/components/dashboard/DashboardTabView.tsx
@@ -11,7 +11,6 @@ import {
   GitCompare
 } from 'lucide-react'
 import { useSessionStore } from '../../stores/sessionStore'
-import { useAttentionStore } from '../../stores/attentionStore'
 import { useDashboardStore } from '../../stores/dashboardStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useUncommittedStore } from '../../stores/uncommittedStore'
@@ -48,7 +47,6 @@ const WINDOW_OPTIONS = [7, 14, 30, 90]
  */
 export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX.Element {
   const sessions = useSessionStore((s) => s.sessions)
-  const attention = useAttentionStore((s) => s.active)
   const idleTooLongMinutes = useSettingsStore((s) => s.settings.idleTooLongMinutes)
 
   const metrics = useDashboardStore((s) => s.metrics)
@@ -87,10 +85,10 @@ export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX
     if (isActive) void refreshUncommitted()
   }, [isActive, refreshUncommitted])
 
-  const kpis = useMemo(() => computeLiveKpis(sessions, attention), [sessions, attention])
+  const kpis = useMemo(() => computeLiveKpis(sessions), [sessions])
   const housekeeping = useMemo(
-    () => computeHousekeeping(sessions, attention, idleTooLongMinutes),
-    [sessions, attention, idleTooLongMinutes]
+    () => computeHousekeeping(sessions, idleTooLongMinutes),
+    [sessions, idleTooLongMinutes]
   )
   // Only treat the snapshot as usable when it matches the currently selected
   // window. While a window switch is in flight the prior snapshot is NOT shown

--- a/src/renderer/src/components/dashboard/DashboardTabView.tsx
+++ b/src/renderer/src/components/dashboard/DashboardTabView.tsx
@@ -1,0 +1,417 @@
+import { useEffect, useMemo } from 'react'
+import {
+  Activity,
+  AlertTriangle,
+  TrendingUp,
+  Hammer,
+  RefreshCw,
+  Hourglass,
+  MoonStar,
+  Timer,
+  GitCompare
+} from 'lucide-react'
+import { useSessionStore } from '../../stores/sessionStore'
+import { useAttentionStore } from '../../stores/attentionStore'
+import { useDashboardStore } from '../../stores/dashboardStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { useUncommittedStore } from '../../stores/uncommittedStore'
+import {
+  computeLiveKpis,
+  computeHousekeeping,
+  formatDuration,
+  pctDelta,
+  average
+} from '../../utils/dashboardMetrics'
+import { DashboardCard } from './DashboardCard'
+import { KpiCard } from './KpiCard'
+import { StatusDonut } from './StatusDonut'
+import { ActivityChart } from './ActivityChart'
+import { TopReposList } from './TopReposList'
+import { AttentionFeed } from './AttentionFeed'
+import { WorkHeatmap } from './WorkHeatmap'
+import { RecentSessionsTable } from './RecentSessionsTable'
+import { CadenceCard } from './CadenceCard'
+import { ProviderMixCard } from './ProviderMixCard'
+import type { DashboardMetrics } from '../../../../preload'
+
+interface DashboardTabViewProps {
+  isActive: boolean
+}
+
+const WINDOW_OPTIONS = [7, 14, 30, 90]
+
+/**
+ * Root of the Overview Dashboard tab. Live KPIs/donut/feed/table read directly
+ * from the session + attention stores (always real-time, decoupled from the
+ * historical snapshot). Historical charts come from the dashboard store, which
+ * refreshes event-driven (no polling).
+ */
+export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX.Element {
+  const sessions = useSessionStore((s) => s.sessions)
+  const attention = useAttentionStore((s) => s.active)
+  const idleTooLongMinutes = useSettingsStore((s) => s.settings.idleTooLongMinutes)
+
+  const metrics = useDashboardStore((s) => s.metrics)
+  const loading = useDashboardStore((s) => s.loading)
+  const error = useDashboardStore((s) => s.error)
+  const windowDays = useDashboardStore((s) => s.windowDays)
+  const dirty = useDashboardStore((s) => s.dirty)
+  const init = useDashboardStore((s) => s.init)
+  const ensureFresh = useDashboardStore((s) => s.ensureFresh)
+  const refresh = useDashboardStore((s) => s.refresh)
+  const setWindowDays = useDashboardStore((s) => s.setWindowDays)
+
+  const uncommittedTotal = useUncommittedStore((s) => s.total)
+  const uncommittedRepoCount = useUncommittedStore((s) => s.repoCount)
+  const refreshUncommitted = useUncommittedStore((s) => s.refresh)
+
+  const updateSettings = useSettingsStore((s) => s.updateSettings)
+  const setSearchQuery = useSessionStore((s) => s.setSearchQuery)
+  const requestStatusFilter = useSessionStore((s) => s.requestStatusFilter)
+
+  // Subscribe to invalidation once; idempotent inside the store.
+  useEffect(() => {
+    init()
+  }, [init])
+
+  // Refresh when the tab becomes visible if never loaded or marked dirty —
+  // events that arrived while hidden are honored here (no dropped updates).
+  useEffect(() => {
+    if (isActive) ensureFresh()
+  }, [isActive, dirty, ensureFresh])
+
+  // Uncommitted counts are git reads — refresh them only when the tab becomes
+  // active (and via the manual button), NOT on every session add/remove
+  // `dirty` flip, which has nothing to do with working-tree state.
+  useEffect(() => {
+    if (isActive) void refreshUncommitted()
+  }, [isActive, refreshUncommitted])
+
+  const kpis = useMemo(() => computeLiveKpis(sessions, attention), [sessions, attention])
+  const housekeeping = useMemo(
+    () => computeHousekeeping(sessions, attention, idleTooLongMinutes),
+    [sessions, attention, idleTooLongMinutes]
+  )
+  // Only treat the snapshot as usable when it matches the currently selected
+  // window. While a window switch is in flight the prior snapshot is NOT shown
+  // under the new label — historical cards fall back to the loading state.
+  const m = metrics && metrics.windowDays === windowDays ? metrics : null
+  const promptsDelta = m ? pctDelta(m.totals.messages, m.previousTotals.messages) : null
+  const avgPrompts = m ? average(m.totals.messages, m.totals.sessions) : 0
+
+  // Reveal the Sessions sidebar, optionally pre-filtered by status and/or a
+  // Reveal the Sessions sidebar, optionally pre-filtered by status and/or a
+  // search term. The status request goes through the session store (consumed
+  // by the panel on its next render) so it survives the panel not being
+  // mounted at click time.
+  const revealSessions = (opts: { status?: string[]; search?: string }): void => {
+    updateSettings({
+      sidebarActiveTab: 'sessions',
+      sidebarPanelCollapsed: false,
+      sidebarVisible: true
+    })
+    setSearchQuery(opts.search ?? '')
+    requestStatusFilter(opts.status ?? ['all'])
+  }
+
+  const selectRepo = (repo: DashboardMetrics['topRepos'][number]): void => {
+    // Search by the local folder name (cwd basename), not the Git remote
+    // handle (e.g. "owner/repo") — sessions are matched on cwd/branch/name, so
+    // searching the handle would find nothing. Fall back to the last path
+    // segment of the repo label when no cwd is known.
+    const term = repo.cwd ? basename(repo.cwd) : repo.repo.split('/').pop() || repo.repo
+    revealSessions({ search: term })
+  }
+
+  return (
+    <div className="h-full overflow-y-auto" style={{ backgroundColor: 'var(--dplex-bg)' }}>
+      <div className="@container max-w-[1200px] mx-auto px-6 py-6">
+        {/* Header */}
+        <div className="flex items-center justify-between gap-3 mb-5 flex-wrap">
+          <div>
+            <h1
+              className="text-[22px] font-bold tracking-tight"
+              style={{ color: 'var(--dplex-text)' }}
+            >
+              Overview
+            </h1>
+            <p className="text-[13px] mt-0.5" style={{ color: 'var(--dplex-text-muted)' }}>
+              What&apos;s running, what needs you, and where you work.
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <div
+              className="flex items-center rounded-lg overflow-hidden"
+              style={{ border: '1px solid var(--dplex-border)' }}
+            >
+              {WINDOW_OPTIONS.map((d) => (
+                <button
+                  key={d}
+                  type="button"
+                  onClick={() => setWindowDays(d)}
+                  className="px-2.5 py-1 text-[11px] font-mono transition-colors"
+                  style={{
+                    color: d === windowDays ? 'var(--dplex-accent-fg)' : 'var(--dplex-text-muted)',
+                    backgroundColor: d === windowDays ? 'var(--dplex-accent)' : 'transparent'
+                  }}
+                >
+                  {d}d
+                </button>
+              ))}
+            </div>
+            <button
+              type="button"
+              onClick={() => {
+                void refresh()
+                void refreshUncommitted()
+              }}
+              disabled={loading}
+              className="grid place-items-center rounded-lg w-8 h-8 transition-colors hover:bg-[var(--dplex-hover)] disabled:opacity-50"
+              style={{ border: '1px solid var(--dplex-border)', color: 'var(--dplex-text-muted)' }}
+              title="Refresh historical metrics"
+            >
+              <RefreshCw size={14} className={loading ? 'animate-spin' : ''} />
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <div
+            className="mb-4 px-3 py-2 rounded-lg text-[12px] font-mono"
+            style={{
+              color: 'var(--dplex-status-error)',
+              backgroundColor: 'color-mix(in srgb, var(--dplex-status-error) 12%, transparent)'
+            }}
+          >
+            Couldn&apos;t load history: {error}
+          </div>
+        )}
+
+        {/* KPI row (live). Container-query columns adapt to the dashboard
+            PANE width (not the window), so KPIs never cram when the pane is
+            narrow (split view, sidebar open): 1-up → 2-up → 4-up. */}
+        <div className="grid grid-cols-1 @md:grid-cols-2 @4xl:grid-cols-4 gap-3.5 mb-3.5">
+          <KpiCard
+            label="Active now"
+            value={kpis.activeCount}
+            unit="running"
+            Icon={Activity}
+            accent="var(--dplex-status-success)"
+            onClick={() => revealSessions({ status: ['active'] })}
+            sub={
+              kpis.activeCount > 0
+                ? `${kpis.statusCounts.executingTool} executing · ${kpis.statusCounts.thinking} thinking`
+                : 'No active sessions'
+            }
+          />
+          <KpiCard
+            label="Needs you"
+            value={kpis.needsYouCount}
+            unit="waiting"
+            Icon={AlertTriangle}
+            accent="var(--dplex-status-approval)"
+            onClick={() => revealSessions({ status: ['waiting'] })}
+            valueColor={
+              kpis.needsYouCount > 0 ? 'var(--dplex-status-approval)' : 'var(--dplex-text)'
+            }
+            sub={`${kpis.approvalCount} approval · ${kpis.inputCount} input`}
+          />
+          <KpiCard
+            label="Sessions today"
+            value={kpis.sessionsToday}
+            unit="started"
+            Icon={TrendingUp}
+            sub={m ? `${m.totals.sessions} in ${windowDays}d` : '—'}
+          />
+          <KpiCard
+            label={`Prompts · ${windowDays}d`}
+            value={m ? formatCompact(m.totals.messages) : '—'}
+            unit="sent"
+            Icon={Hammer}
+            sub={
+              m ? (
+                <DeltaSub
+                  delta={promptsDelta}
+                  fallback={`${formatCompact(m.totals.sessions)} sessions`}
+                  windowDays={windowDays}
+                />
+              ) : (
+                '—'
+              )
+            }
+          />
+        </div>
+
+        {/* Housekeeping — actionable, live (no new data sources). */}
+        <div className="grid grid-cols-1 @md:grid-cols-2 @4xl:grid-cols-4 gap-3.5 mb-3.5">
+          <KpiCard
+            label="Oldest awaiting you"
+            value={
+              housekeeping.oldestWaitingMs !== null
+                ? formatDuration(housekeeping.oldestWaitingMs)
+                : '—'
+            }
+            Icon={Hourglass}
+            accent="var(--dplex-status-approval)"
+            valueColor={
+              housekeeping.oldestWaitingMs !== null
+                ? 'var(--dplex-status-approval)'
+                : 'var(--dplex-text)'
+            }
+            onClick={() => revealSessions({ status: ['waiting'] })}
+            sub={housekeeping.oldestWaitingLabel ?? 'Nothing waiting'}
+          />
+          <KpiCard
+            label="Stale sessions"
+            value={housekeeping.staleCount}
+            unit={`idle >${idleTooLongMinutes}m`}
+            Icon={MoonStar}
+            accent="var(--dplex-text-dim)"
+            onClick={() => revealSessions({ status: ['idle'] })}
+            sub={
+              housekeeping.staleCount > 0 ? 'candidates to resume or close' : 'nothing gone stale'
+            }
+          />
+          <KpiCard
+            label="Longest active"
+            value={
+              housekeeping.longestActiveMs !== null
+                ? formatDuration(housekeeping.longestActiveMs)
+                : '—'
+            }
+            Icon={Timer}
+            accent="var(--dplex-status-success)"
+            onClick={() => revealSessions({ status: ['active'] })}
+            sub={housekeeping.longestActiveName ?? 'No active sessions'}
+          />
+          <KpiCard
+            label="Uncommitted"
+            value={uncommittedTotal}
+            unit="files"
+            Icon={GitCompare}
+            accent="var(--dplex-accent)"
+            sub={
+              uncommittedTotal > 0
+                ? `across ${uncommittedRepoCount} repo${uncommittedRepoCount === 1 ? '' : 's'}`
+                : 'working trees clean'
+            }
+          />
+        </div>
+
+        {/* Content grid — 12 columns once the pane is wide enough, otherwise
+            every card stacks full-width. */}
+        <div className="grid grid-cols-1 @3xl:grid-cols-12 gap-3.5">
+          {/* Activity + status */}
+          <DashboardCard
+            className="@3xl:col-span-8"
+            title="Session activity"
+            meta={`last ${windowDays} days · by provider`}
+          >
+            {m ? (
+              <ActivityChart overTime={m.overTime} providerSplit={m.providerSplit} />
+            ) : (
+              <Placeholder loading={loading} />
+            )}
+          </DashboardCard>
+          <DashboardCard className="@3xl:col-span-4" title="Status right now">
+            <StatusDonut counts={kpis.statusCounts} />
+          </DashboardCard>
+
+          {/* Top repos + attention */}
+          <DashboardCard
+            className="@3xl:col-span-6"
+            title="Repositories you use most"
+            meta={`${windowDays}d · by sessions`}
+          >
+            {m ? (
+              <TopReposList repos={m.topRepos} onSelect={selectRepo} />
+            ) : (
+              <Placeholder loading={loading} />
+            )}
+          </DashboardCard>
+          <DashboardCard className="@3xl:col-span-6" title="Needs attention" meta="live">
+            <AttentionFeed />
+          </DashboardCard>
+
+          {/* Cadence + provider mix */}
+          <DashboardCard className="@3xl:col-span-8" title="Your cadence">
+            {m ? (
+              <CadenceCard overTime={m.overTime} heatmap={m.heatmap} avgPrompts={avgPrompts} />
+            ) : (
+              <Placeholder loading={loading} />
+            )}
+          </DashboardCard>
+          <DashboardCard className="@3xl:col-span-4" title="Provider mix" meta={`${windowDays}d`}>
+            {m ? (
+              <ProviderMixCard providerSplit={m.providerSplit} />
+            ) : (
+              <Placeholder loading={loading} />
+            )}
+          </DashboardCard>
+
+          {/* Heatmap */}
+          <DashboardCard
+            className="@3xl:col-span-12"
+            title="When you work"
+            meta={`by hour × weekday · last ${windowDays} days`}
+          >
+            {m ? <WorkHeatmap cells={m.heatmap} /> : <Placeholder loading={loading} />}
+          </DashboardCard>
+
+          {/* Recent sessions */}
+          <DashboardCard
+            className="@3xl:col-span-12"
+            title="Recent sessions"
+            meta="click a row to open / resume"
+          >
+            <RecentSessionsTable />
+          </DashboardCard>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function Placeholder({ loading }: { loading: boolean }): React.JSX.Element {
+  return (
+    <div
+      className="grid place-items-center text-[12px] font-mono"
+      style={{ height: 120, color: 'var(--dplex-text-dim)' }}
+    >
+      {loading ? 'Loading…' : 'No data yet'}
+    </div>
+  )
+}
+
+/** Sub-line for the Prompts KPI: a period-over-period delta, or a fallback. */
+function DeltaSub({
+  delta,
+  fallback,
+  windowDays
+}: {
+  delta: number | null
+  fallback: string
+  windowDays: number
+}): React.JSX.Element {
+  if (delta === null) return <span>{fallback}</span>
+  const up = delta >= 0
+  const color = up ? 'var(--dplex-status-success)' : 'var(--dplex-status-error)'
+  return (
+    <span style={{ color }}>
+      {up ? '▲' : '▼'} {Math.abs(delta)}% vs prior {windowDays}d
+    </span>
+  )
+}
+
+/** Compact number formatting: 1234 → "1.2k". */
+function formatCompact(n: number): string {
+  if (n < 1000) return String(n)
+  if (n < 1_000_000) return `${(n / 1000).toFixed(n < 10_000 ? 1 : 0)}k`
+  return `${(n / 1_000_000).toFixed(1)}M`
+}
+
+/** Basename of a path, tolerating both `/` and `\` separators. */
+function basename(p: string): string {
+  const parts = p.replace(/\\/g, '/').replace(/\/+$/, '').split('/')
+  return parts[parts.length - 1] || p
+}

--- a/src/renderer/src/components/dashboard/DashboardTabView.tsx
+++ b/src/renderer/src/components/dashboard/DashboardTabView.tsx
@@ -264,12 +264,16 @@ export function DashboardTabView({ isActive }: DashboardTabViewProps): React.JSX
           <KpiCard
             label="Stale sessions"
             value={housekeeping.staleCount}
-            unit={`idle >${idleTooLongMinutes}m`}
+            unit={`quiet >${idleTooLongMinutes}m`}
             Icon={MoonStar}
-            accent="var(--dplex-text-dim)"
-            onClick={() => revealSessions({ status: ['idle'] })}
+            accent={
+              housekeeping.staleCount > 0 ? 'var(--dplex-status-warning)' : 'var(--dplex-text-dim)'
+            }
+            onClick={() => revealSessions({ status: ['active'] })}
             sub={
-              housekeeping.staleCount > 0 ? 'candidates to resume or close' : 'nothing gone stale'
+              housekeeping.staleCount > 0
+                ? 'running but idle — check or close'
+                : 'no idle running sessions'
             }
           />
           <KpiCard

--- a/src/renderer/src/components/dashboard/EmptyState.tsx
+++ b/src/renderer/src/components/dashboard/EmptyState.tsx
@@ -1,0 +1,48 @@
+import type { LucideIcon } from 'lucide-react'
+
+interface EmptyStateProps {
+  Icon: LucideIcon
+  title: string
+  subtitle?: string
+  /** Minimum vertical space so the state reads as intentional, not broken. */
+  minHeight?: number
+}
+
+/**
+ * Shared, understated empty state for dashboard cards. A soft icon chip over a
+ * short title and optional hint, vertically centered — consistent and
+ * professional across every card instead of ad-hoc one-liners.
+ */
+export function EmptyState({
+  Icon,
+  title,
+  subtitle,
+  minHeight = 120
+}: EmptyStateProps): React.JSX.Element {
+  return (
+    <div
+      className="flex flex-col items-center justify-center text-center gap-2 px-4"
+      style={{ minHeight }}
+    >
+      <span
+        className="grid place-items-center rounded-xl"
+        style={{
+          width: 38,
+          height: 38,
+          backgroundColor: 'var(--dplex-bg-elev-2)',
+          border: '1px solid var(--dplex-border)'
+        }}
+      >
+        <Icon size={18} style={{ color: 'var(--dplex-text-dim)' }} />
+      </span>
+      <div className="text-[13px] font-medium" style={{ color: 'var(--dplex-text-2)' }}>
+        {title}
+      </div>
+      {subtitle && (
+        <div className="text-[12px] max-w-[280px]" style={{ color: 'var(--dplex-text-dim)' }}>
+          {subtitle}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/KpiCard.tsx
+++ b/src/renderer/src/components/dashboard/KpiCard.tsx
@@ -1,0 +1,85 @@
+import type { LucideIcon } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+interface KpiCardProps {
+  label: string
+  value: ReactNode
+  unit?: string
+  sub?: ReactNode
+  Icon: LucideIcon
+  /** Accent color for the left bar + icon. Defaults to the brand accent. */
+  accent?: string
+  /** Optional emphasized value color (e.g. amber for "needs you"). */
+  valueColor?: string
+  /** When set, the card becomes an interactive button (e.g. open Sessions). */
+  onClick?: () => void
+}
+
+/**
+ * A single headline metric. Live KPIs re-render the instant their backing
+ * store slice changes — they never wait on the historical snapshot. Sizing is
+ * responsive and overflow-guarded so narrow cards don't clip the value/unit.
+ */
+export function KpiCard({
+  label,
+  value,
+  unit,
+  sub,
+  Icon,
+  accent = 'var(--dplex-accent)',
+  valueColor = 'var(--dplex-text)',
+  onClick
+}: KpiCardProps): React.JSX.Element {
+  const interactive = !!onClick
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={!interactive}
+      className={`relative rounded-xl p-4 overflow-hidden w-full h-full text-left transition-colors ${
+        interactive ? 'cursor-pointer hover:bg-[var(--dplex-bg-elev-2)]' : 'cursor-default'
+      }`}
+      style={{
+        backgroundColor: 'var(--dplex-bg-elev)',
+        border: '1px solid var(--dplex-border)'
+      }}
+    >
+      <span
+        aria-hidden
+        className="absolute left-0 top-3 bottom-3 rounded-r"
+        style={{ width: 3, backgroundColor: accent }}
+      />
+      <div
+        className="flex items-center gap-2 text-[10.5px] font-mono uppercase tracking-wider min-w-0"
+        style={{ color: 'var(--dplex-text-dim)' }}
+      >
+        <Icon size={14} style={{ color: accent }} className="flex-shrink-0" />
+        <span className="leading-tight">{label}</span>
+      </div>
+      <div className="mt-3 flex items-baseline gap-1.5 font-mono flex-wrap">
+        <span
+          className="text-[28px] sm:text-[32px] font-bold leading-none break-all"
+          style={{ color: valueColor }}
+        >
+          {value}
+        </span>
+        {unit && (
+          <span
+            className="text-[12px] whitespace-nowrap"
+            style={{ color: 'var(--dplex-text-dim)' }}
+          >
+            {unit}
+          </span>
+        )}
+      </div>
+      {sub && (
+        <div
+          className="mt-2.5 text-[11.5px] font-mono leading-tight line-clamp-2 break-words"
+          style={{ color: 'var(--dplex-text-muted)' }}
+        >
+          {sub}
+        </div>
+      )}
+    </button>
+  )
+}

--- a/src/renderer/src/components/dashboard/ProviderMixCard.tsx
+++ b/src/renderer/src/components/dashboard/ProviderMixCard.tsx
@@ -1,0 +1,68 @@
+import { useMemo } from 'react'
+import { useProvidersStore } from '../../stores/providersStore'
+import { providerShares } from '../../utils/dashboardMetrics'
+import { EmptyState } from './EmptyState'
+import { PieChart } from 'lucide-react'
+import type { DashboardMetrics } from '../../../../preload'
+
+interface ProviderMixCardProps {
+  providerSplit: DashboardMetrics['providerSplit']
+}
+
+const COLORS = [
+  'var(--dplex-accent)',
+  '#C084FC',
+  'var(--dplex-accent-alt)',
+  'var(--dplex-status-success)',
+  'var(--dplex-status-warning)'
+]
+
+/** Share of sessions by provider — a stacked bar plus a labelled legend. */
+export function ProviderMixCard({ providerSplit }: ProviderMixCardProps): React.JSX.Element {
+  const getLabel = useProvidersStore((s) => s.getLabel)
+  const shares = useMemo(() => providerShares(providerSplit), [providerSplit])
+  const total = useMemo(() => shares.reduce((s, p) => s + p.sessions, 0), [shares])
+
+  if (total === 0) {
+    return <EmptyState Icon={PieChart} title="No sessions in this window yet" />
+  }
+
+  return (
+    <div className="flex flex-col">
+      <div
+        className="flex h-3 rounded-md overflow-hidden"
+        style={{ border: '1px solid var(--dplex-border)' }}
+      >
+        {shares.map((p, i) => (
+          <div
+            key={p.providerId}
+            style={{ width: `${p.pct}%`, backgroundColor: COLORS[i % COLORS.length] }}
+            title={`${getLabel(p.providerId)} · ${p.pct}%`}
+          />
+        ))}
+      </div>
+      <div className="flex flex-col gap-2 mt-3.5">
+        {shares.map((p, i) => (
+          <div key={p.providerId} className="flex items-center gap-2 text-[12.5px]">
+            <span
+              className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+              style={{ backgroundColor: COLORS[i % COLORS.length] }}
+            />
+            <span className="truncate" style={{ color: 'var(--dplex-text-2)' }}>
+              {getLabel(p.providerId)}
+            </span>
+            <span className="ml-auto font-mono" style={{ color: 'var(--dplex-text)' }}>
+              {p.pct}%
+            </span>
+            <span
+              className="font-mono text-[11px] w-10 text-right"
+              style={{ color: 'var(--dplex-text-dim)' }}
+            >
+              {p.sessions}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/RecentSessionsTable.tsx
+++ b/src/renderer/src/components/dashboard/RecentSessionsTable.tsx
@@ -1,0 +1,162 @@
+import { useMemo } from 'react'
+import { Clock } from 'lucide-react'
+import { useSessionStore } from '../../stores/sessionStore'
+import { useProvidersStore } from '../../stores/providersStore'
+import { focusSessionTab } from '../../utils/sessionTabs'
+import { resumeSessionGuarded } from '../../stores/externalResumeConfirmStore'
+import { EmptyState } from './EmptyState'
+import {
+  STATUS_LABEL,
+  STATUS_VAR,
+  effectiveStatus,
+  recentSessions,
+  timeAgo
+} from '../../utils/dashboardMetrics'
+import type { AISession } from '../../types'
+
+/** Most-recent sessions with live status; click a row to open/resume it. */
+export function RecentSessionsTable(): React.JSX.Element {
+  const sessions = useSessionStore((s) => s.sessions)
+  const getLabel = useProvidersStore((s) => s.getLabel)
+
+  const rows = useMemo(() => recentSessions(sessions, 8), [sessions])
+
+  const open = (session: AISession): void => {
+    if (focusSessionTab(session.id, session.aiTool)) return
+    resumeSessionGuarded(session)
+  }
+
+  if (rows.length === 0) {
+    return (
+      <EmptyState
+        Icon={Clock}
+        title="No sessions yet"
+        subtitle="Start an AI session and it will appear here."
+      />
+    )
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr>
+            {['Session', 'Tool', 'Repo / branch', 'Status', 'Msgs', 'Tools', 'Last active'].map(
+              (h, i) => (
+                <th
+                  key={h}
+                  className={`font-mono uppercase tracking-wider font-medium px-2.5 py-2 ${i >= 4 && i <= 5 ? 'text-right' : 'text-left'}`}
+                  style={{
+                    fontSize: 10,
+                    color: 'var(--dplex-text-faint)',
+                    borderBottom: '1px solid var(--dplex-border)'
+                  }}
+                >
+                  {h}
+                </th>
+              )
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((s) => {
+            const status = effectiveStatus(s)
+            const color = STATUS_VAR[status]
+            const repoBranch = [s.cwd ? basename(s.cwd) : null, s.branch]
+              .filter(Boolean)
+              .join(' · ')
+            return (
+              <tr
+                key={`${s.aiTool}:${s.id}`}
+                onClick={() => open(s)}
+                className="cursor-pointer hover:bg-[var(--dplex-hover)]"
+              >
+                <td
+                  className="px-2.5 py-2.5 text-[13px] max-w-[260px] truncate"
+                  style={{
+                    color: 'var(--dplex-text)',
+                    borderBottom: '1px solid var(--dplex-border-subtle)'
+                  }}
+                  title={s.displayName}
+                >
+                  {s.displayName}
+                </td>
+                <td
+                  className="px-2.5 py-2.5"
+                  style={{ borderBottom: '1px solid var(--dplex-border-subtle)' }}
+                >
+                  <span
+                    className="font-mono text-[11px] px-2 py-0.5 rounded-md"
+                    style={{
+                      color: 'var(--dplex-text-2)',
+                      border: '1px solid var(--dplex-border)'
+                    }}
+                  >
+                    {getLabel(s.aiTool)}
+                  </span>
+                </td>
+                <td
+                  className="px-2.5 py-2.5 font-mono text-[12px] max-w-[260px] truncate"
+                  style={{
+                    color: 'var(--dplex-text-muted)',
+                    borderBottom: '1px solid var(--dplex-border-subtle)'
+                  }}
+                  title={s.cwd}
+                >
+                  {repoBranch || '—'}
+                </td>
+                <td
+                  className="px-2.5 py-2.5"
+                  style={{ borderBottom: '1px solid var(--dplex-border-subtle)' }}
+                >
+                  <span
+                    className="inline-flex items-center gap-1.5 font-mono text-[10.5px] px-2 py-0.5 rounded-md"
+                    style={{
+                      color,
+                      backgroundColor: `color-mix(in srgb, ${color} 14%, transparent)`
+                    }}
+                  >
+                    <span className="w-1.5 h-1.5 rounded-full" style={{ backgroundColor: color }} />
+                    {STATUS_LABEL[status]}
+                  </span>
+                </td>
+                <td
+                  className="px-2.5 py-2.5 font-mono text-[12px] text-right"
+                  style={{
+                    color: 'var(--dplex-text-2)',
+                    borderBottom: '1px solid var(--dplex-border-subtle)'
+                  }}
+                >
+                  {s.messageCount ?? 0}
+                </td>
+                <td
+                  className="px-2.5 py-2.5 font-mono text-[12px] text-right"
+                  style={{
+                    color: 'var(--dplex-text-2)',
+                    borderBottom: '1px solid var(--dplex-border-subtle)'
+                  }}
+                >
+                  {s.toolCallCount ?? 0}
+                </td>
+                <td
+                  className="px-2.5 py-2.5 font-mono text-[12px]"
+                  style={{
+                    color: 'var(--dplex-text-dim)',
+                    borderBottom: '1px solid var(--dplex-border-subtle)'
+                  }}
+                >
+                  {timeAgo(s.updatedAt.getTime())}
+                </td>
+              </tr>
+            )
+          })}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+
+function basename(p: string): string {
+  const parts = p.replace(/\\/g, '/').replace(/\/+$/, '').split('/')
+  return parts[parts.length - 1] || p
+}

--- a/src/renderer/src/components/dashboard/StatusDonut.tsx
+++ b/src/renderer/src/components/dashboard/StatusDonut.tsx
@@ -1,0 +1,118 @@
+import { useMemo } from 'react'
+import type { SessionStatus } from '../../types'
+import { STATUS_LABEL, STATUS_ORDER, STATUS_VAR } from '../../utils/dashboardMetrics'
+import { useChartTooltip } from './useChartTooltip'
+
+interface StatusDonutProps {
+  counts: Record<SessionStatus, number>
+}
+
+/**
+ * SVG donut of the live session status distribution, vertically centered so it
+ * sits comfortably even when the card is stretched taller by its row neighbor.
+ * Static (no animation loop); hovering a segment or legend row shows an instant
+ * tooltip with the share of sessions.
+ */
+export function StatusDonut({ counts }: StatusDonutProps): React.JSX.Element {
+  const tip = useChartTooltip()
+  const total = useMemo(() => STATUS_ORDER.reduce((sum, s) => sum + counts[s], 0), [counts])
+
+  const segments = useMemo(() => {
+    const out: { status: SessionStatus; pct: number; offset: number }[] = []
+    let offset = 25 // start at 12 o'clock
+    for (const status of STATUS_ORDER) {
+      const value = counts[status]
+      if (value <= 0) continue
+      const pct = total > 0 ? (value / total) * 100 : 0
+      out.push({ status, pct, offset })
+      offset -= pct
+    }
+    return out
+  }, [counts, total])
+
+  const tipFor = (status: SessionStatus) => (e: React.MouseEvent) => {
+    const pct = total > 0 ? Math.round((counts[status] / total) * 100) : 0
+    tip.show(
+      e,
+      <span>
+        <b>{STATUS_LABEL[status]}</b> · {counts[status]} ({pct}%)
+      </span>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-4 h-full min-h-[150px]">
+      <svg width={118} height={118} viewBox="0 0 42 42" className="flex-shrink-0">
+        <circle
+          cx={21}
+          cy={21}
+          r={15.915}
+          fill="none"
+          stroke="var(--dplex-bg-elev-3)"
+          strokeWidth={5}
+        />
+        {segments.map((seg) => (
+          <circle
+            key={seg.status}
+            cx={21}
+            cy={21}
+            r={15.915}
+            fill="none"
+            stroke={STATUS_VAR[seg.status]}
+            strokeWidth={5}
+            strokeDasharray={`${seg.pct} ${100 - seg.pct}`}
+            strokeDashoffset={seg.offset}
+            style={{ cursor: 'pointer' }}
+            onMouseEnter={tipFor(seg.status)}
+            onMouseMove={tipFor(seg.status)}
+            onMouseLeave={tip.hide}
+          />
+        ))}
+        <text
+          x={21}
+          y={20.5}
+          textAnchor="middle"
+          fontSize={7}
+          fontWeight={700}
+          fontFamily="monospace"
+          fill="var(--dplex-text)"
+        >
+          {total}
+        </text>
+        <text
+          x={21}
+          y={25}
+          textAnchor="middle"
+          fontSize={2.6}
+          fontFamily="monospace"
+          fill="var(--dplex-text-dim)"
+        >
+          SESSIONS
+        </text>
+      </svg>
+      <div className="flex-1 flex flex-col gap-2 min-w-0">
+        {STATUS_ORDER.map((status) => (
+          <div
+            key={status}
+            className="flex items-center gap-2 text-[12.5px] rounded px-1 -mx-1 hover:bg-[var(--dplex-hover)]"
+            onMouseEnter={tipFor(status)}
+            onMouseMove={tipFor(status)}
+            onMouseLeave={tip.hide}
+          >
+            <span
+              className="w-2.5 h-2.5 rounded-sm flex-shrink-0"
+              style={{ backgroundColor: STATUS_VAR[status] }}
+            />
+            <span className="truncate" style={{ color: 'var(--dplex-text-2)' }}>
+              {STATUS_LABEL[status]}
+            </span>
+            <span className="ml-auto font-mono" style={{ color: 'var(--dplex-text-muted)' }}>
+              {counts[status]}
+            </span>
+          </div>
+        ))}
+      </div>
+      {tip.node}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/TopReposList.tsx
+++ b/src/renderer/src/components/dashboard/TopReposList.tsx
@@ -1,0 +1,83 @@
+import { useMemo } from 'react'
+import { FolderGit2 } from 'lucide-react'
+import { EmptyState } from './EmptyState'
+import type { DashboardMetrics } from '../../../../preload'
+
+interface TopReposCardProps {
+  repos: DashboardMetrics['topRepos']
+  onSelect?: (repo: DashboardMetrics['topRepos'][number]) => void
+}
+
+/** Horizontal-bar ranking of the repositories used most in the window. */
+export function TopReposList({ repos, onSelect }: TopReposCardProps): React.JSX.Element {
+  const max = useMemo(() => Math.max(1, ...repos.map((r) => r.sessions)), [repos])
+
+  if (repos.length === 0) {
+    return (
+      <EmptyState
+        Icon={FolderGit2}
+        title="No repository activity yet"
+        subtitle="Sessions you run will be grouped by repository here."
+      />
+    )
+  }
+
+  return (
+    <div className="flex flex-col">
+      {repos.map((r, i) => {
+        const branchLine =
+          r.branches.length > 0
+            ? r.branches.length > 1
+              ? `${r.branches[0]} +${r.branches.length - 1}`
+              : r.branches[0]
+            : '—'
+        return (
+          <button
+            key={r.repo}
+            type="button"
+            onClick={() => onSelect?.(r)}
+            className="flex items-center gap-3 py-2 text-left rounded-md hover:bg-[var(--dplex-hover)] transition-colors px-1 -mx-1"
+            title={r.cwd ?? r.repo}
+          >
+            <span
+              className="font-mono flex-shrink-0 text-right"
+              style={{ fontSize: 11, color: 'var(--dplex-text-faint)', width: 18 }}
+            >
+              {String(i + 1).padStart(2, '0')}
+            </span>
+            <div className="min-w-0" style={{ width: 150 }}>
+              <div
+                className="font-mono text-[13px] truncate"
+                style={{ color: 'var(--dplex-text-2)' }}
+              >
+                {r.repo}
+              </div>
+              <div className="text-[11px] truncate" style={{ color: 'var(--dplex-text-dim)' }}>
+                {branchLine}
+              </div>
+            </div>
+            <div
+              className="flex-1 h-1.5 rounded-full overflow-hidden mx-1"
+              style={{ backgroundColor: 'var(--dplex-bg-elev-3)' }}
+            >
+              <div
+                className="h-full rounded-full"
+                style={{
+                  width: `${(r.sessions / max) * 100}%`,
+                  background:
+                    'linear-gradient(90deg, var(--dplex-accent-3), var(--dplex-accent), var(--dplex-accent-alt))'
+                }}
+              />
+            </div>
+            <span
+              className="font-mono text-[12px] flex-shrink-0 text-right"
+              style={{ color: 'var(--dplex-text)', width: 28 }}
+            >
+              {r.sessions}
+            </span>
+          </button>
+        )
+      })}
+    </div>
+  )
+}

--- a/src/renderer/src/components/dashboard/WorkHeatmap.tsx
+++ b/src/renderer/src/components/dashboard/WorkHeatmap.tsx
@@ -1,0 +1,107 @@
+import { useMemo } from 'react'
+import { useChartTooltip } from './useChartTooltip'
+import type { DashboardMetrics } from '../../../../preload'
+
+interface WorkHeatmapProps {
+  cells: DashboardMetrics['heatmap']
+}
+
+const ROWS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+
+/**
+ * Hour × weekday activity heatmap (Monday-first). Cell opacity scales with the
+ * session count relative to the busiest hour. Hovering a cell shows an instant
+ * tooltip (native `title` was too slow to appear).
+ */
+export function WorkHeatmap({ cells }: WorkHeatmapProps): React.JSX.Element {
+  const tip = useChartTooltip()
+  const { grid, max } = useMemo(() => {
+    const g: number[][] = Array.from({ length: 7 }, () => new Array(24).fill(0))
+    let m = 0
+    for (const c of cells) {
+      if (c.weekday < 0 || c.weekday > 6 || c.hour < 0 || c.hour > 23) continue
+      g[c.weekday][c.hour] = c.count
+      if (c.count > m) m = c.count
+    }
+    return { grid: g, max: m }
+  }, [cells])
+
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="grid gap-[3px] min-w-[640px]"
+        style={{ gridTemplateColumns: '34px repeat(24, 1fr)' }}
+      >
+        <span />
+        {Array.from({ length: 24 }, (_, h) => (
+          <span
+            key={`h-${h}`}
+            className="text-center font-mono self-center"
+            style={{ fontSize: 9, color: 'var(--dplex-text-faint)' }}
+          >
+            {h % 6 === 0 ? String(h).padStart(2, '0') : ''}
+          </span>
+        ))}
+
+        {ROWS.map((label, wd) => (
+          <Row key={label} label={label} wd={wd} counts={grid[wd]} max={max} tip={tip} />
+        ))}
+      </div>
+      {tip.node}
+    </div>
+  )
+}
+
+function Row({
+  label,
+  wd,
+  counts,
+  max,
+  tip
+}: {
+  label: string
+  wd: number
+  counts: number[]
+  max: number
+  tip: ReturnType<typeof useChartTooltip>
+}): React.JSX.Element {
+  return (
+    <>
+      <span
+        className="font-mono self-center"
+        style={{ fontSize: 10, color: 'var(--dplex-text-dim)' }}
+      >
+        {label}
+      </span>
+      {counts.map((count, h) => {
+        const intensity = max > 0 ? count / max : 0
+        const opacity = count === 0 ? 0.05 : 0.18 + intensity * 0.82
+        const onMove = (e: React.MouseEvent): void => {
+          tip.show(
+            e,
+            <span>
+              <b>
+                {label} {String(h).padStart(2, '0')}:00
+              </b>{' '}
+              · {count} session{count === 1 ? '' : 's'}
+            </span>
+          )
+        }
+        return (
+          <div
+            key={h}
+            className="rounded-sm"
+            style={{
+              aspectRatio: '1',
+              backgroundColor: `color-mix(in srgb, var(--dplex-accent) ${Math.round(opacity * 100)}%, transparent)`
+            }}
+            data-wd={wd}
+            onMouseEnter={onMove}
+            onMouseMove={onMove}
+            onMouseLeave={tip.hide}
+          />
+        )
+      })}
+    </>
+  )
+}

--- a/src/renderer/src/components/dashboard/useChartTooltip.tsx
+++ b/src/renderer/src/components/dashboard/useChartTooltip.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useState, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+
+interface TipState {
+  x: number
+  y: number
+  content: ReactNode
+}
+
+interface ChartTooltip {
+  /** Show/move the tooltip at the pointer. Call from onMouseEnter/onMouseMove. */
+  show: (e: { clientX: number; clientY: number }, content: ReactNode) => void
+  /** Hide the tooltip. Call from onMouseLeave. */
+  hide: () => void
+  /** Portal node to render once per chart (null when hidden). */
+  node: ReactNode
+}
+
+/**
+ * Lightweight, instant chart tooltip. Renders through a portal to escape card
+ * `overflow`, follows the cursor, and appears with zero delay (unlike the
+ * native `title` attribute, whose ~1s delay made the heatmap feel sluggish).
+ * One instance per chart component.
+ */
+export function useChartTooltip(): ChartTooltip {
+  const [tip, setTip] = useState<TipState | null>(null)
+
+  const show = useCallback((e: { clientX: number; clientY: number }, content: ReactNode): void => {
+    setTip({ x: e.clientX, y: e.clientY, content })
+  }, [])
+  const hide = useCallback((): void => setTip(null), [])
+
+  const node = tip
+    ? createPortal(
+        <div
+          role="tooltip"
+          style={{
+            position: 'fixed',
+            left: tip.x,
+            top: tip.y - 12,
+            transform: 'translate(-50%, -100%)',
+            pointerEvents: 'none',
+            zIndex: 1000,
+            padding: '6px 9px',
+            borderRadius: 8,
+            background: 'var(--dplex-bg-elev-3)',
+            border: '1px solid var(--dplex-border-strong)',
+            boxShadow: '0 8px 24px -8px rgba(0,0,0,0.6)',
+            color: 'var(--dplex-text)',
+            fontSize: 11.5,
+            fontFamily: "'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, monospace",
+            whiteSpace: 'nowrap',
+            lineHeight: 1.5
+          }}
+        >
+          {tip.content}
+        </div>,
+        document.body
+      )
+    : null
+
+  return { show, hide, node }
+}

--- a/src/renderer/src/components/layout/ActivityBar.tsx
+++ b/src/renderer/src/components/layout/ActivityBar.tsx
@@ -126,22 +126,6 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
             : 'var(--dplex-text-dim)'
         }}
       >
-        {dashboardActive && (
-          <span
-            aria-hidden
-            className="absolute"
-            style={{
-              left: -8,
-              top: '50%',
-              transform: 'translateY(-50%)',
-              width: 3,
-              height: 20,
-              borderRadius: '0 2px 2px 0',
-              backgroundColor: 'var(--dplex-accent)',
-              boxShadow: '0 0 12px var(--dplex-accent-glow)'
-            }}
-          />
-        )}
         <LayoutDashboard size={18} strokeWidth={1.8} />
       </button>
       <div

--- a/src/renderer/src/components/layout/ActivityBar.tsx
+++ b/src/renderer/src/components/layout/ActivityBar.tsx
@@ -1,9 +1,19 @@
 import { useMemo } from 'react'
-import { FolderOpen, Clock, GitBranch, Settings, Search, Files } from 'lucide-react'
+import {
+  FolderOpen,
+  Clock,
+  GitBranch,
+  Settings,
+  Search,
+  Files,
+  LayoutDashboard
+} from 'lucide-react'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useGitPanelStore } from '../../stores/gitPanelStore'
 import { useProjectStore } from '../../stores/projectStore'
 import { useAttentionStore } from '../../stores/attentionStore'
+import { useTerminalStore } from '../../stores/terminalStore'
+import { isDashboardTab } from '../../types'
 import { MOD, SHIFT } from '../../utils/shortcuts'
 
 type ActivityId = 'search' | 'projects' | 'sessions' | 'git' | 'explorer'
@@ -52,6 +62,15 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
   // Sessions attention dot — show whenever the inbox has any active events.
   const attentionCount = useAttentionStore((s) => s.active.length)
 
+  // Whether the focused editor tab is the Overview Dashboard.
+  const dashboardActive = useTerminalStore((s) => {
+    const group = s.groups.find((g) => g.id === s.activeGroupId)
+    if (!group) return false
+    const tab = group.tabs.find((t) => t.id === group.activeTabId)
+    return !!tab && isDashboardTab(tab)
+  })
+  const openDashboard = useTerminalStore((s) => s.openOrFocusDashboardTab)
+
   const select = (id: ActivityId): void => {
     if (id === activeTab && !panelCollapsed) {
       // Click active item again → collapse the panel (VSCode behavior).
@@ -74,6 +93,66 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
         paddingBottom: 12
       }}
     >
+      {/* Dashboard — an action (opens/focuses the dashboard tab), not a
+          side-panel view. Sits above the view switches with its own divider. */}
+      <button
+        type="button"
+        aria-label="Dashboard"
+        aria-selected={dashboardActive}
+        title="Dashboard"
+        onClick={() => openDashboard()}
+        data-testid="activity-bar-dashboard"
+        className="relative grid place-items-center transition-colors"
+        style={{
+          width: 40,
+          height: 40,
+          marginBottom: 8,
+          borderRadius: 10,
+          color: dashboardActive ? 'var(--dplex-accent)' : 'var(--dplex-text-dim)',
+          backgroundColor: dashboardActive ? 'var(--dplex-accent-soft)' : 'transparent'
+        }}
+        onMouseEnter={(e) => {
+          if (!dashboardActive) {
+            e.currentTarget.style.backgroundColor = 'var(--dplex-bg-elev)'
+            e.currentTarget.style.color = 'var(--dplex-text-2)'
+          }
+        }}
+        onMouseLeave={(e) => {
+          e.currentTarget.style.backgroundColor = dashboardActive
+            ? 'var(--dplex-accent-soft)'
+            : 'transparent'
+          e.currentTarget.style.color = dashboardActive
+            ? 'var(--dplex-accent)'
+            : 'var(--dplex-text-dim)'
+        }}
+      >
+        {dashboardActive && (
+          <span
+            aria-hidden
+            className="absolute"
+            style={{
+              left: -8,
+              top: '50%',
+              transform: 'translateY(-50%)',
+              width: 3,
+              height: 20,
+              borderRadius: '0 2px 2px 0',
+              backgroundColor: 'var(--dplex-accent)',
+              boxShadow: '0 0 12px var(--dplex-accent-glow)'
+            }}
+          />
+        )}
+        <LayoutDashboard size={18} strokeWidth={1.8} />
+      </button>
+      <div
+        aria-hidden
+        style={{
+          width: 24,
+          height: 1,
+          marginBottom: 8,
+          backgroundColor: 'var(--dplex-border-subtle)'
+        }}
+      />
       {ITEMS.map(({ id, label, shortcut, Icon }) => {
         const isActive = activeTab === id && !panelCollapsed
         const badge =

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -29,6 +29,7 @@ import type {
   TerminalTab,
   FileDiffTab,
   FileEditorTab,
+  DashboardTab,
   EditorTab,
   EditorGroup,
   LayoutNode
@@ -45,6 +46,7 @@ async function loadPersistedWorkspace(): Promise<{
       | (TerminalTab & { kind?: 'terminal' })
       | (FileDiffTab & { kind: 'fileDiff' })
       | (FileEditorTab & { kind: 'fileEditor' })
+      | (DashboardTab & { kind: 'dashboard' })
       | { kind: 'diff' } // Legacy repo-level diff tab — quietly dropped on restore.
     const data = (await window.dplex.sessions.loadWorkspace()) as {
       groups: Array<{
@@ -68,12 +70,16 @@ async function loadPersistedWorkspace(): Promise<{
         if (t.kind === 'diff') return false
         if (t.kind === 'fileDiff') return true
         if (t.kind === 'fileEditor') return true
+        if (t.kind === 'dashboard') return true
         return !!(t as TerminalTab).command
       })
       if (keepers.length === 0) continue
 
       const preparedTabs: EditorTab[] = await Promise.all(
         keepers.map(async (t): Promise<EditorTab> => {
+          if (t.kind === 'dashboard') {
+            return { ...(t as DashboardTab) }
+          }
           if (t.kind === 'fileDiff') {
             const ft = t as FileDiffTab
             // Restored fileDiff tabs are always permanent — preview tabs

--- a/src/renderer/src/components/layout/SidePanel.tsx
+++ b/src/renderer/src/components/layout/SidePanel.tsx
@@ -82,6 +82,22 @@ export function SidePanel(): React.JSX.Element | null {
     return () => window.removeEventListener('dplex:focus-search', handler)
   }, [])
 
+  // Apply a status filter requested from elsewhere (e.g. the Dashboard's
+  // "Active now" / "Needs you" drill-down KPIs). The request lives in the
+  // session store (not a fire-and-forget DOM event), so it survives this panel
+  // not being visible yet when the dashboard makes the request. We subscribe
+  // imperatively and consume + clear the request when it appears.
+  useEffect(() => {
+    const consume = (pending: string[] | null): void => {
+      if (pending && pending.length > 0) {
+        setStatusFilters(new Set(pending))
+        useSessionStore.getState().clearPendingStatusFilter()
+      }
+    }
+    consume(useSessionStore.getState().pendingStatusFilter)
+    return useSessionStore.subscribe((s) => consume(s.pendingStatusFilter))
+  }, [])
+
   // Compute available providers and counts
   const providerOptions = useMemo(() => {
     const counts = new Map<string, number>()
@@ -259,6 +275,8 @@ export function SidePanel(): React.JSX.Element | null {
               color: hasActiveFilters ? 'var(--dplex-accent)' : 'var(--dplex-text-muted)'
             }}
             title="Filter & group options"
+            data-testid="sessions-filter-toggle"
+            aria-pressed={hasActiveFilters}
           >
             <SlidersHorizontal size={13} />
           </button>

--- a/src/renderer/src/components/sessions/SessionItem.tsx
+++ b/src/renderer/src/components/sessions/SessionItem.tsx
@@ -111,7 +111,8 @@ export function SessionItem({
   const backingTabId = useTerminalStore((s) => {
     for (const group of s.groups) {
       for (const tab of group.tabs) {
-        if (tab.kind === 'fileDiff' || tab.kind === 'fileEditor') continue
+        if (tab.kind === 'fileDiff' || tab.kind === 'fileEditor' || tab.kind === 'dashboard')
+          continue
         if (tab.providerId === session.aiTool && tab.sessionId === session.id) {
           return tab.id
         }
@@ -126,7 +127,8 @@ export function SessionItem({
     const group = s.groups.find((g) => g.id === s.activeGroupId)
     if (!group) return false
     const tab = group.tabs.find((t) => t.id === group.activeTabId)
-    if (!tab || tab.kind === 'fileDiff' || tab.kind === 'fileEditor') return false
+    if (!tab || tab.kind === 'fileDiff' || tab.kind === 'fileEditor' || tab.kind === 'dashboard')
+      return false
     return tab.providerId === session.aiTool && tab.sessionId === session.id
   })
 

--- a/src/renderer/src/components/terminal/EditorGroup.tsx
+++ b/src/renderer/src/components/terminal/EditorGroup.tsx
@@ -1,6 +1,6 @@
 import { useState, DragEvent } from 'react'
 import type { EditorGroup as EditorGroupType } from '../../types'
-import { isFileDiffTab, isFileEditorTab } from '../../types'
+import { isFileDiffTab, isFileEditorTab, isDashboardTab } from '../../types'
 import { useTerminalStore } from '../../stores/terminalStore'
 import { useFocusFilter } from '../../hooks/useFocusFilter'
 import { GroupTabBar } from './GroupTabBar'
@@ -8,6 +8,7 @@ import { TabHeader } from './TabHeader'
 import { TerminalView } from './TerminalView'
 import { FileDiffTabView } from '../diff/FileDiffTabView'
 import { FileEditorTabView } from './FileEditorTabView'
+import { DashboardTabView } from '../dashboard/DashboardTabView'
 
 interface EditorGroupProps {
   group: EditorGroupType
@@ -129,6 +130,8 @@ export function EditorGroup({ group }: EditorGroupProps): React.JSX.Element {
                 <FileDiffTabView tab={tab} />
               ) : isFileEditorTab(tab) ? (
                 <FileEditorTabView tab={tab} isActive={isActiveGroup && isActive} />
+              ) : isDashboardTab(tab) ? (
+                <DashboardTabView isActive={isActiveGroup && isActive} />
               ) : (
                 <TerminalView
                   terminalId={tab.id}

--- a/src/renderer/src/components/terminal/GroupTabBar.tsx
+++ b/src/renderer/src/components/terminal/GroupTabBar.tsx
@@ -3,6 +3,7 @@ import {
   Plus,
   X,
   Terminal as TerminalIcon,
+  LayoutDashboard,
   SplitSquareHorizontal,
   SplitSquareVertical
 } from 'lucide-react'
@@ -18,7 +19,7 @@ import { getTabIdentity } from '../../utils/tabProject'
 import { openInheritedTerminal, openInheritedSplit } from '../../utils/inheritCwd'
 import { ShellSelector } from './ShellSelector'
 import type { EditorGroup } from '../../types'
-import { isTerminalTab, isFileDiffTab, isFileEditorTab } from '../../types'
+import { isTerminalTab, isFileDiffTab, isFileEditorTab, isDashboardTab } from '../../types'
 
 interface GroupTabBarProps {
   group: EditorGroup
@@ -227,6 +228,12 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
                 >
                   {identity.initials}
                 </span>
+              ) : isDashboardTab(tab) ? (
+                <LayoutDashboard
+                  size={13}
+                  className="flex-shrink-0"
+                  style={{ color: isActive ? 'var(--dplex-text)' : 'var(--dplex-text-muted)' }}
+                />
               ) : (
                 <TerminalIcon
                   size={13}

--- a/src/renderer/src/components/terminal/TabHeader.tsx
+++ b/src/renderer/src/components/terminal/TabHeader.tsx
@@ -49,7 +49,9 @@ export function TabHeader({ tab }: TabHeaderProps): JSX.Element | null {
     ? tab.repoRootFs
     : isFileEditor
       ? tab.rootFs
-      : (tab.worktreePath ?? tab.cwd)
+      : isTerminal
+        ? (tab.worktreePath ?? tab.cwd)
+        : undefined
   const branch = (isTerminal ? tab.worktreeBranch : undefined) ?? session?.branch
   const fileDiffPath = isFileDiff ? tab.file.gitPath : isFileEditor ? tab.relPath : undefined
 

--- a/src/renderer/src/components/worktrees/DeleteWorktreeModal.tsx
+++ b/src/renderer/src/components/worktrees/DeleteWorktreeModal.tsx
@@ -41,6 +41,7 @@ export function DeleteWorktreeModal({
         const root = normalizePath(t.rootFs)
         return root === normalizedWorktreePath || root.startsWith(normalizedWorktreePath + '/')
       }
+      if (t.kind === 'dashboard') return false
       if (t.worktreePath && normalizePath(t.worktreePath) === normalizedWorktreePath) {
         return true
       }

--- a/src/renderer/src/components/worktrees/RemoveWorktreeProjectModal.tsx
+++ b/src/renderer/src/components/worktrees/RemoveWorktreeProjectModal.tsx
@@ -45,6 +45,7 @@ export function RemoveWorktreeProjectModal({
         const root = normalizePath(t.rootFs)
         return root === projectPath || root.startsWith(projectPath + '/')
       }
+      if (t.kind === 'dashboard') return false
       if (t.worktreePath && normalizePath(t.worktreePath) === projectPath) return true
       if (!t.cwd) return false
       const cwd = normalizePath(t.cwd)

--- a/src/renderer/src/services/search/commandsSource.ts
+++ b/src/renderer/src/services/search/commandsSource.ts
@@ -15,7 +15,8 @@ import {
   BellRing,
   RefreshCw,
   Files,
-  ChevronsDownUp
+  ChevronsDownUp,
+  LayoutDashboard
 } from 'lucide-react'
 import type { SearchItem, SearchSource } from './types'
 import { useTerminalStore } from '../../stores/terminalStore'
@@ -43,6 +44,16 @@ interface CommandEntry {
 }
 
 const COMMANDS: readonly CommandEntry[] = [
+  {
+    id: 'open-dashboard',
+    label: 'Open Dashboard',
+    description: 'Open the Overview dashboard tab',
+    keywords: ['overview', 'metrics', 'stats', 'home', 'activity'],
+    Icon: LayoutDashboard,
+    run: () => {
+      useTerminalStore.getState().openOrFocusDashboardTab()
+    }
+  },
   {
     id: 'add-project',
     label: 'Add Project',

--- a/src/renderer/src/stores/dashboardStore.ts
+++ b/src/renderer/src/stores/dashboardStore.ts
@@ -1,0 +1,101 @@
+import { create } from 'zustand'
+import type { DashboardMetrics } from '../../../preload'
+
+interface DashboardState {
+  /** Last historical snapshot from the aggregation IPC (null until first load). */
+  metrics: DashboardMetrics | null
+  loading: boolean
+  error: string | null
+  /** Rolling window for historical aggregation, in days. */
+  windowDays: number
+  /**
+   * Set when a session add/remove invalidates the snapshot while the dashboard
+   * is hidden. Refreshed on next show — events are never dropped based on
+   * visibility (lesson from the git-graph autorefresh staleness bug).
+   */
+  dirty: boolean
+  lastLoadedAt: number
+
+  /** Idempotent: subscribe to session add/remove to mark the snapshot dirty. */
+  init: () => void
+  /** Fetch a fresh snapshot. No-ops a concurrent load. */
+  refresh: () => Promise<void>
+  /** Refresh only if never loaded or marked dirty. Call when the tab is shown. */
+  ensureFresh: () => void
+  setWindowDays: (days: number) => void
+}
+
+// Module-level subscription bookkeeping so `init` is safe to call from every
+// dashboard mount without stacking duplicate IPC listeners.
+let initialized = false
+let invalidateTimer: ReturnType<typeof setTimeout> | null = null
+// Monotonic counter bumped on every invalidation. `refresh` snapshots it at
+// start and only clears `dirty` if it hasn't advanced since — so an
+// invalidation that fires *during* an in-flight refresh is never overwritten
+// (and thus never silently dropped, leaving a hidden dashboard stale).
+let invalidationGeneration = 0
+
+export const useDashboardStore = create<DashboardState>((set, get) => ({
+  metrics: null,
+  loading: false,
+  error: null,
+  windowDays: 30,
+  dirty: true,
+  lastLoadedAt: 0,
+
+  init: () => {
+    if (initialized) return
+    initialized = true
+    const markDirty = (): void => {
+      invalidationGeneration += 1
+      // Debounce bursts of add/remove events into a single dirty flip.
+      if (invalidateTimer) clearTimeout(invalidateTimer)
+      invalidateTimer = setTimeout(() => {
+        set({ dirty: true })
+      }, 400)
+    }
+    // Event-driven only — no polling. Added/removed sessions change the
+    // historical aggregates; status-only updates do not, so we ignore them.
+    window.dplex.sessions.onSessionAdded(markDirty)
+    window.dplex.sessions.onSessionRemoved(markDirty)
+  },
+
+  refresh: async () => {
+    if (get().loading) return
+    const requestedWindow = get().windowDays
+    const startGen = invalidationGeneration
+    set({ loading: true, error: null })
+    try {
+      const metrics = await window.dplex.dashboard.getMetrics(requestedWindow)
+      // The snapshot is stale if, while the IPC was in flight, the window
+      // changed (user clicked another range) OR a session add/remove fired
+      // (invalidationGeneration advanced). In either case keep `dirty` and
+      // re-fetch so we never render under a wrong label or drop an update.
+      const stale = get().windowDays !== requestedWindow || invalidationGeneration !== startGen
+      if (stale) {
+        // Don't commit a snapshot for a window the user is no longer viewing —
+        // it would otherwise flash under the new window's labels. Keep the
+        // prior snapshot, stay dirty, and refetch for the current window.
+        set({ loading: false, dirty: true })
+        void get().refresh()
+      } else {
+        set({ metrics, loading: false, dirty: false, lastLoadedAt: Date.now() })
+      }
+    } catch (err) {
+      set({ error: String(err), loading: false })
+    }
+  },
+
+  ensureFresh: () => {
+    const { metrics, dirty, loading } = get()
+    if (loading) return
+    if (!metrics || dirty) void get().refresh()
+  },
+
+  setWindowDays: (days) => {
+    const clamped = Math.max(1, Math.min(365, Math.floor(days)))
+    if (clamped === get().windowDays) return
+    set({ windowDays: clamped, dirty: true })
+    void get().refresh()
+  }
+}))

--- a/src/renderer/src/stores/sessionStore.ts
+++ b/src/renderer/src/stores/sessionStore.ts
@@ -17,8 +17,20 @@ interface SessionState {
    */
   liveTabTitles: Record<string, string>
 
+  /**
+   * A status filter (e.g. `['waiting']`) requested from elsewhere — currently
+   * the dashboard's drill-down KPIs. Held in the store (not a fire-and-forget
+   * DOM event) so it survives the Sessions panel not being mounted yet when
+   * the request is made. The panel consumes and clears it on its next render.
+   */
+  pendingStatusFilter: string[] | null
+
   refreshSessions: () => Promise<void>
   setSearchQuery: (query: string) => void
+  /** Request a Sessions-panel status filter (consumed + cleared by the panel). */
+  requestStatusFilter: (status: string[]) => void
+  /** Clear the pending status-filter request after the panel applies it. */
+  clearPendingStatusFilter: () => void
   closeSession: (sessionId: string) => Promise<void>
   deleteSession: (sessionId: string) => Promise<void>
   setSessionNameOverride: (sessionId: string, name: string) => void
@@ -79,6 +91,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
     watching: false,
     sessionNameOverrides: {},
     liveTabTitles: {},
+    pendingStatusFilter: null,
 
     refreshSessions: async () => {
       set({ loading: true, error: null })
@@ -104,6 +117,14 @@ export const useSessionStore = create<SessionState>((set, get) => {
 
     setSearchQuery: (query) => {
       set({ searchQuery: query })
+    },
+
+    requestStatusFilter: (status) => {
+      set({ pendingStatusFilter: status })
+    },
+
+    clearPendingStatusFilter: () => {
+      if (get().pendingStatusFilter !== null) set({ pendingStatusFilter: null })
     },
 
     closeSession: async (sessionId) => {
@@ -161,8 +182,7 @@ export const useSessionStore = create<SessionState>((set, get) => {
         const liveTabTitles = { ...state.liveTabTitles, [key]: title }
         // Apply immediately to any matching session row, but never override
         // a user-set persistent name.
-        const persistent =
-          state.sessionNameOverrides[key] ?? state.sessionNameOverrides[sessionId]
+        const persistent = state.sessionNameOverrides[key] ?? state.sessionNameOverrides[sessionId]
         if (persistent) return { liveTabTitles }
         return {
           liveTabTitles,

--- a/src/renderer/src/stores/terminalStore.ts
+++ b/src/renderer/src/stores/terminalStore.ts
@@ -3,11 +3,12 @@ import type {
   TerminalTab,
   FileDiffTab,
   FileEditorTab,
+  DashboardTab,
   EditorTab,
   EditorGroup,
   LayoutNode
 } from '../types'
-import { isFileDiffTab, isFileEditorTab, isTerminalTab } from '../types'
+import { isFileDiffTab, isFileEditorTab, isTerminalTab, isDashboardTab } from '../types'
 import { destroyTerminal } from '../services/terminalRegistry'
 import { useSessionStore } from './sessionStore'
 
@@ -185,6 +186,11 @@ interface TerminalState {
     preview?: boolean
   }) => string
   updateFileEditorTab: (tabId: string, patch: Partial<Omit<FileEditorTab, 'id' | 'kind'>>) => void
+  /**
+   * Open the singleton Overview Dashboard tab, or focus it if already open.
+   * Returns the dashboard tab id.
+   */
+  openOrFocusDashboardTab: () => string
 }
 
 export const useTerminalStore = create<TerminalState>((set, get) => ({
@@ -853,6 +859,62 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
         return promotedOut ? { ...g, tabs, previewTabId: undefined } : { ...g, tabs }
       })
     }))
+  },
+
+  openOrFocusDashboardTab: (): string => {
+    const state = get()
+
+    // Focus an existing dashboard tab anywhere (singleton).
+    for (const g of state.groups) {
+      const existing = g.tabs.find((t) => isDashboardTab(t))
+      if (existing) {
+        set({
+          activeGroupId: g.id,
+          groups: state.groups.map((gg) =>
+            gg.id === g.id ? { ...gg, activeTabId: existing.id } : gg
+          )
+        })
+        return existing.id
+      }
+    }
+
+    const tab: DashboardTab = {
+      id: makeTerminalId(),
+      title: 'Dashboard',
+      kind: 'dashboard'
+    }
+
+    // No groups yet — create the first group.
+    const targetGroupId = state.activeGroupId
+    if (state.groups.length === 0 || !targetGroupId) {
+      const newGroup: EditorGroup = {
+        id: 'group-0',
+        tabs: [tab],
+        activeTabId: tab.id
+      }
+      set({
+        groups: [newGroup],
+        layout: { type: 'group', groupId: newGroup.id },
+        activeGroupId: newGroup.id
+      })
+      return tab.id
+    }
+
+    const targetGroup = state.groups.find((g) => g.id === targetGroupId)
+    if (!targetGroup) {
+      const gid = makeGroupId()
+      const newGroup: EditorGroup = { id: gid, tabs: [tab], activeTabId: tab.id }
+      set({ groups: [...state.groups, newGroup], activeGroupId: gid })
+      return tab.id
+    }
+
+    set({
+      groups: state.groups.map((g) =>
+        g.id === targetGroupId ? { ...g, tabs: [...g.tabs, tab], activeTabId: tab.id } : g
+      ),
+      activeGroupId: targetGroupId
+    })
+    return tab.id
   }
 }))
 
@@ -881,9 +943,13 @@ function serializeWorkspace(): unknown {
         .filter((t) => {
           if (isFileDiffTab(t)) return t.preview !== true
           if (isFileEditorTab(t)) return t.preview !== true
+          if (isDashboardTab(t)) return true
           return isTerminalTab(t) && !!t.command
         })
         .map((t) => {
+          if (isDashboardTab(t)) {
+            return { kind: 'dashboard' as const, id: t.id, title: t.title }
+          }
           if (isFileDiffTab(t)) {
             return {
               kind: 'fileDiff' as const,

--- a/src/renderer/src/stores/uncommittedStore.ts
+++ b/src/renderer/src/stores/uncommittedStore.ts
@@ -1,0 +1,85 @@
+import { create } from 'zustand'
+import { useProjectStore } from './projectStore'
+import { normalizePath } from '../utils/normalizePath'
+
+/** One repo's working-tree change count. */
+export interface UncommittedRepo {
+  root: string
+  label: string
+  count: number
+}
+
+interface UncommittedState {
+  /** Total uncommitted files across all registered repos. */
+  total: number
+  /** Number of repos with at least one uncommitted change. */
+  repoCount: number
+  /** Per-repo breakdown (count > 0 only), most-changed first. */
+  repos: UncommittedRepo[]
+  loading: boolean
+  /**
+   * Query the working-tree change count for every registered project. Reuses
+   * the existing `diff.listChanges` IPC; runs on demand (dashboard open /
+   * manual refresh), concurrency-capped — no polling.
+   */
+  refresh: () => Promise<void>
+}
+
+function folderName(p: string): string {
+  const parts = p.replace(/\\/g, '/').replace(/\/+$/, '').split('/')
+  return parts[parts.length - 1] || p
+}
+
+/** Run `tasks` with a bounded number of concurrent workers. */
+async function pooled<T>(items: T[], limit: number, fn: (item: T) => Promise<void>): Promise<void> {
+  let cursor = 0
+  const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+    while (cursor < items.length) {
+      const idx = cursor++
+      await fn(items[idx])
+    }
+  })
+  await Promise.all(workers)
+}
+
+export const useUncommittedStore = create<UncommittedState>((set, get) => ({
+  total: 0,
+  repoCount: 0,
+  repos: [],
+  loading: false,
+
+  refresh: async () => {
+    if (get().loading) return
+    set({ loading: true })
+    // Each project (and worktree) is a distinct checkout — dedupe only by the
+    // normalized path so two projects on the exact same folder count once.
+    const projects = useProjectStore.getState().projects
+    const seen = new Set<string>()
+    const targets: { root: string; label: string }[] = []
+    for (const p of projects) {
+      const key = normalizePath(p.path)
+      if (seen.has(key)) continue
+      seen.add(key)
+      targets.push({ root: p.path, label: p.name || folderName(p.path) })
+    }
+
+    const repos: UncommittedRepo[] = []
+    await pooled(targets, 4, async ({ root, label }) => {
+      try {
+        const res = await window.dplex.diff.listChanges(root, { kind: 'workingTree' })
+        const count = res.totalCount ?? res.files.length
+        if (count > 0) repos.push({ root, label, count })
+      } catch {
+        // Non-git folder or transient error — treat as no changes.
+      }
+    })
+
+    repos.sort((a, b) => b.count - a.count)
+    set({
+      repos,
+      repoCount: repos.length,
+      total: repos.reduce((sum, r) => sum + r.count, 0),
+      loading: false
+    })
+  }
+}))

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -41,7 +41,18 @@ export interface FileDiffTab {
   sideBySide?: boolean
 }
 
-export type EditorTab = TerminalTab | FileDiffTab | FileEditorTab
+export type EditorTab = TerminalTab | FileDiffTab | FileEditorTab | DashboardTab
+
+/**
+ * The Overview Dashboard tab. A singleton (only one exists at a time) opened
+ * from the activity bar / command palette. Carries no payload — all data is
+ * pulled live from stores and the dashboard aggregation IPC.
+ */
+export interface DashboardTab {
+  id: string
+  title: string
+  kind: 'dashboard'
+}
 
 /**
  * Editable file tab opened from the file explorer. Distinct from the
@@ -71,6 +82,10 @@ export function isFileDiffTab(tab: EditorTab): tab is FileDiffTab {
 
 export function isFileEditorTab(tab: EditorTab): tab is FileEditorTab {
   return tab.kind === 'fileEditor'
+}
+
+export function isDashboardTab(tab: EditorTab): tab is DashboardTab {
+  return tab.kind === 'dashboard'
 }
 
 export function isTerminalTab(tab: EditorTab): tab is TerminalTab {

--- a/src/renderer/src/utils/dashboardMetrics.ts
+++ b/src/renderer/src/utils/dashboardMetrics.ts
@@ -1,0 +1,251 @@
+import type { AISession, SessionStatus } from '../types'
+import type { AttentionEvent } from '../../../preload/attentionTypes'
+
+/** CSS variable carrying the themed color for each detailed status. */
+export const STATUS_VAR: Record<SessionStatus, string> = {
+  idle: 'var(--dplex-status-idle)',
+  thinking: 'var(--dplex-status-thinking)',
+  executingTool: 'var(--dplex-status-executing)',
+  awaitingApproval: 'var(--dplex-status-approval)',
+  waitingForUser: 'var(--dplex-status-waiting)'
+}
+
+/** Short human label for each detailed status. */
+export const STATUS_LABEL: Record<SessionStatus, string> = {
+  idle: 'Idle',
+  thinking: 'Thinking',
+  executingTool: 'Executing tool',
+  awaitingApproval: 'Awaiting approval',
+  waitingForUser: 'Waiting for you'
+}
+
+/** Order used when rendering the status donut / legend. */
+export const STATUS_ORDER: SessionStatus[] = [
+  'executingTool',
+  'thinking',
+  'awaitingApproval',
+  'waitingForUser',
+  'idle'
+]
+
+/** Effective detailed status for a session, collapsing active-but-untyped → thinking. */
+export function effectiveStatus(s: AISession): SessionStatus {
+  if (s.status !== 'active') return 'idle'
+  return s.detailedStatus ?? 'thinking'
+}
+
+export interface LiveKpis {
+  activeCount: number
+  needsYouCount: number
+  approvalCount: number
+  inputCount: number
+  sessionsToday: number
+  statusCounts: Record<SessionStatus, number>
+}
+
+/** Whether a timestamp falls on the local calendar "today". */
+function isToday(d: Date): boolean {
+  const now = new Date()
+  return (
+    d.getFullYear() === now.getFullYear() &&
+    d.getMonth() === now.getMonth() &&
+    d.getDate() === now.getDate()
+  )
+}
+
+/**
+ * Derive the live KPI numbers from the session list and attention inbox.
+ * Pure — depends only on its inputs, so it memoizes cleanly in a component.
+ */
+export function computeLiveKpis(
+  sessions: readonly AISession[],
+  attention: readonly AttentionEvent[]
+): LiveKpis {
+  const statusCounts: Record<SessionStatus, number> = {
+    idle: 0,
+    thinking: 0,
+    executingTool: 0,
+    awaitingApproval: 0,
+    waitingForUser: 0
+  }
+  let activeCount = 0
+  let sessionsToday = 0
+  for (const s of sessions) {
+    statusCounts[effectiveStatus(s)] += 1
+    if (s.status === 'active') activeCount += 1
+    if (isToday(s.createdAt)) sessionsToday += 1
+  }
+
+  let approvalCount = 0
+  let inputCount = 0
+  for (const e of attention) {
+    if (e.suppressed) continue
+    if (e.kind === 'waitingForApproval') approvalCount += 1
+    else if (e.kind === 'waitingForInput') inputCount += 1
+  }
+
+  return {
+    activeCount,
+    needsYouCount: approvalCount + inputCount,
+    approvalCount,
+    inputCount,
+    sessionsToday,
+    statusCounts
+  }
+}
+
+/** Most-recently-active sessions, newest first. */
+export function recentSessions(sessions: readonly AISession[], limit = 8): AISession[] {
+  return [...sessions].sort((a, b) => b.updatedAt.getTime() - a.updatedAt.getTime()).slice(0, limit)
+}
+
+/** Relative "time ago" label for a timestamp. */
+export function timeAgo(ms: number): string {
+  const diff = Date.now() - ms
+  if (diff < 45_000) return 'just now'
+  const mins = Math.round(diff / 60_000)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.round(mins / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.round(hours / 24)
+  return `${days}d ago`
+}
+
+/** Compact duration label, e.g. 45s / 14m / 2h 14m / 3d 4h. */
+export function formatDuration(ms: number): string {
+  const s = Math.max(0, Math.floor(ms / 1000))
+  if (s < 60) return `${s}s`
+  const m = Math.floor(s / 60)
+  if (m < 60) return `${m}m`
+  const h = Math.floor(m / 60)
+  if (h < 24) return `${h}h ${m % 60}m`
+  const d = Math.floor(h / 24)
+  return `${d}d ${h % 24}h`
+}
+
+export interface Housekeeping {
+  /** Age (ms) of the longest-waiting attention item, or null when none. */
+  oldestWaitingMs: number | null
+  oldestWaitingLabel: string | null
+  /** Idle sessions inactive longer than the idle-too-long threshold. */
+  staleCount: number
+  /** Elapsed (ms) of the longest-running active session, or null. */
+  longestActiveMs: number | null
+  longestActiveName: string | null
+}
+
+/**
+ * Live "housekeeping" signals from the session list + attention inbox — the
+ * actionable things a user should clean up. Pure over its inputs.
+ */
+export function computeHousekeeping(
+  sessions: readonly AISession[],
+  attention: readonly AttentionEvent[],
+  idleTooLongMinutes: number,
+  nowMs: number = Date.now()
+): Housekeeping {
+  // Oldest item that needs the user (approval / input), ignoring dismissed.
+  let oldestWaitingMs: number | null = null
+  let oldestWaitingLabel: string | null = null
+  for (const e of attention) {
+    if (e.suppressed) continue
+    if (e.kind !== 'waitingForApproval' && e.kind !== 'waitingForInput') continue
+    const age = nowMs - e.createdAt
+    if (oldestWaitingMs === null || age > oldestWaitingMs) {
+      oldestWaitingMs = age
+      oldestWaitingLabel = `${e.displayName} · ${
+        e.kind === 'waitingForApproval' ? 'approval' : 'input'
+      }`
+    }
+  }
+
+  // Stale = idle sessions whose last activity is older than the threshold.
+  const thresholdMs = Math.max(1, idleTooLongMinutes) * 60_000
+  let staleCount = 0
+  let longestActiveMs: number | null = null
+  let longestActiveName: string | null = null
+  for (const s of sessions) {
+    if (s.status === 'active') {
+      const elapsed = nowMs - s.createdAt.getTime()
+      if (longestActiveMs === null || elapsed > longestActiveMs) {
+        longestActiveMs = elapsed
+        longestActiveName = s.displayName
+      }
+    } else {
+      const last = s.lastActivityTime ?? s.updatedAt.getTime()
+      if (nowMs - last > thresholdMs) staleCount += 1
+    }
+  }
+
+  return {
+    oldestWaitingMs,
+    oldestWaitingLabel,
+    staleCount,
+    longestActiveMs,
+    longestActiveName
+  }
+}
+
+/** Percentage change current-vs-previous; null when there's no prior baseline. */
+export function pctDelta(current: number, previous: number): number | null {
+  if (previous <= 0) return null
+  return Math.round(((current - previous) / previous) * 100)
+}
+
+/** Average to one decimal, guarding divide-by-zero. */
+export function average(total: number, count: number): number {
+  if (count <= 0) return 0
+  return Math.round((total / count) * 10) / 10
+}
+
+/**
+ * Trailing active-day streak: consecutive most-recent days with ≥1 session. A
+ * zero on the final bucket (today, possibly not started yet) doesn't break it.
+ */
+export function activeStreak(overTime: ReadonlyArray<{ total: number }>): number {
+  let streak = 0
+  let i = overTime.length - 1
+  // Allow today (last bucket) to be empty without ending the streak.
+  if (i >= 0 && overTime[i].total === 0) i -= 1
+  for (; i >= 0; i--) {
+    if (overTime[i].total > 0) streak += 1
+    else break
+  }
+  return streak
+}
+
+/** Busiest weekday (0=Mon) and hour from the heatmap, or null when empty. */
+export function busiestSlot(
+  heatmap: ReadonlyArray<{ weekday: number; hour: number; count: number }>
+): { weekday: number; hour: number } | null {
+  const byWeekday = new Array(7).fill(0)
+  const byHour = new Array(24).fill(0)
+  let any = false
+  for (const c of heatmap) {
+    if (c.count <= 0) continue
+    any = true
+    byWeekday[c.weekday] += c.count
+    byHour[c.hour] += c.count
+  }
+  if (!any) return null
+  const weekday = byWeekday.indexOf(Math.max(...byWeekday))
+  const hour = byHour.indexOf(Math.max(...byHour))
+  return { weekday, hour }
+}
+
+const WEEKDAY_NAMES = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+
+/** Full weekday name for a Monday-first index. */
+export function weekdayName(index: number): string {
+  return WEEKDAY_NAMES[index] ?? ''
+}
+
+/** Per-provider share of sessions as integer percentages (largest first). */
+export function providerShares(
+  providerSplit: ReadonlyArray<{ providerId: string; sessions: number }>
+): { providerId: string; sessions: number; pct: number }[] {
+  const total = providerSplit.reduce((sum, p) => sum + p.sessions, 0)
+  return providerSplit
+    .map((p) => ({ ...p, pct: total > 0 ? Math.round((p.sessions / total) * 100) : 0 }))
+    .sort((a, b) => b.sessions - a.sessions)
+}

--- a/src/renderer/src/utils/dashboardMetrics.ts
+++ b/src/renderer/src/utils/dashboardMetrics.ts
@@ -1,5 +1,4 @@
 import type { AISession, SessionStatus } from '../types'
-import type { AttentionEvent } from '../../../preload/attentionTypes'
 
 /** CSS variable carrying the themed color for each detailed status. */
 export const STATUS_VAR: Record<SessionStatus, string> = {
@@ -54,13 +53,15 @@ function isToday(d: Date): boolean {
 }
 
 /**
- * Derive the live KPI numbers from the session list and attention inbox.
- * Pure — depends only on its inputs, so it memoizes cleanly in a component.
+ * Derive the live KPI numbers from the session list. Pure — depends only on
+ * its inputs, so it memoizes cleanly in a component.
+ *
+ * "Needs you" is derived from each session's live `detailedStatus` (the same
+ * source the Sessions panel's "waiting" filter and the status donut use), NOT
+ * from the attention inbox — inbox notifications can be acknowledged, dismissed
+ * or seeded and drift out of sync with the real session state.
  */
-export function computeLiveKpis(
-  sessions: readonly AISession[],
-  attention: readonly AttentionEvent[]
-): LiveKpis {
+export function computeLiveKpis(sessions: readonly AISession[]): LiveKpis {
   const statusCounts: Record<SessionStatus, number> = {
     idle: 0,
     thinking: 0,
@@ -76,13 +77,8 @@ export function computeLiveKpis(
     if (isToday(s.createdAt)) sessionsToday += 1
   }
 
-  let approvalCount = 0
-  let inputCount = 0
-  for (const e of attention) {
-    if (e.suppressed) continue
-    if (e.kind === 'waitingForApproval') approvalCount += 1
-    else if (e.kind === 'waitingForInput') inputCount += 1
-  }
+  const approvalCount = statusCounts.awaitingApproval
+  const inputCount = statusCounts.waitingForUser
 
   return {
     activeCount,
@@ -124,10 +120,10 @@ export function formatDuration(ms: number): string {
 }
 
 export interface Housekeeping {
-  /** Age (ms) of the longest-waiting attention item, or null when none. */
+  /** Age (ms) the longest-waiting session has been waiting, or null when none. */
   oldestWaitingMs: number | null
   oldestWaitingLabel: string | null
-  /** Session id of the oldest-waiting item (for focusing it in the panel). */
+  /** Session id of the oldest-waiting session (for focusing it in the panel). */
   oldestWaitingSessionId: string | null
   /** Active sessions that have gone quiet beyond the idle-too-long threshold. */
   staleCount: number
@@ -139,45 +135,47 @@ export interface Housekeeping {
 }
 
 /**
- * Live "housekeeping" signals from the session list + attention inbox — the
- * actionable things a user should clean up. Pure over its inputs.
+ * Live "housekeeping" signals from the session list — the actionable things a
+ * user should clean up. Pure over its inputs.
+ *
+ * "Oldest awaiting you" is derived from each session's live `detailedStatus`
+ * (awaitingApproval / waitingForUser), NOT the attention inbox — inbox
+ * notifications can be acknowledged/dismissed/seeded and drift out of sync,
+ * which would make this disagree with the Sessions panel's "waiting" filter.
  */
 export function computeHousekeeping(
   sessions: readonly AISession[],
-  attention: readonly AttentionEvent[],
   idleTooLongMinutes: number,
   nowMs: number = Date.now()
 ): Housekeeping {
-  // Oldest item that needs the user (approval / input), ignoring dismissed.
-  // "Oldest" = the largest age = the smallest createdAt; we keep the running
-  // maximum age, so an event waiting longer always wins over a newer one.
+  const thresholdMs = Math.max(1, idleTooLongMinutes) * 60_000
   let oldestWaitingMs: number | null = null
   let oldestWaitingLabel: string | null = null
   let oldestWaitingSessionId: string | null = null
-  for (const e of attention) {
-    if (e.suppressed) continue
-    if (e.kind !== 'waitingForApproval' && e.kind !== 'waitingForInput') continue
-    const age = nowMs - e.createdAt
-    if (oldestWaitingMs === null || age > oldestWaitingMs) {
-      oldestWaitingMs = age
-      oldestWaitingLabel = `${e.displayName} · ${
-        e.kind === 'waitingForApproval' ? 'approval' : 'input'
-      }`
-      oldestWaitingSessionId = e.sessionId
-    }
-  }
-
-  // Stale = ACTIVE sessions that have gone quiet: still running (lock alive)
-  // but with no activity for longer than the idle-too-long threshold. These
-  // are the actionable "check on it or close it" candidates — a stuck or
-  // forgotten agent. Non-active (historical) sessions are intentionally
-  // excluded; counting those would just tally your entire session history.
-  const thresholdMs = Math.max(1, idleTooLongMinutes) * 60_000
   let staleCount = 0
   let longestActiveMs: number | null = null
   let longestActiveName: string | null = null
   let longestActiveSessionId: string | null = null
+
   for (const s of sessions) {
+    const status = effectiveStatus(s)
+
+    // Oldest session that needs the user. The wait age is approximated by the
+    // time since last activity (when the agent asked). "Oldest" = the largest
+    // such age, so a session waiting longer always wins over a newer one.
+    if (status === 'awaitingApproval' || status === 'waitingForUser') {
+      const since = s.lastActivityTime ?? s.updatedAt.getTime()
+      const age = nowMs - since
+      if (oldestWaitingMs === null || age > oldestWaitingMs) {
+        oldestWaitingMs = age
+        oldestWaitingLabel = `${s.displayName} · ${
+          status === 'awaitingApproval' ? 'approval' : 'input'
+        }`
+        oldestWaitingSessionId = s.id
+      }
+    }
+
+    // Stale + longest-active only consider running sessions (lock alive).
     if (s.status !== 'active') continue
     const elapsed = nowMs - s.createdAt.getTime()
     if (longestActiveMs === null || elapsed > longestActiveMs) {

--- a/src/renderer/src/utils/dashboardMetrics.ts
+++ b/src/renderer/src/utils/dashboardMetrics.ts
@@ -159,22 +159,24 @@ export function computeHousekeeping(
     }
   }
 
-  // Stale = idle sessions whose last activity is older than the threshold.
+  // Stale = ACTIVE sessions that have gone quiet: still running (lock alive)
+  // but with no activity for longer than the idle-too-long threshold. These
+  // are the actionable "check on it or close it" candidates — a stuck or
+  // forgotten agent. Non-active (historical) sessions are intentionally
+  // excluded; counting those would just tally your entire session history.
   const thresholdMs = Math.max(1, idleTooLongMinutes) * 60_000
   let staleCount = 0
   let longestActiveMs: number | null = null
   let longestActiveName: string | null = null
   for (const s of sessions) {
-    if (s.status === 'active') {
-      const elapsed = nowMs - s.createdAt.getTime()
-      if (longestActiveMs === null || elapsed > longestActiveMs) {
-        longestActiveMs = elapsed
-        longestActiveName = s.displayName
-      }
-    } else {
-      const last = s.lastActivityTime ?? s.updatedAt.getTime()
-      if (nowMs - last > thresholdMs) staleCount += 1
+    if (s.status !== 'active') continue
+    const elapsed = nowMs - s.createdAt.getTime()
+    if (longestActiveMs === null || elapsed > longestActiveMs) {
+      longestActiveMs = elapsed
+      longestActiveName = s.displayName
     }
+    const last = s.lastActivityTime ?? s.updatedAt.getTime()
+    if (nowMs - last > thresholdMs) staleCount += 1
   }
 
   return {

--- a/src/renderer/src/utils/dashboardMetrics.ts
+++ b/src/renderer/src/utils/dashboardMetrics.ts
@@ -127,11 +127,15 @@ export interface Housekeeping {
   /** Age (ms) of the longest-waiting attention item, or null when none. */
   oldestWaitingMs: number | null
   oldestWaitingLabel: string | null
-  /** Idle sessions inactive longer than the idle-too-long threshold. */
+  /** Session id of the oldest-waiting item (for focusing it in the panel). */
+  oldestWaitingSessionId: string | null
+  /** Active sessions that have gone quiet beyond the idle-too-long threshold. */
   staleCount: number
   /** Elapsed (ms) of the longest-running active session, or null. */
   longestActiveMs: number | null
   longestActiveName: string | null
+  /** Session id of the longest-running active session. */
+  longestActiveSessionId: string | null
 }
 
 /**
@@ -145,8 +149,11 @@ export function computeHousekeeping(
   nowMs: number = Date.now()
 ): Housekeeping {
   // Oldest item that needs the user (approval / input), ignoring dismissed.
+  // "Oldest" = the largest age = the smallest createdAt; we keep the running
+  // maximum age, so an event waiting longer always wins over a newer one.
   let oldestWaitingMs: number | null = null
   let oldestWaitingLabel: string | null = null
+  let oldestWaitingSessionId: string | null = null
   for (const e of attention) {
     if (e.suppressed) continue
     if (e.kind !== 'waitingForApproval' && e.kind !== 'waitingForInput') continue
@@ -156,6 +163,7 @@ export function computeHousekeeping(
       oldestWaitingLabel = `${e.displayName} · ${
         e.kind === 'waitingForApproval' ? 'approval' : 'input'
       }`
+      oldestWaitingSessionId = e.sessionId
     }
   }
 
@@ -168,12 +176,14 @@ export function computeHousekeeping(
   let staleCount = 0
   let longestActiveMs: number | null = null
   let longestActiveName: string | null = null
+  let longestActiveSessionId: string | null = null
   for (const s of sessions) {
     if (s.status !== 'active') continue
     const elapsed = nowMs - s.createdAt.getTime()
     if (longestActiveMs === null || elapsed > longestActiveMs) {
       longestActiveMs = elapsed
       longestActiveName = s.displayName
+      longestActiveSessionId = s.id
     }
     const last = s.lastActivityTime ?? s.updatedAt.getTime()
     if (nowMs - last > thresholdMs) staleCount += 1
@@ -182,9 +192,11 @@ export function computeHousekeeping(
   return {
     oldestWaitingMs,
     oldestWaitingLabel,
+    oldestWaitingSessionId,
     staleCount,
     longestActiveMs,
-    longestActiveName
+    longestActiveName,
+    longestActiveSessionId
   }
 }
 

--- a/src/renderer/src/utils/tabFocus.ts
+++ b/src/renderer/src/utils/tabFocus.ts
@@ -1,4 +1,5 @@
 import type { EditorTab, LayoutNode, Project } from '../types'
+import { isDashboardTab } from '../types'
 import { getTabIdentity } from './tabProject'
 
 /**
@@ -9,7 +10,10 @@ import { getTabIdentity } from './tabProject'
  * visual grouping in {@link getTabIdentity}.
  *
  * Tabs with no project identity (plain shell terminals, file/diff tabs outside
- * any registered project) never match — in isolate mode they are hidden.
+ * any registered project) never match — in isolate mode they are hidden. The
+ * Dashboard is the exception: it's a global, project-agnostic view, so it
+ * stays visible under isolate mode (otherwise opening it while focused would
+ * render nothing).
  */
 export function tabMatchesFocus(
   tab: EditorTab,
@@ -17,6 +21,7 @@ export function tabMatchesFocus(
   targetProjectId: string | null
 ): boolean {
   if (!targetProjectId) return true
+  if (isDashboardTab(tab)) return true
   const identity = getTabIdentity(tab, projects)
   if (!identity) return false
   return identity.colorProject.id === targetProjectId || identity.matched.id === targetProjectId

--- a/src/renderer/src/utils/tabProject.ts
+++ b/src/renderer/src/utils/tabProject.ts
@@ -1,5 +1,5 @@
 import type { EditorTab, Project } from '../types'
-import { isFileDiffTab, isFileEditorTab } from '../types'
+import { isFileDiffTab, isFileEditorTab, isDashboardTab } from '../types'
 import { normalizePath } from './normalizePath'
 import { getAvatarColor, getAvatarInitials } from './projectStatus'
 
@@ -13,6 +13,7 @@ import { getAvatarColor, getAvatarInitials } from './projectStatus'
 export function getTabProjectPath(tab: EditorTab): string | undefined {
   if (isFileDiffTab(tab)) return tab.repoRootFs
   if (isFileEditorTab(tab)) return tab.rootFs
+  if (isDashboardTab(tab)) return undefined
   return tab.worktreePath ?? tab.cwd
 }
 

--- a/tests/e2e/dashboard.e2e.spec.ts
+++ b/tests/e2e/dashboard.e2e.spec.ts
@@ -1,0 +1,86 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
+import { closeApp, launchApp } from './support/electronApp'
+
+/**
+ * E2E coverage for the Overview Dashboard tab: the activity-bar entry opens
+ * (and focuses, never duplicates) a dashboard tab, and the core cards render.
+ */
+test.describe('DPlex dashboard', () => {
+  let app: ElectronApplication | undefined
+  let window: Page | undefined
+  let userDataDir: string | undefined
+
+  test.beforeEach(async () => {
+    const launched = await launchApp()
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+  })
+
+  test.afterEach(async () => {
+    await closeApp(app, userDataDir)
+  })
+
+  test('activity-bar button opens and focuses a single dashboard tab', async () => {
+    if (!window) throw new Error('Window not available')
+
+    const button = window.getByTestId('activity-bar-dashboard')
+    await expect(button).toBeVisible()
+
+    await button.click()
+
+    // The dashboard renders its "Overview" heading and key cards.
+    await expect(window.getByRole('heading', { name: 'Overview' })).toBeVisible()
+    await expect(window.getByText('Active now', { exact: true })).toBeVisible()
+    await expect(window.getByText('Needs you', { exact: true })).toBeVisible()
+    await expect(window.getByText('Status right now', { exact: true })).toBeVisible()
+
+    // A dashboard tab now exists in the tab strip.
+    const dashTabs = window.getByTestId('editor-tab-label').filter({ hasText: 'Dashboard' })
+    await expect(dashTabs).toHaveCount(1)
+
+    // Tier-1 housekeeping + cadence cards render.
+    await expect(window.getByText('Oldest awaiting you', { exact: true })).toBeVisible()
+    await expect(window.getByText('Stale sessions', { exact: true })).toBeVisible()
+    await expect(window.getByText('Longest active', { exact: true })).toBeVisible()
+    await expect(window.getByText('Uncommitted', { exact: true })).toBeVisible()
+    await expect(window.getByText('Your cadence', { exact: true })).toBeVisible()
+    await expect(window.getByText('Provider mix', { exact: true })).toBeVisible()
+
+    // Clicking again focuses the existing tab rather than creating a second.
+    await button.click()
+    await expect(dashTabs).toHaveCount(1)
+    await expect(window.getByRole('heading', { name: 'Overview' })).toBeVisible()
+  })
+
+  test('window selector switches the historical aggregation range', async () => {
+    if (!window) throw new Error('Window not available')
+
+    await window.getByTestId('activity-bar-dashboard').click()
+    await expect(window.getByRole('heading', { name: 'Overview' })).toBeVisible()
+
+    // Switching to the 7-day window updates the meta labels on the cards.
+    await window.getByRole('button', { name: '7d', exact: true }).click()
+    await expect(window.getByText('last 7 days · by provider')).toBeVisible()
+  })
+
+  test('clicking the Active now KPI reveals the Sessions sidebar with a status filter', async () => {
+    if (!window) throw new Error('Window not available')
+
+    await window.getByTestId('activity-bar-dashboard').click()
+    await expect(window.getByRole('heading', { name: 'Overview' })).toBeVisible()
+
+    // The KPI card is a button; clicking it should switch the sidebar to the
+    // Sessions view (its search box becomes visible)…
+    await window.getByText('Active now', { exact: true }).click()
+    await expect(window.getByPlaceholder('Search sessions...')).toBeVisible()
+
+    // …and the requested status filter must actually be applied — verifying the
+    // request survives the panel not being mounted at click time (the filter
+    // toggle reflects active filters via aria-pressed).
+    await expect(window.getByTestId('sessions-filter-toggle')).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+  })
+})

--- a/tests/unit/dashboard-aggregator.test.ts
+++ b/tests/unit/dashboard-aggregator.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Unit tests for the dashboard aggregator. Pure function — no window stub,
+ * no I/O. Verifies repo rollups, provider split, day bucketing, and the
+ * hour×weekday heatmap against a fixed `nowMs`.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { computeDashboardMetrics } from '../../src/main/services/dashboard/dashboardAggregator'
+import type { HistoricalSession } from '../../src/main/services/dashboard/types'
+
+const DAY = 86_400_000
+
+function makeSession(overrides: Partial<HistoricalSession>): HistoricalSession {
+  return {
+    id: Math.random().toString(36).slice(2),
+    providerId: 'copilot-cli',
+    cwd: '/work/repo-a',
+    repository: 'repo-a',
+    branch: 'main',
+    createdAtMs: 0,
+    updatedAtMs: 0,
+    messageCount: 0,
+    toolCallCount: 0,
+    ...overrides
+  }
+}
+
+// A stable "now": 2024-01-15 12:00 local.
+const NOW = new Date(2024, 0, 15, 12, 0, 0).getTime()
+
+describe('computeDashboardMetrics', () => {
+  it('totals sessions, messages and tool calls within the window', () => {
+    const sessions = [
+      makeSession({ createdAtMs: NOW - DAY, messageCount: 3, toolCallCount: 10 }),
+      makeSession({ createdAtMs: NOW - 2 * DAY, messageCount: 5, toolCallCount: 20 })
+    ]
+    const m = computeDashboardMetrics(sessions, { windowDays: 30, nowMs: NOW })
+    expect(m.totals.sessions).toBe(2)
+    expect(m.totals.messages).toBe(8)
+    expect(m.totals.toolCalls).toBe(30)
+  })
+
+  it('excludes sessions created before the window cutoff', () => {
+    const sessions = [
+      makeSession({ createdAtMs: NOW - 2 * DAY }),
+      makeSession({ createdAtMs: NOW - 40 * DAY }) // outside a 30d window
+    ]
+    const m = computeDashboardMetrics(sessions, { windowDays: 30, nowMs: NOW })
+    expect(m.totals.sessions).toBe(1)
+  })
+
+  it('computes previousTotals for the immediately preceding window', () => {
+    const sessions = [
+      // current window (last 10 days)
+      makeSession({ createdAtMs: NOW - 2 * DAY, messageCount: 5 }),
+      makeSession({ createdAtMs: NOW - 4 * DAY, messageCount: 3 }),
+      // previous window (10–20 days ago)
+      makeSession({ createdAtMs: NOW - 12 * DAY, messageCount: 4 }),
+      // older than two windows → excluded from both
+      makeSession({ createdAtMs: NOW - 40 * DAY, messageCount: 99 })
+    ]
+    const m = computeDashboardMetrics(sessions, { windowDays: 10, nowMs: NOW })
+    expect(m.totals.sessions).toBe(2)
+    expect(m.totals.messages).toBe(8)
+    expect(m.previousTotals.sessions).toBe(1)
+    expect(m.previousTotals.messages).toBe(4)
+  })
+
+  it('ranks repos by session count and collects distinct branches', () => {
+    const sessions = [
+      makeSession({ repository: 'repo-a', branch: 'main', createdAtMs: NOW - DAY }),
+      makeSession({ repository: 'repo-a', branch: 'feat-x', createdAtMs: NOW - 2 * DAY }),
+      makeSession({ repository: 'repo-a', branch: 'main', createdAtMs: NOW - 3 * DAY }),
+      makeSession({ repository: 'repo-b', branch: 'main', createdAtMs: NOW - DAY })
+    ]
+    const m = computeDashboardMetrics(sessions, { windowDays: 30, nowMs: NOW })
+    expect(m.topRepos[0].repo).toBe('repo-a')
+    expect(m.topRepos[0].sessions).toBe(3)
+    expect(m.topRepos[0].branches.sort()).toEqual(['feat-x', 'main'])
+    expect(m.topRepos[1].repo).toBe('repo-b')
+  })
+
+  it('derives a repo label from cwd basename when repository is missing', () => {
+    const sessions = [
+      makeSession({ repository: null, cwd: '/home/me/projects/cool-app', createdAtMs: NOW - DAY })
+    ]
+    const m = computeDashboardMetrics(sessions, { windowDays: 30, nowMs: NOW })
+    expect(m.topRepos[0].repo).toBe('cool-app')
+  })
+
+  it('splits sessions by provider, sorted by count', () => {
+    const sessions = [
+      makeSession({ providerId: 'copilot-cli', createdAtMs: NOW - DAY }),
+      makeSession({ providerId: 'copilot-cli', createdAtMs: NOW - 2 * DAY }),
+      makeSession({ providerId: 'claude-code', createdAtMs: NOW - DAY })
+    ]
+    const m = computeDashboardMetrics(sessions, { windowDays: 30, nowMs: NOW })
+    expect(m.providerSplit[0]).toEqual({ providerId: 'copilot-cli', sessions: 2 })
+    expect(m.providerSplit[1]).toEqual({ providerId: 'claude-code', sessions: 1 })
+  })
+
+  it('produces a gap-free daily bucket series oldest → newest', () => {
+    const m = computeDashboardMetrics([], { windowDays: 7, nowMs: NOW })
+    // 7-day window spans cutoff..now → 8 local-day boundaries inclusive.
+    expect(m.overTime.length).toBeGreaterThanOrEqual(7)
+    for (let i = 1; i < m.overTime.length; i++) {
+      expect(m.overTime[i].dateMs).toBeGreaterThan(m.overTime[i - 1].dateMs)
+    }
+  })
+
+  it('seeds buckets exactly at local midnight with no duplicate days (DST-safe)', () => {
+    // Use a long window so it spans a DST transition in any DST timezone.
+    const m = computeDashboardMetrics([], { windowDays: 90, nowMs: NOW })
+    const seen = new Set<number>()
+    for (const b of m.overTime) {
+      // Each key must be local midnight: re-normalizing must be a no-op.
+      const d = new Date(b.dateMs)
+      const midnight = new Date(d).setHours(0, 0, 0, 0)
+      expect(b.dateMs).toBe(midnight)
+      // And every calendar day must appear at most once.
+      expect(seen.has(b.dateMs)).toBe(false)
+      seen.add(b.dateMs)
+    }
+  })
+
+  it('buckets a session into the correct local day and provider', () => {
+    const sessions = [makeSession({ providerId: 'claude-code', createdAtMs: NOW - DAY })]
+    const m = computeDashboardMetrics(sessions, { windowDays: 7, nowMs: NOW })
+    const hit = m.overTime.find((b) => b.total > 0)
+    expect(hit).toBeDefined()
+    expect(hit?.byProvider['claude-code']).toBe(1)
+  })
+
+  it('always returns a full 7×24 heatmap and counts the right cell', () => {
+    // NOW is 2024-01-15 (a Monday) at 12:00 → weekday 0, hour 12.
+    const sessions = [makeSession({ createdAtMs: NOW })]
+    const m = computeDashboardMetrics(sessions, { windowDays: 30, nowMs: NOW })
+    expect(m.heatmap).toHaveLength(168)
+    const cell = m.heatmap.find((c) => c.weekday === 0 && c.hour === 12)
+    expect(cell?.count).toBe(1)
+  })
+
+  it('handles an empty session list without throwing', () => {
+    const m = computeDashboardMetrics([], { windowDays: 30, nowMs: NOW })
+    expect(m.totals.sessions).toBe(0)
+    expect(m.topRepos).toEqual([])
+    expect(m.heatmap).toHaveLength(168)
+  })
+})

--- a/tests/unit/dashboard-metrics.test.ts
+++ b/tests/unit/dashboard-metrics.test.ts
@@ -136,18 +136,42 @@ describe('formatDuration', () => {
 
 describe('computeHousekeeping', () => {
   const NOW = Date.now()
-  it('finds the oldest waiting attention item', () => {
+  it('finds the OLDEST waiting attention item, not the newest', () => {
     const hk = computeHousekeeping(
       [],
       [
-        event('waitingForApproval', { createdAt: NOW - 10 * 60_000, displayName: 'recent' }),
-        event('waitingForInput', { createdAt: NOW - 30 * 60_000, displayName: 'old' })
+        event('waitingForApproval', {
+          createdAt: NOW - 10 * 60_000,
+          displayName: 'recent',
+          sessionId: 'recent-id'
+        }),
+        event('waitingForInput', {
+          createdAt: NOW - 30 * 60_000,
+          displayName: 'old',
+          sessionId: 'old-id'
+        })
       ],
       30,
       NOW
     )
+    // 30m-old event must win over the 10m-old one.
     expect(Math.round((hk.oldestWaitingMs ?? 0) / 60_000)).toBe(30)
     expect(hk.oldestWaitingLabel).toContain('old')
+    expect(hk.oldestWaitingSessionId).toBe('old-id')
+  })
+
+  it('picks the oldest regardless of input ordering (oldest listed first)', () => {
+    const hk = computeHousekeeping(
+      [],
+      [
+        event('waitingForApproval', { createdAt: NOW - 50 * 60_000, sessionId: 'oldest' }),
+        event('waitingForInput', { createdAt: NOW - 5 * 60_000, sessionId: 'newest' })
+      ],
+      30,
+      NOW
+    )
+    expect(hk.oldestWaitingSessionId).toBe('oldest')
+    expect(Math.round((hk.oldestWaitingMs ?? 0) / 60_000)).toBe(50)
   })
 
   it('ignores suppressed and finished events for oldest-waiting', () => {
@@ -192,19 +216,22 @@ describe('computeHousekeeping', () => {
     expect(hk.staleCount).toBe(1)
   })
 
-  it('reports the longest-running active session', () => {
+  it('reports the longest-running active session and its id', () => {
     const a = session({
+      id: 'short-id',
       status: 'active',
       createdAt: new Date(NOW - 30 * 60_000),
       displayName: 'short'
     })
     const b = session({
+      id: 'long-id',
       status: 'active',
       createdAt: new Date(NOW - 2 * 3_600_000),
       displayName: 'long'
     })
     const hk = computeHousekeeping([a, b], [], 30, NOW)
     expect(hk.longestActiveName).toBe('long')
+    expect(hk.longestActiveSessionId).toBe('long-id')
     expect(Math.round((hk.longestActiveMs ?? 0) / 3_600_000)).toBe(2)
   })
 })

--- a/tests/unit/dashboard-metrics.test.ts
+++ b/tests/unit/dashboard-metrics.test.ts
@@ -1,7 +1,7 @@
 /**
  * Unit tests for the renderer-side live dashboard derivations
- * (`computeLiveKpis`, `recentSessions`, `timeAgo`). Pure functions over the
- * session list + attention inbox — no store or window access required.
+ * (`computeLiveKpis`, `computeHousekeeping`, helpers). Pure functions over the
+ * session list — no store or window access required.
  */
 
 import { describe, expect, it } from 'vitest'
@@ -20,7 +20,6 @@ import {
   weekdayName
 } from '../../src/renderer/src/utils/dashboardMetrics'
 import type { AISession } from '../../src/renderer/src/types'
-import type { AttentionEvent } from '../../src/preload/attentionTypes'
 
 function session(overrides: Partial<AISession>): AISession {
   return {
@@ -30,24 +29,6 @@ function session(overrides: Partial<AISession>): AISession {
     aiTool: 'copilot-cli',
     createdAt: new Date(),
     updatedAt: new Date(),
-    ...overrides
-  }
-}
-
-function event(
-  kind: AttentionEvent['kind'],
-  overrides: Partial<AttentionEvent> = {}
-): AttentionEvent {
-  return {
-    compositeId: `copilot-cli:${Math.random()}`,
-    providerId: 'copilot-cli',
-    sessionId: 'abc',
-    displayName: 'Session',
-    kind,
-    createdAt: Date.now(),
-    escalated: false,
-    suppressed: false,
-    seeded: false,
     ...overrides
   }
 }
@@ -71,28 +52,30 @@ describe('computeLiveKpis', () => {
       session({ status: 'active', detailedStatus: 'thinking' }),
       session({ status: 'idle' })
     ]
-    const kpis = computeLiveKpis(sessions, [])
+    const kpis = computeLiveKpis(sessions)
     expect(kpis.activeCount).toBe(2)
     expect(kpis.statusCounts.executingTool).toBe(1)
     expect(kpis.statusCounts.thinking).toBe(1)
     expect(kpis.statusCounts.idle).toBe(1)
   })
 
-  it('derives needs-you counts from the attention inbox', () => {
-    const attention = [
-      event('waitingForApproval'),
-      event('waitingForInput'),
-      event('waitingForInput'),
-      event('finished')
+  it('derives needs-you counts from live session status, not the inbox', () => {
+    const sessions = [
+      session({ status: 'active', detailedStatus: 'awaitingApproval' }),
+      session({ status: 'active', detailedStatus: 'waitingForUser' }),
+      session({ status: 'active', detailedStatus: 'waitingForUser' }),
+      session({ status: 'active', detailedStatus: 'thinking' }),
+      session({ status: 'idle' })
     ]
-    const kpis = computeLiveKpis([], attention)
+    const kpis = computeLiveKpis(sessions)
     expect(kpis.approvalCount).toBe(1)
     expect(kpis.inputCount).toBe(2)
     expect(kpis.needsYouCount).toBe(3)
   })
 
-  it('ignores suppressed attention events', () => {
-    const kpis = computeLiveKpis([], [event('waitingForApproval', { suppressed: true })])
+  it('does not count a non-active session as needing you (stale status)', () => {
+    // An idle session whose detailedStatus is stale must not inflate needs-you.
+    const kpis = computeLiveKpis([session({ status: 'idle', detailedStatus: 'awaitingApproval' })])
     expect(kpis.needsYouCount).toBe(0)
   })
 
@@ -136,36 +119,48 @@ describe('formatDuration', () => {
 
 describe('computeHousekeeping', () => {
   const NOW = Date.now()
-  it('finds the OLDEST waiting attention item, not the newest', () => {
+  it('finds the OLDEST waiting session (by detailedStatus), not the newest', () => {
     const hk = computeHousekeeping(
-      [],
       [
-        event('waitingForApproval', {
-          createdAt: NOW - 10 * 60_000,
+        session({
+          id: 'recent-id',
           displayName: 'recent',
-          sessionId: 'recent-id'
+          status: 'active',
+          detailedStatus: 'awaitingApproval',
+          lastActivityTime: NOW - 10 * 60_000
         }),
-        event('waitingForInput', {
-          createdAt: NOW - 30 * 60_000,
+        session({
+          id: 'old-id',
           displayName: 'old',
-          sessionId: 'old-id'
+          status: 'active',
+          detailedStatus: 'waitingForUser',
+          lastActivityTime: NOW - 30 * 60_000
         })
       ],
       30,
       NOW
     )
-    // 30m-old event must win over the 10m-old one.
+    // The session waiting 30m must win over the one waiting 10m.
     expect(Math.round((hk.oldestWaitingMs ?? 0) / 60_000)).toBe(30)
     expect(hk.oldestWaitingLabel).toContain('old')
     expect(hk.oldestWaitingSessionId).toBe('old-id')
   })
 
-  it('picks the oldest regardless of input ordering (oldest listed first)', () => {
+  it('picks the oldest waiting regardless of input ordering', () => {
     const hk = computeHousekeeping(
-      [],
       [
-        event('waitingForApproval', { createdAt: NOW - 50 * 60_000, sessionId: 'oldest' }),
-        event('waitingForInput', { createdAt: NOW - 5 * 60_000, sessionId: 'newest' })
+        session({
+          id: 'oldest',
+          status: 'active',
+          detailedStatus: 'awaitingApproval',
+          lastActivityTime: NOW - 50 * 60_000
+        }),
+        session({
+          id: 'newest',
+          status: 'active',
+          detailedStatus: 'waitingForUser',
+          lastActivityTime: NOW - 5 * 60_000
+        })
       ],
       30,
       NOW
@@ -174,17 +169,18 @@ describe('computeHousekeeping', () => {
     expect(Math.round((hk.oldestWaitingMs ?? 0) / 60_000)).toBe(50)
   })
 
-  it('ignores suppressed and finished events for oldest-waiting', () => {
+  it('reports nothing waiting when no active session needs the user', () => {
     const hk = computeHousekeeping(
-      [],
       [
-        event('finished', { createdAt: NOW - 60 * 60_000 }),
-        event('waitingForApproval', { createdAt: NOW - 5 * 60_000, suppressed: true })
+        session({ status: 'active', detailedStatus: 'thinking' }),
+        // Stale idle status must not register as waiting.
+        session({ status: 'idle', detailedStatus: 'awaitingApproval' })
       ],
       30,
       NOW
     )
     expect(hk.oldestWaitingMs).toBeNull()
+    expect(hk.oldestWaitingSessionId).toBeNull()
   })
 
   it('counts only ACTIVE sessions that have gone quiet beyond the threshold', () => {
@@ -201,7 +197,7 @@ describe('computeHousekeeping', () => {
       lastActivityTime: NOW - 2 * 60_000
     })
     const oldIdle = session({ status: 'idle', lastActivityTime: NOW - 10 * 86_400_000 })
-    const hk = computeHousekeeping([activeQuiet, activeBusy, oldIdle], [], 30, NOW)
+    const hk = computeHousekeeping([activeQuiet, activeBusy, oldIdle], 30, NOW)
     expect(hk.staleCount).toBe(1)
   })
 
@@ -212,7 +208,7 @@ describe('computeHousekeeping', () => {
       updatedAt: new Date(NOW - 50 * 60_000),
       lastActivityTime: undefined
     })
-    const hk = computeHousekeeping([s], [], 30, NOW)
+    const hk = computeHousekeeping([s], 30, NOW)
     expect(hk.staleCount).toBe(1)
   })
 
@@ -229,7 +225,7 @@ describe('computeHousekeeping', () => {
       createdAt: new Date(NOW - 2 * 3_600_000),
       displayName: 'long'
     })
-    const hk = computeHousekeeping([a, b], [], 30, NOW)
+    const hk = computeHousekeeping([a, b], 30, NOW)
     expect(hk.longestActiveName).toBe('long')
     expect(hk.longestActiveSessionId).toBe('long-id')
     expect(Math.round((hk.longestActiveMs ?? 0) / 3_600_000)).toBe(2)

--- a/tests/unit/dashboard-metrics.test.ts
+++ b/tests/unit/dashboard-metrics.test.ts
@@ -163,11 +163,32 @@ describe('computeHousekeeping', () => {
     expect(hk.oldestWaitingMs).toBeNull()
   })
 
-  it('counts idle sessions inactive beyond the threshold', () => {
-    const fresh = session({ status: 'idle', lastActivityTime: NOW - 5 * 60_000 })
-    const stale = session({ status: 'idle', lastActivityTime: NOW - 45 * 60_000 })
-    const active = session({ status: 'active', lastActivityTime: NOW - 90 * 60_000 })
-    const hk = computeHousekeeping([fresh, stale, active], [], 30, NOW)
+  it('counts only ACTIVE sessions that have gone quiet beyond the threshold', () => {
+    // Active but quiet for 45m → stale. Active and recently active → not.
+    // Idle (non-active) sessions are excluded regardless of how old they are.
+    const activeQuiet = session({
+      status: 'active',
+      createdAt: new Date(NOW - 2 * 3_600_000),
+      lastActivityTime: NOW - 45 * 60_000
+    })
+    const activeBusy = session({
+      status: 'active',
+      createdAt: new Date(NOW - 2 * 3_600_000),
+      lastActivityTime: NOW - 2 * 60_000
+    })
+    const oldIdle = session({ status: 'idle', lastActivityTime: NOW - 10 * 86_400_000 })
+    const hk = computeHousekeeping([activeQuiet, activeBusy, oldIdle], [], 30, NOW)
+    expect(hk.staleCount).toBe(1)
+  })
+
+  it('falls back to updatedAt when an active session has no lastActivityTime', () => {
+    const s = session({
+      status: 'active',
+      createdAt: new Date(NOW - 3 * 3_600_000),
+      updatedAt: new Date(NOW - 50 * 60_000),
+      lastActivityTime: undefined
+    })
+    const hk = computeHousekeeping([s], [], 30, NOW)
     expect(hk.staleCount).toBe(1)
   })
 

--- a/tests/unit/dashboard-metrics.test.ts
+++ b/tests/unit/dashboard-metrics.test.ts
@@ -82,7 +82,7 @@ describe('computeLiveKpis', () => {
   it('counts only sessions created today', () => {
     const old = session({ createdAt: new Date(Date.now() - 3 * 86_400_000) })
     const fresh = session({ createdAt: new Date() })
-    const kpis = computeLiveKpis([old, fresh], [])
+    const kpis = computeLiveKpis([old, fresh])
     expect(kpis.sessionsToday).toBe(1)
   })
 })

--- a/tests/unit/dashboard-metrics.test.ts
+++ b/tests/unit/dashboard-metrics.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Unit tests for the renderer-side live dashboard derivations
+ * (`computeLiveKpis`, `recentSessions`, `timeAgo`). Pure functions over the
+ * session list + attention inbox — no store or window access required.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  computeLiveKpis,
+  computeHousekeeping,
+  recentSessions,
+  effectiveStatus,
+  timeAgo,
+  formatDuration,
+  pctDelta,
+  average,
+  activeStreak,
+  busiestSlot,
+  providerShares,
+  weekdayName
+} from '../../src/renderer/src/utils/dashboardMetrics'
+import type { AISession } from '../../src/renderer/src/types'
+import type { AttentionEvent } from '../../src/preload/attentionTypes'
+
+function session(overrides: Partial<AISession>): AISession {
+  return {
+    id: Math.random().toString(36).slice(2),
+    displayName: 'Session',
+    status: 'idle',
+    aiTool: 'copilot-cli',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides
+  }
+}
+
+function event(
+  kind: AttentionEvent['kind'],
+  overrides: Partial<AttentionEvent> = {}
+): AttentionEvent {
+  return {
+    compositeId: `copilot-cli:${Math.random()}`,
+    providerId: 'copilot-cli',
+    sessionId: 'abc',
+    displayName: 'Session',
+    kind,
+    createdAt: Date.now(),
+    escalated: false,
+    suppressed: false,
+    seeded: false,
+    ...overrides
+  }
+}
+
+describe('effectiveStatus', () => {
+  it('reports idle for non-active sessions regardless of detailedStatus', () => {
+    expect(effectiveStatus(session({ status: 'idle', detailedStatus: 'thinking' }))).toBe('idle')
+  })
+
+  it('falls back to thinking for active-but-untyped sessions', () => {
+    expect(effectiveStatus(session({ status: 'active', detailedStatus: undefined }))).toBe(
+      'thinking'
+    )
+  })
+})
+
+describe('computeLiveKpis', () => {
+  it('counts active sessions and breaks down by status', () => {
+    const sessions = [
+      session({ status: 'active', detailedStatus: 'executingTool' }),
+      session({ status: 'active', detailedStatus: 'thinking' }),
+      session({ status: 'idle' })
+    ]
+    const kpis = computeLiveKpis(sessions, [])
+    expect(kpis.activeCount).toBe(2)
+    expect(kpis.statusCounts.executingTool).toBe(1)
+    expect(kpis.statusCounts.thinking).toBe(1)
+    expect(kpis.statusCounts.idle).toBe(1)
+  })
+
+  it('derives needs-you counts from the attention inbox', () => {
+    const attention = [
+      event('waitingForApproval'),
+      event('waitingForInput'),
+      event('waitingForInput'),
+      event('finished')
+    ]
+    const kpis = computeLiveKpis([], attention)
+    expect(kpis.approvalCount).toBe(1)
+    expect(kpis.inputCount).toBe(2)
+    expect(kpis.needsYouCount).toBe(3)
+  })
+
+  it('ignores suppressed attention events', () => {
+    const kpis = computeLiveKpis([], [event('waitingForApproval', { suppressed: true })])
+    expect(kpis.needsYouCount).toBe(0)
+  })
+
+  it('counts only sessions created today', () => {
+    const old = session({ createdAt: new Date(Date.now() - 3 * 86_400_000) })
+    const fresh = session({ createdAt: new Date() })
+    const kpis = computeLiveKpis([old, fresh], [])
+    expect(kpis.sessionsToday).toBe(1)
+  })
+})
+
+describe('recentSessions', () => {
+  it('returns sessions newest-first, capped at the limit', () => {
+    const a = session({ displayName: 'a', updatedAt: new Date(1000) })
+    const b = session({ displayName: 'b', updatedAt: new Date(3000) })
+    const c = session({ displayName: 'c', updatedAt: new Date(2000) })
+    const out = recentSessions([a, b, c], 2)
+    expect(out.map((s) => s.displayName)).toEqual(['b', 'c'])
+  })
+})
+
+describe('timeAgo', () => {
+  it('labels sub-minute as "just now"', () => {
+    expect(timeAgo(Date.now() - 5_000)).toBe('just now')
+  })
+  it('labels minutes, hours and days', () => {
+    expect(timeAgo(Date.now() - 5 * 60_000)).toMatch(/m ago/)
+    expect(timeAgo(Date.now() - 3 * 3_600_000)).toMatch(/h ago/)
+    expect(timeAgo(Date.now() - 2 * 86_400_000)).toMatch(/d ago/)
+  })
+})
+
+describe('formatDuration', () => {
+  it('formats seconds, minutes, hours and days', () => {
+    expect(formatDuration(45_000)).toBe('45s')
+    expect(formatDuration(5 * 60_000)).toBe('5m')
+    expect(formatDuration(2 * 3_600_000 + 14 * 60_000)).toBe('2h 14m')
+    expect(formatDuration(3 * 86_400_000 + 4 * 3_600_000)).toBe('3d 4h')
+  })
+})
+
+describe('computeHousekeeping', () => {
+  const NOW = Date.now()
+  it('finds the oldest waiting attention item', () => {
+    const hk = computeHousekeeping(
+      [],
+      [
+        event('waitingForApproval', { createdAt: NOW - 10 * 60_000, displayName: 'recent' }),
+        event('waitingForInput', { createdAt: NOW - 30 * 60_000, displayName: 'old' })
+      ],
+      30,
+      NOW
+    )
+    expect(Math.round((hk.oldestWaitingMs ?? 0) / 60_000)).toBe(30)
+    expect(hk.oldestWaitingLabel).toContain('old')
+  })
+
+  it('ignores suppressed and finished events for oldest-waiting', () => {
+    const hk = computeHousekeeping(
+      [],
+      [
+        event('finished', { createdAt: NOW - 60 * 60_000 }),
+        event('waitingForApproval', { createdAt: NOW - 5 * 60_000, suppressed: true })
+      ],
+      30,
+      NOW
+    )
+    expect(hk.oldestWaitingMs).toBeNull()
+  })
+
+  it('counts idle sessions inactive beyond the threshold', () => {
+    const fresh = session({ status: 'idle', lastActivityTime: NOW - 5 * 60_000 })
+    const stale = session({ status: 'idle', lastActivityTime: NOW - 45 * 60_000 })
+    const active = session({ status: 'active', lastActivityTime: NOW - 90 * 60_000 })
+    const hk = computeHousekeeping([fresh, stale, active], [], 30, NOW)
+    expect(hk.staleCount).toBe(1)
+  })
+
+  it('reports the longest-running active session', () => {
+    const a = session({
+      status: 'active',
+      createdAt: new Date(NOW - 30 * 60_000),
+      displayName: 'short'
+    })
+    const b = session({
+      status: 'active',
+      createdAt: new Date(NOW - 2 * 3_600_000),
+      displayName: 'long'
+    })
+    const hk = computeHousekeeping([a, b], [], 30, NOW)
+    expect(hk.longestActiveName).toBe('long')
+    expect(Math.round((hk.longestActiveMs ?? 0) / 3_600_000)).toBe(2)
+  })
+})
+
+describe('pctDelta / average', () => {
+  it('computes percentage change and guards a zero baseline', () => {
+    expect(pctDelta(120, 100)).toBe(20)
+    expect(pctDelta(80, 100)).toBe(-20)
+    expect(pctDelta(5, 0)).toBeNull()
+  })
+  it('averages to one decimal and guards divide-by-zero', () => {
+    expect(average(24, 10)).toBe(2.4)
+    expect(average(5, 0)).toBe(0)
+  })
+})
+
+describe('activeStreak', () => {
+  it('counts consecutive trailing active days', () => {
+    expect(activeStreak([{ total: 1 }, { total: 0 }, { total: 2 }, { total: 3 }])).toBe(2)
+  })
+  it("doesn't let an empty final day (today) break the streak", () => {
+    expect(activeStreak([{ total: 2 }, { total: 3 }, { total: 0 }])).toBe(2)
+  })
+  it('returns 0 when the most recent days are empty', () => {
+    expect(activeStreak([{ total: 1 }, { total: 0 }, { total: 0 }])).toBe(0)
+  })
+})
+
+describe('busiestSlot', () => {
+  it('finds the busiest weekday and hour', () => {
+    const cells = [
+      { weekday: 2, hour: 15, count: 10 },
+      { weekday: 2, hour: 16, count: 4 },
+      { weekday: 0, hour: 9, count: 1 }
+    ]
+    expect(busiestSlot(cells)).toEqual({ weekday: 2, hour: 15 })
+  })
+  it('returns null when empty', () => {
+    expect(busiestSlot([{ weekday: 0, hour: 0, count: 0 }])).toBeNull()
+  })
+})
+
+describe('providerShares', () => {
+  it('computes integer percentages, largest first', () => {
+    const out = providerShares([
+      { providerId: 'claude-code', sessions: 1 },
+      { providerId: 'copilot-cli', sessions: 3 }
+    ])
+    expect(out[0]).toEqual({ providerId: 'copilot-cli', sessions: 3, pct: 75 })
+    expect(out[1].pct).toBe(25)
+  })
+})
+
+describe('weekdayName', () => {
+  it('maps Monday-first indices', () => {
+    expect(weekdayName(0)).toBe('Monday')
+    expect(weekdayName(6)).toBe('Sunday')
+  })
+})

--- a/tests/unit/dashboard-tab.test.ts
+++ b/tests/unit/dashboard-tab.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Unit tests for the Overview Dashboard tab in `terminalStore`:
+ * the singleton open/focus invariant and workspace serialization.
+ *
+ * Runs in node env with a stubbed `window.dplex` (some actions persist the
+ * workspace via the debounced saver).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  useTerminalStore,
+  _serializeWorkspaceForTests
+} from '../../src/renderer/src/stores/terminalStore'
+import { isDashboardTab } from '../../src/renderer/src/types'
+
+function setupWindow(): void {
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: {
+      sessions: {
+        saveWorkspace: vi.fn().mockResolvedValue(undefined),
+        saveWorkspaceSync: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined)
+      },
+      pty: { destroy: vi.fn() }
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}
+
+beforeEach(() => {
+  setupWindow()
+  useTerminalStore.setState({
+    groups: [],
+    layout: { type: 'group', groupId: '' },
+    activeGroupId: null,
+    restored: false
+  } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function allTabs(): { kind?: string; id: string }[] {
+  return useTerminalStore.getState().groups.flatMap((g) => g.tabs)
+}
+
+describe('openOrFocusDashboardTab', () => {
+  it('creates a single dashboard tab when none exists', () => {
+    const id = useTerminalStore.getState().openOrFocusDashboardTab()
+    const dashboards = allTabs().filter((t) => t.kind === 'dashboard')
+    expect(dashboards).toHaveLength(1)
+    expect(dashboards[0].id).toBe(id)
+  })
+
+  it('focuses the existing dashboard instead of creating a second one', () => {
+    const first = useTerminalStore.getState().openOrFocusDashboardTab()
+    const second = useTerminalStore.getState().openOrFocusDashboardTab()
+    expect(second).toBe(first)
+    expect(allTabs().filter((t) => t.kind === 'dashboard')).toHaveLength(1)
+  })
+
+  it('activates the group and tab that hosts the dashboard', () => {
+    const id = useTerminalStore.getState().openOrFocusDashboardTab()
+    const state = useTerminalStore.getState()
+    const group = state.groups.find((g) => g.id === state.activeGroupId)
+    expect(group?.activeTabId).toBe(id)
+  })
+
+  it('persists the dashboard tab in the serialized workspace', () => {
+    useTerminalStore.getState().openOrFocusDashboardTab()
+    const data = _serializeWorkspaceForTests() as {
+      groups: { tabs: { kind?: string }[] }[]
+    }
+    const persisted = data.groups.flatMap((g) => g.tabs).filter((t) => t.kind === 'dashboard')
+    expect(persisted).toHaveLength(1)
+  })
+
+  it('produces tabs the isDashboardTab guard recognizes', () => {
+    useTerminalStore.getState().openOrFocusDashboardTab()
+    const tab = useTerminalStore.getState().groups[0].tabs[0]
+    expect(isDashboardTab(tab)).toBe(true)
+  })
+})

--- a/tests/unit/tab-focus.test.ts
+++ b/tests/unit/tab-focus.test.ts
@@ -44,6 +44,12 @@ describe('tabMatchesFocus', () => {
     expect(tabMatchesFocus(term('t', '/tmp/scratch'), projects, 'alpha')).toBe(false)
     expect(tabMatchesFocus(term('t', undefined), projects, 'alpha')).toBe(false)
   })
+
+  it('always matches the project-agnostic dashboard tab, even under isolate', () => {
+    const dashboard = { id: 'd', title: 'Dashboard', kind: 'dashboard' as const }
+    expect(tabMatchesFocus(dashboard, projects, 'alpha')).toBe(true)
+    expect(tabMatchesFocus(dashboard, projects, null)).toBe(true)
+  })
 })
 
 describe('pruneLayoutToGroups', () => {


### PR DESCRIPTION
## Overview

Adds a first-class **Dashboard** tab that answers, at a glance: what's running, what needs you, where you work, and how much you get done. Opened from a new activity-bar button or the command palette.

All metrics are derived from data DPlex already has — session events, the attention inbox, git status, and the Copilot Chronicle / Claude session files. No new telemetry.

## What's included

**Live (real-time from the session/attention stores — no polling):**
- KPIs: **Active now**, **Needs you**, **Sessions today**
- **Status donut**, **attention feed**, **recent sessions** table
- **Housekeeping**: oldest request awaiting you, stale (idle-too-long) sessions, longest-running active session, uncommitted changes across repos
- **Drill-down**: clicking a KPI reveals the Sessions sidebar filtered to the relevant status; clicking a repo or session opens/resumes it

**Historical (new `dashboard:getMetrics` IPC → `ProviderRegistry.getSessionHistory`; Copilot via the Chronicle DB, Claude via a cheap JSONL scan):**
- Activity-over-time chart, top repositories, work-time heatmap, provider mix, active-day streak, and a period-over-period prompts delta
- Refreshed on tab open / debounced session add-remove invalidation / manual refresh — **never polled**, with a dirty-while-hidden guard so updates aren't dropped while the tab is inactive

## Implementation notes
- New `'dashboard'` editor tab kind (singleton open/focus, persisted and restored with the workspace)
- Inline **SVG/CSS** charts (no new dependencies) with instant cursor tooltips
- Responsive via **Tailwind container queries** — the layout adapts to the pane width, not the window, so it degrades gracefully in split views / with the sidebar open
- DST-safe day bucketing; windowed Chronicle turn counts; bounded, on-demand uncommitted-changes fan-out

## Testing
- **Unit**: aggregator (windowing, DST, previous-window deltas), live metric/housekeeping helpers, and the singleton tab serialize/restore — `npm run test:unit` green (604 passed)
- **E2E**: `tests/e2e/dashboard.e2e.spec.ts` — opens/focuses the tab, window selector, and KPI → filtered-sidebar drill-down
- `npm run typecheck`, `npm run build`, and lint all clean on the new code

## Review
Two rounds of dual-model code review (Claude Opus 4.7 + GPT-5.5); all genuine findings fixed — including the KPI→sidebar filter hand-off (now via store state, robust to mount timing), stale-window guard on the historical snapshot, and windowing the Chronicle turn-count query.

## Versioning
Bumps to **0.28.0** (MINOR — new user-visible feature) with a customer-facing `CHANGELOG.md` entry and compare links.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
