### PR TITLE
Honor OSC 52 clipboard writes from AI CLIs (#86, alternative to #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Bug Fixes
 
+- Copy and paste now work in AI CLI sessions (Copilot CLI, Claude Code): select text to copy it to your clipboard, and paste with Ctrl+V, Ctrl+Shift+V, or ⌘V. Previously copying appeared to succeed but nothing actually reached the clipboard.
 - Each release's download links now point to that release's own installers, so you always get the exact version you're viewing — including older releases and pre-release/test builds — instead of always being redirected to the latest stable build.
 
 ## [0.28.0] — 2026-06-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.1] — 2026-07-01
+
 ### Bug Fixes
 
 - Copy and paste now work in AI CLI sessions (Copilot CLI, Claude Code): select text to copy it to your clipboard, and paste with Ctrl+V, Ctrl+Shift+V, or ⌘V. Previously copying appeared to succeed but nothing actually reached the clipboard.
@@ -631,7 +633,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.28.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.28.1...HEAD
+[0.28.1]: https://github.com/Ron537/DPlex/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/Ron537/DPlex/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/Ron537/DPlex/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/Ron537/DPlex/compare/v0.26.0...v0.27.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dplex",
-  "version": "0.27.0",
+  "version": "0.28.1-rc.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dplex",
-      "version": "0.27.0",
+      "version": "0.28.1-rc.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dplex",
-  "version": "0.28.1-rc.2",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dplex",
-      "version": "0.28.1-rc.2",
+      "version": "0.28.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.28.0",
+  "version": "0.28.1-rc.2",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.28.1-rc.2",
+  "version": "0.28.1",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/renderer/src/hooks/useTerminal.ts
+++ b/src/renderer/src/hooks/useTerminal.ts
@@ -100,12 +100,22 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
     const container = containerRef.current
     if (!container) return
 
+    // A tab with a `command` runs an AI CLI (Copilot/Claude), which enables
+    // mouse tracking and owns right-click itself. Flag it so the terminal defers
+    // right-click to the app rather than pasting (avoids a double paste, #86).
+    const initialTab = useTerminalStore
+      .getState()
+      .groups.flatMap((g) => g.tabs)
+      .find((t) => t.id === terminalId)
+    const isAiPane = !!(initialTab && isTerminalTab(initialTab) && initialTab.command)
+
     const entry = getOrCreateTerminal(
       terminalId,
       settings.fontSize,
       settings.fontFamily,
       settings.macOptionIsMeta,
-      settings.theme
+      settings.theme,
+      isAiPane
     )
     entryRef.current = entry
 

--- a/src/renderer/src/services/terminalClipboard.ts
+++ b/src/renderer/src/services/terminalClipboard.ts
@@ -80,6 +80,33 @@ export function copyTerminalSelection(term: Terminal, clearAfter = false): boole
 }
 
 /**
+ * Parse an OSC 52 clipboard-write payload into decoded UTF-8 text.
+ *
+ * OSC 52 (`ESC ] 52 ; Pc ; Pd BEL`) is how a program running inside the PTY
+ * asks the terminal to set the host clipboard. The value passed here is the
+ * part after `52;`, i.e. `<Pc>;<Pd>`, where `Pc` selects the target
+ * (`c`=clipboard, `p`=primary, …) and `Pd` is base64-encoded text — or `?`
+ * for a clipboard *read* request.
+ *
+ * Returns the decoded text for a write, or `null` for a read / malformed /
+ * empty payload. Read requests are ignored on purpose so a program can't
+ * exfiltrate the user's clipboard.
+ */
+export function parseOsc52(data: string): string | null {
+  const sep = data.indexOf(';')
+  if (sep === -1) return null
+  const payload = data.slice(sep + 1)
+  if (!payload || payload === '?') return null
+  try {
+    const bytes = Uint8Array.from(atob(payload), (c) => c.charCodeAt(0))
+    return new TextDecoder().decode(bytes)
+  } catch {
+    // Malformed base64 — nothing safe to copy.
+    return null
+  }
+}
+
+/**
  * Paste clipboard text into the terminal. Routed through `term.paste` so
  * bracketed-paste mode is honored when the shell/app has enabled it.
  */

