### PR TITLE
ci: link release notes to each release's own assets (not /latest)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -188,14 +188,20 @@ jobs:
               printf '## ✨ What'\''s New\n\n%s\n\n---\n\n' "$CHANGELOG_SECTION"
             fi
             printf '%s\n\n---\n\n' "$GENERATED"
+            # Link to THIS release's own assets (tag-specific), not
+            # /releases/latest/download — otherwise every release body
+            # (including prereleases and older versions) points at whatever
+            # is currently "latest", so an RC would hand testers the stable
+            # build and old releases could never be downloaded from their own
+            # page. `$TAG` is this release's tag (github.ref_name).
             printf '## 📦 Downloads\n\n'
             printf '| Platform | Download |\n'
             printf '| -------- | -------- |\n'
-            printf '| macOS (Apple Silicon) | [DPlex-arm64.dmg](https://github.com/%s/releases/latest/download/DPlex-arm64.dmg) |\n' "$GITHUB_REPOSITORY"
-            printf '| macOS (Intel) | [DPlex-x64.dmg](https://github.com/%s/releases/latest/download/DPlex-x64.dmg) |\n' "$GITHUB_REPOSITORY"
-            printf '| Windows | [DPlex-Setup.exe](https://github.com/%s/releases/latest/download/DPlex-Setup.exe) |\n' "$GITHUB_REPOSITORY"
-            printf '| Linux (AppImage) | [DPlex.AppImage](https://github.com/%s/releases/latest/download/DPlex.AppImage) |\n' "$GITHUB_REPOSITORY"
-            printf '| Linux (Debian) | [DPlex-amd64.deb](https://github.com/%s/releases/latest/download/DPlex-amd64.deb) |\n\n' "$GITHUB_REPOSITORY"
+            printf '| macOS (Apple Silicon) | [DPlex-arm64.dmg](https://github.com/%s/releases/download/%s/DPlex-arm64.dmg) |\n' "$GITHUB_REPOSITORY" "$TAG"
+            printf '| macOS (Intel) | [DPlex-x64.dmg](https://github.com/%s/releases/download/%s/DPlex-x64.dmg) |\n' "$GITHUB_REPOSITORY" "$TAG"
+            printf '| Windows | [DPlex-Setup.exe](https://github.com/%s/releases/download/%s/DPlex-Setup.exe) |\n' "$GITHUB_REPOSITORY" "$TAG"
+            printf '| Linux (AppImage) | [DPlex.AppImage](https://github.com/%s/releases/download/%s/DPlex.AppImage) |\n' "$GITHUB_REPOSITORY" "$TAG"
+            printf '| Linux (Debian) | [DPlex-amd64.deb](https://github.com/%s/releases/download/%s/DPlex-amd64.deb) |\n\n' "$GITHUB_REPOSITORY" "$TAG"
             printf '> Builds are currently unsigned — verify the SHA-256 from this page if you want extra confidence. macOS builds are ad-hoc codesigned; you may still need `xattr -dr com.apple.quarantine /Applications/DPlex.app` on first launch.\n'
           } > /tmp/release-body.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- Each release's download links now point to that release's own installers, so you always get the exact version you're viewing — including older releases and pre-release/test builds — instead of always being redirected to the latest stable build.
+
 ## [0.28.0] — 2026-06-23
 
 ### Features


### PR DESCRIPTION
Fixes a long-standing issue where **every release page's download table linked to `/releases/latest/download/<asset>`** instead of the assets belonging to that release.

### Problem
- Older releases' pages served the **current latest** binary, so there was no way to download a specific older version from its own page.
- A **prerelease / RC** page handed testers the **stable** build — or 404'd — defeating the purpose of a test build. (Hit live while cutting `v0.28.1-rc.1` for #86: the RC body pointed at `latest/download`, i.e. `0.28.0`.)

### Fix
Switch the release-notes downloads table to the **tag-specific** form `/releases/download/<tag>/<asset>` (`$TAG` = `github.ref_name`), so each release links to its own installers.

### Scope / deliberately unchanged
- `README.md` and `site/index.html` install commands intentionally keep `/releases/latest/download/...` — those are "get the newest" links for new users and should always track latest.

### Validation
- Tag-specific URL pattern confirmed live: `releases/download/v0.28.0/DPlex-Setup.exe` → **HTTP 200**.
- `release.yml` parses as valid YAML; `printf` args verified (`%s` → repo, `%s` → tag).
- Grepped all `latest/download` usages — only README / landing-page (intentional) remain; the per-release notes table is the only thing changed.

### Note: version bump
This is a CI-only change. I deliberately did **not** bump `package.json` to avoid a collision with PR #96 (which already claims `0.28.1`). Bump at merge time per release order (e.g. `0.28.2` if this lands after #96). Changelog entry added under `[Unreleased]`.