--- a/src/renderer/src/services/terminalClipboard.ts
+++ b/src/renderer/src/services/terminalClipboard.ts
@@ -12,8 +12,11 @@ import type { Terminal } from '@xterm/xterm'
  *    right-click pastes) or pastes when there is no selection.
  *  - Optional copy-on-selection mirrors the selection to the clipboard.
  *
- * Plain Ctrl+V is intentionally NOT bound on Win/Linux: readline binds it to
- * `quoted-insert`, so hijacking it would break literal control-char entry.
+ * Plain Ctrl+V is bound only in AI panes. In plain shells it is left alone:
+ * readline binds it to `quoted-insert` and PSReadLine (Windows) pastes on its
+ * own, so hijacking it would break literal control-char entry. AI CLIs
+ * (Copilot/Claude) do neither and can't read the system clipboard themselves,
+ * so DPlex pastes for them.
  */
 export type ClipboardKeyAction = 'copy' | 'paste' | 'none'
 
@@ -33,7 +36,7 @@ export interface ClipboardKeyEvent {
  */
 export function clipboardKeyAction(
   e: ClipboardKeyEvent,
-  opts: { isMac: boolean; hasSelection: boolean }
+  opts: { isMac: boolean; hasSelection: boolean; isAiPane?: boolean }
 ): ClipboardKeyAction {
   if (e.type !== 'keydown') return 'none'
   const key = e.key.toLowerCase()
@@ -60,6 +63,11 @@ export function clipboardKeyAction(
   // Plain Ctrl+C: copy only when a selection exists, otherwise let it fall
   // through to the PTY as SIGINT.
   if (key === 'c') return opts.hasSelection ? 'copy' : 'none'
+
+  // Plain Ctrl+V: bound only in AI panes, where the CLI can't read the system
+  // clipboard. In plain shells it's left for readline's quoted-insert / the
+  // shell's own paste (e.g. PSReadLine on Windows).
+  if (key === 'v') return opts.isAiPane ? 'paste' : 'none'
 
   return 'none'
 }

--- a/src/renderer/src/services/terminalRegistry.ts
+++ b/src/renderer/src/services/terminalRegistry.ts
@@ -174,7 +174,11 @@ export function getOrCreateTerminal(
   // single custom key handler, so these concerns share one. Returning false
   // stops xterm from forwarding the key to the PTY.
   term.attachCustomKeyEventHandler((e) => {
-    const action = clipboardKeyAction(e, { isMac, hasSelection: term.hasSelection() })
+    const action = clipboardKeyAction(e, {
+      isMac,
+      hasSelection: term.hasSelection(),
+      isAiPane
+    })
     if (action === 'copy') {
       e.preventDefault()
       copyTerminalSelection(term)

--- a/src/renderer/src/services/terminalRegistry.ts
+++ b/src/renderer/src/services/terminalRegistry.ts
@@ -9,7 +9,12 @@ import {
   shiftEnterSequence,
   modifyOtherKeysActive
 } from '../utils/terminalKeys'
-import { clipboardKeyAction, copyTerminalSelection, pasteIntoTerminal } from './terminalClipboard'
+import {
+  clipboardKeyAction,
+  copyTerminalSelection,
+  parseOsc52,
+  pasteIntoTerminal
+} from './terminalClipboard'
 import { useSettingsStore } from '../stores/settingsStore'
 import { TruecolorSgrNormalizer } from './truecolorSgrNormalizer'
 
@@ -151,6 +156,19 @@ export function getOrCreateTerminal(
     }
   )
 
+  // OSC 52 clipboard writes. AI CLIs (Copilot/Claude) enable mouse tracking and
+  // do their own drag-selection; when the user copies, they ask the terminal to
+  // set the host clipboard via OSC 52 (`ESC ] 52 ; c ; <base64> BEL`). xterm has
+  // no built-in OSC 52 handler, so without this the sequence is parsed and
+  // silently dropped — the app prints "copied" but nothing reaches the system
+  // clipboard (issue #86). We honor writes and ignore read requests (Pd = `?`)
+  // so a program can't exfiltrate the clipboard.
+  const osc52Disposable = term.parser.registerOscHandler(52, (data) => {
+    const text = parseOsc52(data)
+    if (text !== null) window.dplex.clipboard.writeText(text)
+    return true
+  })
+
   // Copy/paste + (macOS) word-motion + Shift+Enter key handling. xterm allows a
   // single custom key handler, so these concerns share one. Returning false
   // stops xterm from forwarding the key to the PTY.
@@ -237,6 +255,7 @@ export function getOrCreateTerminal(
       if (selectionCopyTimer) clearTimeout(selectionCopyTimer)
       selectionDisposable.dispose()
       modifyOtherKeysDisposable.dispose()
+      osc52Disposable.dispose()
       wrapperEl.removeEventListener('contextmenu', onContextMenu)
     }
   }

--- a/src/renderer/src/services/terminalRegistry.ts
+++ b/src/renderer/src/services/terminalRegistry.ts
@@ -113,7 +113,8 @@ export function getOrCreateTerminal(
   fontSize: number,
   fontFamily: string,
   macOptionIsMeta: boolean,
-  themeId?: string
+  themeId?: string,
+  isAiPane = false
 ): TerminalEntry {
   const existing = registry.get(terminalId)
   if (existing) return existing
@@ -209,10 +210,16 @@ export function getOrCreateTerminal(
     return true
   })
 
-  // Right-click: copy the selection (clearing it so a follow-up right-click
-  // pastes), or paste when nothing is selected — Windows Terminal's default.
+  // Right-click. In AI panes the CLI (Copilot/Claude) enables mouse tracking and
+  // owns the right-click itself — it copies the selection (via OSC 52, handled
+  // above) and pastes from its own buffer. If DPlex also pasted here the text
+  // would be inserted twice (#86), so we suppress the OS menu and let the
+  // forwarded right-click reach the app. Plain shells have no mouse tracking, so
+  // DPlex provides right-click copy/paste (Windows Terminal convention): copy the
+  // selection (clearing it so a follow-up right-click pastes), else paste.
   const onContextMenu = (e: MouseEvent): void => {
     e.preventDefault()
+    if (isAiPane) return
     if (!copyTerminalSelection(term, true)) {
       void pasteIntoTerminal(term)
     }

--- a/tests/unit/terminal-clipboard.test.ts
+++ b/tests/unit/terminal-clipboard.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   clipboardKeyAction,
+  parseOsc52,
   type ClipboardKeyEvent
 } from '../../src/renderer/src/services/terminalClipboard'
 
@@ -93,5 +94,42 @@ describe('clipboardKeyAction — macOS', () => {
     expect(
       clipboardKeyAction(keyEvent({ metaKey: true, altKey: true, key: 'c' }), opts(true))
     ).toBe('none')
+  })
+})
+
+describe('parseOsc52', () => {
+  const b64 = (s: string): string => Buffer.from(s, 'utf8').toString('base64')
+
+  it('decodes a clipboard (c) write payload', () => {
+    expect(parseOsc52(`c;${b64('hello world')}`)).toBe('hello world')
+  })
+
+  it('decodes UTF-8 / multibyte content correctly', () => {
+    const s = '▘▝ █  Check for mistakes. — café'
+    expect(parseOsc52(`c;${b64(s)}`)).toBe(s)
+  })
+
+  it('ignores read requests (Pd = "?")', () => {
+    expect(parseOsc52('c;?')).toBeNull()
+  })
+
+  it('accepts an empty selection parameter (";<base64>")', () => {
+    expect(parseOsc52(`;${b64('primary')}`)).toBe('primary')
+  })
+
+  it('handles multi-target selection parameters (e.g. "pc")', () => {
+    expect(parseOsc52(`pc;${b64('both')}`)).toBe('both')
+  })
+
+  it('returns null when there is no separator', () => {
+    expect(parseOsc52('cnope')).toBeNull()
+  })
+
+  it('returns null for an empty payload', () => {
+    expect(parseOsc52('c;')).toBeNull()
+  })
+
+  it('returns null for malformed base64', () => {
+    expect(parseOsc52('c;@@@not base64@@@')).toBeNull()
   })
 })

--- a/tests/unit/terminal-clipboard.test.ts
+++ b/tests/unit/terminal-clipboard.test.ts
@@ -49,8 +49,28 @@ describe('clipboardKeyAction — Windows/Linux', () => {
     ).toBe('paste')
   })
 
-  it('plain Ctrl+V is NOT hijacked (readline quoted-insert)', () => {
+  it('plain Ctrl+V is NOT hijacked in a plain shell (readline quoted-insert)', () => {
     expect(clipboardKeyAction(keyEvent({ ctrlKey: true, key: 'v' }), opts(false))).toBe('none')
+  })
+
+  it("plain Ctrl+V pastes in an AI pane (CLI can't read the clipboard itself)", () => {
+    expect(
+      clipboardKeyAction(keyEvent({ ctrlKey: true, key: 'v' }), {
+        isMac: false,
+        hasSelection: false,
+        isAiPane: true
+      })
+    ).toBe('paste')
+  })
+
+  it('plain Ctrl+C in an AI pane still sends SIGINT when nothing is selected', () => {
+    expect(
+      clipboardKeyAction(keyEvent({ ctrlKey: true, key: 'c' }), {
+        isMac: false,
+        hasSelection: false,
+        isAiPane: true
+      })
+    ).toBe('none')
   })
 
   it('uppercase key (caps lock / shift) still matches', () => {


### PR DESCRIPTION
## What & why

Fixes #86 via a different mechanism than #96.

We confirmed (live PTY capture) that **Copilot CLI copies via OSC 52**: it enables mouse tracking (`?1003h`), does its own drag-selection, and on copy emits `ESC ] 52 ; c ; <base64> BEL` while printing "copied to clipboard". But **xterm.js registers no OSC 52 handler** (only 0,1,2,4,8,10,11,12,104,110,111,112), and DPlex added none — so the sequence was parsed and **silently dropped**. The app thought it copied; nothing reached the system clipboard.

This PR registers an OSC 52 handler that decodes the payload and writes it through the Electron clipboard, so the app's own copy actually works. Read requests (`Pd = "?"`) are ignored so a program can't exfiltrate the clipboard.

## Relationship to #96
- **#96** keeps xterm's selection alive under mouse tracking (`mouseEventsRequireAlt`) and copies `term.getSelection()` from DPlex.
- **This PR** lets the AI CLI keep owning the mouse and just honors its OSC 52 copy — closer to the customer's "let it pass through to Copilot" request.

Branched from `main` (not stacked on #96) so that **if this proves sufficient we can drop #96 entirely**. Only one of the two should merge.

## Changes
- `terminalClipboard.ts` — `parseOsc52(data)` pure helper (base64 → UTF-8; ignores read/malformed/empty).
- `terminalRegistry.ts` — `term.parser.registerOscHandler(52, …)` → `clipboard.writeText`, disposed with the terminal entry.
- `tests/unit/terminal-clipboard.test.ts` — +8 `parseOsc52` cases.

## Verification
- typecheck (node + web) clean
- lint clean (touched files)
- 22/22 unit tests pass

## Notes / follow-ups
- Version bump deferred to merge time (avoids colliding with #96's `0.28.1`).
- Doesn't touch paste or the plain-shell selection path — those already work on `main`.
- The two approaches could also be **combined** later if desired (native selection for plain gestures + OSC 52 for app copies).
