### PR TITLE
Tab colors, project colors, and projects-panel polish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.29.0] — 2026-07-09
+
+### Features
+
+- Give any tab its own color: right-click a tab and pick a color (or clear it). The whole tab is tinted with the color — even when it's not the active one — and the active tab's breadcrumb header (project · path) and content area pick up a subtle matching tint (which you can turn off in Settings → Appearance if you prefer the tint on the tab only). Your choices are remembered across restarts. The right-click menu also offers quick Rename and Close.
+- Set a color for a whole project: right-click a project in the sidebar and pick a "Tab color" to tint every one of that project's tabs (across its worktrees too) and its avatar. Project avatars are now neutral grey by default and take on the color you choose, so color in the sidebar always means something you picked. Individual tabs can still override, and the choice is remembered across restarts.
+
+### Improvements
+
+- The theme picker in Settings → Appearance is now more compact, so the other appearance options are visible without scrolling.
+- Idle, resumable sessions inside a project are now tucked into a collapsible "Idle · N resumable" row that's closed by default, so a project's live sessions stay front and centre. Click it to reveal (and resume) older sessions when you want them.
+
 ## [0.28.1] — 2026-07-01
 
 ### Bug Fixes
@@ -633,7 +645,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.28.1...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.29.0...HEAD
+[0.29.0]: https://github.com/Ron537/DPlex/compare/v0.28.1...v0.29.0
 [0.28.1]: https://github.com/Ron537/DPlex/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/Ron537/DPlex/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/Ron537/DPlex/compare/v0.27.0...v0.27.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dplex",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dplex",
-      "version": "0.28.1",
+      "version": "0.29.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.28.1",
+  "version": "0.29.0",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/renderer/src/components/attention/AttentionBellButton.tsx
+++ b/src/renderer/src/components/attention/AttentionBellButton.tsx
@@ -8,6 +8,7 @@ import { focusSessionTab } from '../../utils/sessionTabs'
 import { ProjectAvatar } from '../projects/ProjectAvatar'
 import { decideRowClickAction } from './rowClickAction'
 import { normalizePath } from '../../utils/normalizePath'
+import { colorSourceProject } from '../../utils/tabProject'
 import type { AttentionEvent, AttentionKind } from '../../../../preload/attentionTypes'
 
 const KIND_LABEL: Record<AttentionKind, string> = {
@@ -78,21 +79,28 @@ export function AttentionBellButton(): React.JSX.Element {
    * on disk but the prefix check would only succeed for slashes), and
    * the avatar would always fall back to the initial-letter placeholder.
    * Mirrors the same approach used by `findProjectForTab`. */
-  const resolveProject = (event: AttentionEvent): { id: string; name: string } | undefined => {
+  const resolveProject = (
+    event: AttentionEvent
+  ): { id: string; name: string; tabColor?: string } | undefined => {
     const session = sessions.find((s) => s.id === event.sessionId && s.aiTool === event.providerId)
     const cwd = session?.cwd
     if (!cwd) return undefined
     const normCwd = normalizePath(cwd)
-    let best: { id: string; name: string; len: number } | undefined
+    let best: { id: string; name: string; tabColor?: string; len: number } | undefined
     for (const p of projects) {
       const normProject = normalizePath(p.path)
       if (normCwd === normProject || normCwd.startsWith(normProject + '/')) {
         if (!best || normProject.length > best.len) {
-          best = { id: p.id, name: p.name, len: normProject.length }
+          best = {
+            id: p.id,
+            name: p.name,
+            tabColor: colorSourceProject(p, projects).tabColor,
+            len: normProject.length
+          }
         }
       }
     }
-    return best ? { id: best.id, name: best.name } : undefined
+    return best ? { id: best.id, name: best.name, tabColor: best.tabColor } : undefined
   }
 
   const handleRowClick = (event: AttentionEvent): void => {
@@ -279,7 +287,7 @@ export function AttentionBellButton(): React.JSX.Element {
                         onClick={() => handleRowClick(e)}
                       >
                         {project ? (
-                          <ProjectAvatar projectId={project.id} name={project.name} size={28} />
+                          <ProjectAvatar color={project.tabColor} name={project.name} size={28} />
                         ) : (
                           <span
                             aria-hidden

--- a/src/renderer/src/components/projects/ProjectAvatar.tsx
+++ b/src/renderer/src/components/projects/ProjectAvatar.tsx
@@ -1,9 +1,9 @@
 import { memo } from 'react'
-import { getAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
+import { deriveAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
 
 interface ProjectAvatarProps {
-  /** Stable id used to derive the deterministic avatar color. */
-  projectId: string
+  /** The project's chosen tab color (hex), if any. Absent → neutral grey. */
+  color?: string
   /** Project name used to derive the 1-2 letter glyph. */
   name: string
   /** Square size in px. Defaults to 22 — the size used in the command palette. */
@@ -11,17 +11,18 @@ interface ProjectAvatarProps {
 }
 
 /**
- * Small square project avatar — deterministic color + initials glyph derived
- * from the project's id/name. Used in surfaces that aren't `ProjectItem`
- * (e.g. the command palette) so they share the same visual identity as the
+ * Small square project avatar — neutral grey by default, tinted with the
+ * project's chosen tab color when one is set. The glyph is the project's
+ * 1-2 letter initials. Used in surfaces that aren't `ProjectItem` (e.g. the
+ * command palette, tab header) so they share the same visual identity as the
  * sidebar without duplicating the styling logic.
  */
 export const ProjectAvatar = memo(function ProjectAvatar({
-  projectId,
+  color: tabColor,
   name,
   size = 22
 }: ProjectAvatarProps): React.JSX.Element {
-  const color = getAvatarColor(projectId)
+  const color = deriveAvatarColor(tabColor)
   const initials = getAvatarInitials(name)
   return (
     <span

--- a/src/renderer/src/components/projects/ProjectAvatarButton.tsx
+++ b/src/renderer/src/components/projects/ProjectAvatarButton.tsx
@@ -1,7 +1,7 @@
 import { memo, useCallback, useEffect, useState } from 'react'
 import { useProjectStore } from '../../stores/projectStore'
 import { useSettingsStore } from '../../stores/settingsStore'
-import { getAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
+import { deriveAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
 import { focusFirstTabForPaths } from '../../utils/sessionTabs'
 import { STATUS_ACTIVE_COLOR } from '../../utils/statusColors'
 import { aggregateVisual } from '../../utils/aggregateVisual'
@@ -75,7 +75,7 @@ export const ProjectAvatarButton = memo(function ProjectAvatarButton({
       s.status === 'active' &&
       (s.detailedStatus === 'thinking' || s.detailedStatus === 'executingTool')
   )
-  const color = getAvatarColor(project.id)
+  const color = deriveAvatarColor(project.tabColor)
   const initials = getAvatarInitials(project.name)
   const attentionCount = attentionEvents.length
 
@@ -163,9 +163,7 @@ export const ProjectAvatarButton = memo(function ProjectAvatarButton({
           // tinted border (same hue as bg) so the silhouette stays
           // visible even on themes where the soft fill is invisible.
           border: `1.5px solid ${
-            statusRevealed && attentionCount > 0
-              ? 'var(--dplex-status-approval)'
-              : color.border
+            statusRevealed && attentionCount > 0 ? 'var(--dplex-status-approval)' : color.border
           }`,
           transition: 'border-color 280ms ease, opacity 280ms ease',
           // Dim avatars for projects that are not "live" so the rail clearly

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -15,7 +15,8 @@ import {
   ArrowUp,
   ArrowDown,
   GitCompare,
-  Tag as TagIcon
+  Tag as TagIcon,
+  X
 } from 'lucide-react'
 import type { Project, AISession, ProviderInfo, WorktreeDefaults } from '../../types'
 import { useProjectStore } from '../../stores/projectStore'
@@ -25,7 +26,7 @@ import { useSettingsStore } from '../../stores/settingsStore'
 import { useGitBranch } from '../../hooks/useGitBranch'
 import { useWorktrees } from '../../hooks/useWorktrees'
 import { STATUS_ACTIVE_COLOR } from '../../utils/statusColors'
-import { getAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
+import { deriveAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
 import { isMixedProviderList } from '../../utils/providerHelpers'
 import { aggregateVisual } from '../../utils/aggregateVisual'
 import { PromptsDialog } from '../sessions/PromptsDialog'
@@ -35,6 +36,8 @@ import { TagPickerPopover } from './TagPickerPopover'
 import { WorktreeSection } from './WorktreeSection'
 import type { ProjectActivity } from '../../hooks/useProjectSessions'
 import { focusFirstTabForPaths } from '../../utils/sessionTabs'
+import { colorSourceProject } from '../../utils/tabProject'
+import { TAB_COLORS } from '../../utils/tabColors'
 import { PopoverMenu } from '../common/PopoverMenu'
 import { NewWorktreeModal } from '../worktrees/NewWorktreeModal'
 import { ManageWorktreesModal } from '../worktrees/ManageWorktreesModal'
@@ -95,6 +98,8 @@ export function ProjectItem({
   const removeProject = useProjectStore((s) => s.removeProject)
   const togglePin = useProjectStore((s) => s.togglePin)
   const reorderProject = useProjectStore((s) => s.reorderProject)
+  const setProjectTabColor = useProjectStore((s) => s.setProjectTabColor)
+  const allProjectsForColor = useProjectStore((s) => s.projects)
   const startAISession = useProjectStore((s) => s.startAISession)
   const setActiveGroup = useTerminalStore((s) => s.setActiveGroup)
   const setActiveTerminalInGroup = useTerminalStore((s) => s.setActiveTerminalInGroup)
@@ -157,7 +162,11 @@ export function ProjectItem({
   const isActive = isDirectlyActive || isAmbientActive
   const branch = useGitBranch(project.path)
   const { sessions, openTabs, activeCount, hasActive, lastActivity } = activity
-  const avatarColor = getAvatarColor(project.id)
+  // A worktree row shares its origin's color (see colorSourceProject); resolve
+  // it so the avatar, the picker's selected swatch, and writes all target the
+  // same project the tab-color resolution actually reads.
+  const colorSource = colorSourceProject(project, allProjectsForColor)
+  const avatarColor = deriveAvatarColor(colorSource.tabColor)
   const avatarInitials = getAvatarInitials(project.name)
   // Only top-level origin projects can be pinned. Worktree children ride with
   // their parent — pinning a child has no defined semantics.
@@ -614,6 +623,63 @@ export function ProjectItem({
             <TagIcon size={11} /> Tags…
           </button>
 
+          {/* Project-wide tab color — tints every tab of this project (main
+              checkout + worktrees). Individual tabs can override via their own
+              right-click menu. */}
+          <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+          <div
+            className="px-3 pt-0.5 pb-1 text-[10px] font-semibold uppercase"
+            style={{ color: 'var(--dplex-text-faint)', letterSpacing: '0.08em' }}
+          >
+            Tab color
+          </div>
+          <div className="flex items-center gap-1.5 px-3 pb-2">
+            {TAB_COLORS.map((c) => {
+              const selected = colorSource.tabColor === c.value
+              return (
+                <button
+                  key={c.id}
+                  type="button"
+                  title={c.label}
+                  aria-pressed={selected}
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    setProjectTabColor(colorSource.id, c.value)
+                    setShowMenu(false)
+                    setContextMenuPos(null)
+                  }}
+                  className="rounded-full transition-transform hover:scale-110"
+                  style={{
+                    width: 16,
+                    height: 16,
+                    backgroundColor: c.value,
+                    boxShadow: selected ? `0 0 0 2px var(--dplex-bg), 0 0 0 3px ${c.value}` : 'none'
+                  }}
+                />
+              )
+            })}
+            <button
+              type="button"
+              title="No color"
+              aria-label="Clear project tab color"
+              onClick={(e) => {
+                e.stopPropagation()
+                setProjectTabColor(colorSource.id, null)
+                setShowMenu(false)
+                setContextMenuPos(null)
+              }}
+              className="grid place-items-center rounded-full hover:bg-[var(--dplex-hover)]"
+              style={{
+                width: 16,
+                height: 16,
+                border: '1px solid var(--dplex-border-strong)',
+                color: 'var(--dplex-text-muted)'
+              }}
+            >
+              <X size={10} />
+            </button>
+          </div>
+
           {canPin && (
             <>
               <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
@@ -739,6 +805,7 @@ export function ProjectItem({
             </>
           ) : (
             <ProjectSessionList
+              scopeId={project.id}
               sessions={sessions}
               openTabs={openTabs}
               providers={providers}

--- a/src/renderer/src/components/projects/ProjectSessionList.tsx
+++ b/src/renderer/src/components/projects/ProjectSessionList.tsx
@@ -1,4 +1,5 @@
 import { useMemo, type JSX } from 'react'
+import { ChevronRight, ChevronDown } from 'lucide-react'
 import type { AISession, ProviderInfo } from '../../types'
 import { SessionItem } from '../sessions/SessionItem'
 import { PendingSessionItem } from '../sessions/PendingSessionItem'
@@ -7,6 +8,7 @@ import { RecentSessionRow } from '../sessions/RecentSessionRow'
 import { ExternalSessionsDivider } from '../sessions/ExternalSessionsDivider'
 import { pairTabsToSessions, type OpenTabWithGroup } from '../../utils/sessionPairing'
 import { useSettingsStore } from '../../stores/settingsStore'
+import { useProjectStore } from '../../stores/projectStore'
 
 /**
  * Mirrors the pairing rule in `pairTabsToSessions` so any session that a
@@ -37,6 +39,10 @@ export function selectRecentSessions(
 }
 
 interface ProjectSessionListProps {
+  /** Stable id for this session-list scope (a project id for plain projects,
+   *  or a worktree section id). Keys the collapsible "Idle · N resumable"
+   *  rollup's per-scope expansion state in the project store. */
+  scopeId: string
   /** Active AI sessions in this scope (a project or one of its worktrees). */
   sessions: AISession[]
   /** Open AI terminal tabs in this scope. */
@@ -77,6 +83,7 @@ interface ProjectSessionListProps {
  * an open tab above are excluded to avoid duplicate rows.
  */
 export function ProjectSessionList({
+  scopeId,
   sessions,
   openTabs,
   emptyMessage,
@@ -94,6 +101,11 @@ export function ProjectSessionList({
   const settingRecentCount = useSettingsStore((s) => s.settings.recentSessionsCount)
   const effectiveShowRecent = showRecent ?? settingShowRecent
   const effectiveLimit = recentLimit ?? settingRecentCount
+  // Idle sessions collapse into a "Idle · N resumable" rollup that is closed
+  // by default so idle work doesn't clutter the live rows. Expansion state is
+  // per-scope and ephemeral (see projectStore.expandedIdleSections).
+  const idleExpanded = useProjectStore((s) => s.expandedIdleSections.has(scopeId))
+  const toggleIdleSection = useProjectStore((s) => s.toggleIdleSection)
 
   const recentSessions = useMemo(
     () =>
@@ -184,9 +196,28 @@ export function ProjectSessionList({
               }}
             />
           )}
-          {recentSessions.map((session) => (
-            <RecentSessionRow key={`recent:${session.aiTool}:${session.id}`} session={session} />
-          ))}
+          {/* Collapsible "Idle · N resumable" rollup — closed by default so
+              idle sessions stay out of the way until the user asks for them. */}
+          <button
+            type="button"
+            onClick={() => toggleIdleSection(scopeId)}
+            aria-expanded={idleExpanded}
+            title={idleExpanded ? 'Hide resumable sessions' : 'Show resumable sessions'}
+            className="group flex items-center gap-1.5 w-full text-left px-3 py-[3px] mx-1 rounded-[5px] hover:bg-[var(--dplex-hover)] transition-colors"
+          >
+            {idleExpanded ? (
+              <ChevronDown size={11} style={{ color: 'var(--dplex-text-dim)', flexShrink: 0 }} />
+            ) : (
+              <ChevronRight size={11} style={{ color: 'var(--dplex-text-dim)', flexShrink: 0 }} />
+            )}
+            <span style={{ fontSize: 11, fontWeight: 500, color: 'var(--dplex-text-muted)' }}>
+              Idle · {recentSessions.length} resumable
+            </span>
+          </button>
+          {idleExpanded &&
+            recentSessions.map((session) => (
+              <RecentSessionRow key={`recent:${session.aiTool}:${session.id}`} session={session} />
+            ))}
         </>
       )}
     </>

--- a/src/renderer/src/components/projects/WorktreeSection.tsx
+++ b/src/renderer/src/components/projects/WorktreeSection.tsx
@@ -201,6 +201,7 @@ export function WorktreeSection({
 
       {isExpanded && (
         <ProjectSessionList
+          scopeId={sectionId}
           sessions={sessions}
           openTabs={openTabs}
           providers={providers}

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -185,6 +185,55 @@ function ToggleRow({
   )
 }
 
+/**
+ * Compact theme swatch used in the Appearance picker. Shows a small
+ * bg / bgAlt / accent / text preview strip and the theme name — deliberately
+ * short so several rows of themes fit without pushing the settings below the
+ * fold. Selected state uses the accent border + soft ring.
+ */
+function ThemeTile({
+  themeId,
+  name,
+  selected,
+  onSelect
+}: {
+  themeId: string
+  name: string
+  selected: boolean
+  onSelect: () => void
+}): React.JSX.Element {
+  const theme = getTheme(themeId)
+  return (
+    <button
+      onClick={onSelect}
+      title={name}
+      className="flex flex-col p-1.5 rounded-lg transition-colors text-left"
+      style={{
+        backgroundColor: 'var(--dplex-bg-alt)',
+        border: '1px solid',
+        borderColor: selected ? 'var(--dplex-accent)' : 'var(--dplex-border)',
+        boxShadow: selected ? '0 0 0 2px var(--dplex-accent-soft)' : undefined
+      }}
+    >
+      <div
+        className="h-7 rounded-md flex overflow-hidden mb-1.5"
+        style={{ border: '1px solid var(--dplex-border)' }}
+      >
+        <span className="flex-1" style={{ backgroundColor: theme.ui.bg }} />
+        <span className="flex-1" style={{ backgroundColor: theme.ui.bgAlt }} />
+        <span className="flex-1" style={{ backgroundColor: theme.ui.accent }} />
+        <span className="flex-1" style={{ backgroundColor: theme.ui.text }} />
+      </div>
+      <span
+        className="text-[11px] font-medium truncate px-0.5"
+        style={{ color: 'var(--dplex-text)' }}
+      >
+        {name}
+      </span>
+    </button>
+  )
+}
+
 export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JSX.Element | null {
   const settings = useSettingsStore((s) => s.settings)
   const updateSettings = useSettingsStore((s) => s.updateSettings)
@@ -402,46 +451,16 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                   >
                     Dark
                   </h4>
-                  <div className="grid grid-cols-4 gap-2.5 mb-4">
-                    {darkThemes.map((t) => {
-                      const theme = getTheme(t.id)
-                      const isSelected = settings.theme === t.id
-                      return (
-                        <button
-                          key={t.id}
-                          onClick={() => applyNow({ theme: t.id })}
-                          className="flex flex-col p-2.5 rounded-lg transition-colors text-left"
-                          style={{
-                            backgroundColor: 'var(--dplex-bg-alt)',
-                            border: '1px solid',
-                            borderColor: isSelected ? 'var(--dplex-accent)' : 'var(--dplex-border)',
-                            boxShadow: isSelected ? '0 0 0 3px var(--dplex-accent-soft)' : undefined
-                          }}
-                        >
-                          <div
-                            className="h-12 rounded flex overflow-hidden mb-2"
-                            style={{ border: '1px solid var(--dplex-border)' }}
-                          >
-                            <span className="flex-1" style={{ backgroundColor: theme.ui.bg }} />
-                            <span className="flex-1" style={{ backgroundColor: theme.ui.bgAlt }} />
-                            <span className="flex-1" style={{ backgroundColor: theme.ui.accent }} />
-                            <span className="flex-1" style={{ backgroundColor: theme.ui.text }} />
-                          </div>
-                          <span
-                            className="text-[12px] font-medium"
-                            style={{ color: 'var(--dplex-text)' }}
-                          >
-                            {t.name}
-                          </span>
-                          <span
-                            className="text-[11px] mt-0.5"
-                            style={{ color: 'var(--dplex-text-muted)' }}
-                          >
-                            Dark
-                          </span>
-                        </button>
-                      )
-                    })}
+                  <div className="grid grid-cols-4 gap-2 mb-3">
+                    {darkThemes.map((t) => (
+                      <ThemeTile
+                        key={t.id}
+                        themeId={t.id}
+                        name={t.name}
+                        selected={settings.theme === t.id}
+                        onSelect={() => applyNow({ theme: t.id })}
+                      />
+                    ))}
                   </div>
                   <h4
                     className="text-[10px] font-semibold uppercase tracking-wider mb-2"
@@ -449,47 +468,32 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
                   >
                     Light
                   </h4>
-                  <div className="grid grid-cols-4 gap-2.5">
-                    {lightThemes.map((t) => {
-                      const theme = getTheme(t.id)
-                      const isSelected = settings.theme === t.id
-                      return (
-                        <button
-                          key={t.id}
-                          onClick={() => applyNow({ theme: t.id })}
-                          className="flex flex-col p-2.5 rounded-lg transition-colors text-left"
-                          style={{
-                            backgroundColor: 'var(--dplex-bg-alt)',
-                            border: '1px solid',
-                            borderColor: isSelected ? 'var(--dplex-accent)' : 'var(--dplex-border)',
-                            boxShadow: isSelected ? '0 0 0 3px var(--dplex-accent-soft)' : undefined
-                          }}
-                        >
-                          <div
-                            className="h-12 rounded flex overflow-hidden mb-2"
-                            style={{ border: '1px solid var(--dplex-border)' }}
-                          >
-                            <span className="flex-1" style={{ backgroundColor: theme.ui.bg }} />
-                            <span className="flex-1" style={{ backgroundColor: theme.ui.bgAlt }} />
-                            <span className="flex-1" style={{ backgroundColor: theme.ui.accent }} />
-                            <span className="flex-1" style={{ backgroundColor: theme.ui.text }} />
-                          </div>
-                          <span
-                            className="text-[12px] font-medium"
-                            style={{ color: 'var(--dplex-text)' }}
-                          >
-                            {t.name}
-                          </span>
-                          <span
-                            className="text-[11px] mt-0.5"
-                            style={{ color: 'var(--dplex-text-muted)' }}
-                          >
-                            Light
-                          </span>
-                        </button>
-                      )
-                    })}
+                  <div className="grid grid-cols-4 gap-2">
+                    {lightThemes.map((t) => (
+                      <ThemeTile
+                        key={t.id}
+                        themeId={t.id}
+                        name={t.name}
+                        selected={settings.theme === t.id}
+                        onSelect={() => applyNow({ theme: t.id })}
+                      />
+                    ))}
                   </div>
+                </SettingItem>
+              )}
+
+              {activeTab === 'appearance' && (
+                <SettingItem label="Tab Color" settingId="tab-color-content">
+                  <ToggleRow
+                    label="Apply tab color to the tab's header and content"
+                    checked={settings.applyTabColorToContent}
+                    onChange={(v) => applyNow({ applyTabColorToContent: v })}
+                  />
+                  <p className="text-[11px] mt-1" style={{ color: 'var(--dplex-text-muted)' }}>
+                    When off, a colored tab still shows its color on the tab itself, but its
+                    breadcrumb header (project · path) and content keep the theme&apos;s default
+                    background.
+                  </p>
                 </SettingItem>
               )}
 

--- a/src/renderer/src/components/terminal/EditorGroup.tsx
+++ b/src/renderer/src/components/terminal/EditorGroup.tsx
@@ -2,7 +2,10 @@ import { useState, DragEvent } from 'react'
 import type { EditorGroup as EditorGroupType } from '../../types'
 import { isFileDiffTab, isFileEditorTab, isDashboardTab } from '../../types'
 import { useTerminalStore } from '../../stores/terminalStore'
+import { useProjectStore } from '../../stores/projectStore'
+import { useSettingsStore } from '../../stores/settingsStore'
 import { useFocusFilter } from '../../hooks/useFocusFilter'
+import { getTabIdentity } from '../../utils/tabProject'
 import { GroupTabBar } from './GroupTabBar'
 import { TabHeader } from './TabHeader'
 import { TerminalView } from './TerminalView'
@@ -32,6 +35,17 @@ export function EditorGroup({ group }: EditorGroupProps): React.JSX.Element {
     ? group.activeTabId
     : visibleTabs[0]?.id
   const activeTab = visibleTabs.find((t) => t.id === effectiveActiveId)
+
+  // Effective colour of the active tab (explicit per-tab colour, else its
+  // project's colour). Drives a very subtle wash over the pane content so the
+  // whole surface — not just the tab — reflects the chosen colour.
+  const projects = useProjectStore((s) => s.projects)
+  const applyTabColorToContent = useSettingsStore((s) => s.settings.applyTabColorToContent)
+  const activeTabColor =
+    applyTabColorToContent && activeTab
+      ? ((activeTab as { color?: string }).color ??
+        getTabIdentity(activeTab, projects)?.colorProject.tabColor)
+      : undefined
 
   // Activate this group. When isolate focus has pushed the rendered (effective)
   // active tab away from the stored `activeTabId` (the stored one is hidden),
@@ -142,6 +156,18 @@ export function EditorGroup({ group }: EditorGroupProps): React.JSX.Element {
             </div>
           )
         })}
+
+        {/* Subtle colour wash — tints the whole pane with the active tab's
+            colour (~7%) so a coloured tab carries through to its content, not
+            just the tab strip. Sits above the content but below the
+            inactive-group dim and drop overlays, and never intercepts input. */}
+        {activeTabColor && (
+          <div
+            aria-hidden
+            className="absolute inset-0 pointer-events-none"
+            style={{ backgroundColor: `${activeTabColor}12`, zIndex: 5 }}
+          />
+        )}
 
         {/* Inactive-group dimming wash. Tinted toward the panel/sidebar
             tone so a non-focused group's content visually matches its

--- a/src/renderer/src/components/terminal/GroupTabBar.tsx
+++ b/src/renderer/src/components/terminal/GroupTabBar.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, DragEvent } from 'react'
 import {
   Plus,
   X,
+  Pencil,
   Terminal as TerminalIcon,
   LayoutDashboard,
   SplitSquareHorizontal,
@@ -13,6 +14,8 @@ import { useSessionStore } from '../../stores/sessionStore'
 import { useProjectStore } from '../../stores/projectStore'
 import { useFocusFilter } from '../../hooks/useFocusFilter'
 import { StatusDot } from '../common/StatusDot'
+import { PopoverMenu } from '../common/PopoverMenu'
+import { TAB_COLORS } from '../../utils/tabColors'
 import { labelForVisual } from '../../utils/sessionStatusVisual'
 import { effectiveSessionVisual } from '../../utils/sessionPairing'
 import { getTabIdentity } from '../../utils/tabProject'
@@ -38,6 +41,7 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
   const setActiveGroup = useTerminalStore((s) => s.setActiveGroup)
   const setActiveTerminalInGroup = useTerminalStore((s) => s.setActiveTerminalInGroup)
   const renameTerminal = useTerminalStore((s) => s.renameTerminal)
+  const setTabColor = useTerminalStore((s) => s.setTabColor)
   const promotePreviewTab = useTerminalStore((s) => s.promotePreviewTab)
   const moveTerminalToGroup = useTerminalStore((s) => s.moveTerminalToGroup)
   const reorderTab = useTerminalStore((s) => s.reorderTab)
@@ -45,6 +49,10 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
   const [editingTabId, setEditingTabId] = useState<string | null>(null)
   const [editValue, setEditValue] = useState('')
   const [dragOverIndex, setDragOverIndex] = useState<number | null>(null)
+  // Right-click tab context menu (color picker + rename/close), anchored at
+  // the cursor via a 1×1 virtual anchor element.
+  const [menu, setMenu] = useState<{ tabId: string; x: number; y: number } | null>(null)
+  const menuAnchorRef = useRef<HTMLDivElement>(null)
   const inputRef = useRef<HTMLInputElement>(null)
 
   const sessions = useSessionStore((s) => s.sessions)
@@ -142,6 +150,20 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
             (isFileDiff || isFileEditor) && (tab as { preview?: boolean }).preview === true
           const isDirty = isFileEditor && tab.dirty === true
           const identity = getTabIdentity(tab, projects)
+          // Effective tab colour: an explicit per-tab colour wins; otherwise
+          // the tab inherits its project's colour (shared across the origin +
+          // its worktrees via `colorProject`).
+          const tabColor = (tab as { color?: string }).color ?? identity?.colorProject.tabColor
+          // A coloured tab tints its whole chip (stronger when active) so the
+          // colour is unmistakable at a glance; uncoloured tabs keep the
+          // default active/inactive surfaces.
+          const tabBg = tabColor
+            ? isActive
+              ? `${tabColor}38`
+              : `${tabColor}1F`
+            : isActive
+              ? 'var(--dplex-bg)'
+              : 'var(--dplex-bg-alt)'
           // Isolate mode hides non-matching tabs entirely; dim mode keeps them
           // visible but de-emphasized. Iterate the real `group.tabs` (returning
           // null for hidden tabs) so drag-reorder indices stay correct.
@@ -176,7 +198,7 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
                 marginBottom: isActive ? -1 : 0,
                 paddingBottom: isActive ? 1 : 0,
                 borderLeftColor: dragOverIndex === index ? 'var(--dplex-accent)' : 'transparent',
-                backgroundColor: isActive ? 'var(--dplex-bg)' : 'var(--dplex-bg-alt)',
+                backgroundColor: tabBg,
                 color: isActive ? 'var(--dplex-text)' : 'var(--dplex-text-muted)',
                 opacity: dimmed ? 0.4 : 1,
                 zIndex: isActive ? 1 : 0
@@ -192,12 +214,17 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
                   handleDoubleClick(tab.id, tab.title)
                 }
               }}
+              onContextMenu={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                setActiveGroup(group.id)
+                setMenu({ tabId: tab.id, x: e.clientX, y: e.clientY })
+              }}
             >
-              {/* Active tab gets a 2-px accent stripe along the top edge —
-                  flat VS Code style. Project identity is now carried by
-                  the avatar (below) and the pane's TabHeader, so the tab
-                  itself only needs the active indicator. v2 adds a soft
-                  glow under the stripe to match the visual identity. */}
+              {/* Only the active tab gets the 2-px top stripe — flat VS Code
+                  style. It adopts the tab's chosen colour (falling back to the
+                  accent). Inactive tabs, coloured or not, carry no stripe; a
+                  coloured inactive tab is identified by its full-chip tint. */}
               {isActive && (
                 <span
                   aria-hidden
@@ -207,8 +234,8 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
                     left: 0,
                     right: 0,
                     height: 2,
-                    backgroundColor: 'var(--dplex-accent)',
-                    boxShadow: '0 0 8px var(--dplex-accent-glow)',
+                    backgroundColor: tabColor ?? 'var(--dplex-accent)',
+                    boxShadow: `0 0 8px ${tabColor ? `${tabColor}66` : 'var(--dplex-accent-glow)'}`,
                     pointerEvents: 'none'
                   }}
                 />
@@ -365,6 +392,112 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
           <SplitSquareVertical size={13} />
         </button>
       </div>
+
+      {menu &&
+        (() => {
+          const menuTab = group.tabs.find((t) => t.id === menu.tabId)
+          if (!menuTab) return null
+          const currentColor = (menuTab as { color?: string }).color
+          return (
+            <>
+              <div
+                ref={menuAnchorRef}
+                aria-hidden
+                style={{
+                  position: 'fixed',
+                  left: menu.x,
+                  top: menu.y,
+                  width: 1,
+                  height: 1,
+                  pointerEvents: 'none'
+                }}
+              />
+              <PopoverMenu
+                anchorRef={menuAnchorRef}
+                open
+                align="left"
+                onClose={() => setMenu(null)}
+                className="min-w-[184px]"
+              >
+                <div
+                  className="px-3 pt-1.5 pb-1 text-[10px] font-semibold uppercase"
+                  style={{ color: 'var(--dplex-text-faint)', letterSpacing: '0.08em' }}
+                >
+                  Tab color
+                </div>
+                <div className="flex items-center gap-1.5 px-3 pb-2">
+                  {TAB_COLORS.map((c) => {
+                    const selected = currentColor === c.value
+                    return (
+                      <button
+                        key={c.id}
+                        type="button"
+                        title={c.label}
+                        aria-pressed={selected}
+                        onClick={() => {
+                          setTabColor(menu.tabId, c.value)
+                          setMenu(null)
+                        }}
+                        className="rounded-full transition-transform hover:scale-110"
+                        style={{
+                          width: 16,
+                          height: 16,
+                          backgroundColor: c.value,
+                          boxShadow: selected
+                            ? `0 0 0 2px var(--dplex-bg), 0 0 0 3px ${c.value}`
+                            : 'none'
+                        }}
+                      />
+                    )
+                  })}
+                  <button
+                    type="button"
+                    title="No color"
+                    aria-label="Clear tab color"
+                    onClick={() => {
+                      setTabColor(menu.tabId, null)
+                      setMenu(null)
+                    }}
+                    className="grid place-items-center rounded-full hover:bg-[var(--dplex-hover)]"
+                    style={{
+                      width: 16,
+                      height: 16,
+                      border: '1px solid var(--dplex-border-strong)',
+                      color: 'var(--dplex-text-muted)'
+                    }}
+                  >
+                    <X size={10} />
+                  </button>
+                </div>
+                <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+                {isTerminalTab(menuTab) && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      handleDoubleClick(menuTab.id, menuTab.title)
+                      setMenu(null)
+                    }}
+                    className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+                    style={{ color: 'var(--dplex-text)' }}
+                  >
+                    <Pencil size={12} /> Rename
+                  </button>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    requestCloseTab(menu.tabId)
+                    setMenu(null)
+                  }}
+                  className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+                  style={{ color: 'var(--dplex-text)' }}
+                >
+                  <X size={12} /> Close
+                </button>
+              </PopoverMenu>
+            </>
+          )
+        })()}
     </div>
   )
 }

--- a/src/renderer/src/components/terminal/TabHeader.tsx
+++ b/src/renderer/src/components/terminal/TabHeader.tsx
@@ -5,6 +5,7 @@ import { isFileDiffTab, isFileEditorTab, isTerminalTab } from '../../types'
 import { useProjectStore } from '../../stores/projectStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useProvidersStore } from '../../stores/providersStore'
+import { useSettingsStore } from '../../stores/settingsStore'
 import { getTabIdentity } from '../../utils/tabProject'
 import { ProjectAvatar } from '../projects/ProjectAvatar'
 import { ProviderGlyph } from '../common/ProviderGlyph'
@@ -34,6 +35,7 @@ export function TabHeader({ tab }: TabHeaderProps): JSX.Element | null {
   const projects = useProjectStore((s) => s.projects)
   const sessions = useSessionStore((s) => s.sessions)
   const getProviderLabel = useProvidersStore((s) => s.getLabel)
+  const applyTabColorToContent = useSettingsStore((s) => s.settings.applyTabColorToContent)
 
   const identity = getTabIdentity(tab, projects)
   const isTerminal = isTerminalTab(tab)
@@ -60,12 +62,21 @@ export function TabHeader({ tab }: TabHeaderProps): JSX.Element | null {
   const visual = session ? effectiveSessionVisual(session) : undefined
   const providerLabel = session ? getProviderLabel(session.aiTool) : undefined
 
+  // Effective tab colour (explicit per-tab, else project colour) — tints this
+  // breadcrumb header to match the tab and its content wash, unless the user
+  // has turned off "apply tab color to content".
+  const headerColor = applyTabColorToContent
+    ? ((tab as { color?: string }).color ?? identity?.colorProject.tabColor)
+    : undefined
+
   return (
     <div
       className="flex items-center gap-2 px-3 select-none flex-shrink-0"
       style={{
         height: 30,
-        backgroundColor: 'var(--dplex-bg-alt)',
+        backgroundColor: headerColor
+          ? `color-mix(in srgb, ${headerColor} 10%, var(--dplex-bg-alt))`
+          : 'var(--dplex-bg-alt)',
         borderBottom: '1px solid var(--dplex-border-subtle)',
         fontSize: 12,
         color: 'var(--dplex-text-muted)'
@@ -73,7 +84,7 @@ export function TabHeader({ tab }: TabHeaderProps): JSX.Element | null {
     >
       {identity ? (
         <ProjectAvatar
-          projectId={identity.colorProject.id}
+          color={identity.colorProject.tabColor}
           name={identity.colorProject.name}
           size={18}
         />

--- a/src/renderer/src/services/search/projectsSource.ts
+++ b/src/renderer/src/services/search/projectsSource.ts
@@ -3,6 +3,7 @@ import type { SearchItem, SearchSource } from './types'
 import { useProjectStore } from '../../stores/projectStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { focusFirstTabForPaths } from '../../utils/sessionTabs'
+import { colorSourceProject } from '../../utils/tabProject'
 import { pathBasename } from './pathUtils'
 import { ProjectAvatar } from '../../components/projects/ProjectAvatar'
 
@@ -46,7 +47,11 @@ export const projectsSource: SearchSource = {
         description,
         keywords: [pathBasename(p.path), p.path, ...(p.pinned ? ['pinned'] : []), ...tagKeywords],
         ...(p.tags && p.tags.length > 0 ? { tags: [...p.tags] } : {}),
-        icon: createElement(ProjectAvatar, { projectId: p.id, name: p.name, size: 24 }),
+        icon: createElement(ProjectAvatar, {
+          color: colorSourceProject(p, ctx.projects).tabColor,
+          name: p.name,
+          size: 24
+        }),
         run: () => openProject(p.id)
       }
       if (p.parentRepoName) {

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -31,6 +31,16 @@ interface ProjectState {
    * loads.
    */
   collapsedWorktreeSections: Set<string>
+  /**
+   * Per-scope expansion state for the collapsible "Idle · N resumable"
+   * rollup that groups a project/worktree's recent (idle) sessions. Keyed by
+   * the scope id passed to `ProjectSessionList` (a project id for plain
+   * projects, or the worktree section id — `${parentId}::main` or a worktree
+   * project id). Defaults to **collapsed** — a scope appears in this set only
+   * after the user expands its idle rollup, so idle sessions stay tucked away
+   * until asked for. Ephemeral like `collapsedWorktreeSections`; not persisted.
+   */
+  expandedIdleSections: Set<string>
   /** Id of the most recently expanded project. Used to visually emphasize it. */
   lastExpandedProjectId: string | null
   /**
@@ -56,6 +66,8 @@ interface ProjectState {
   toggleExpanded: (id: string) => void
   /** Toggle the collapsed/expanded state of a worktree section header. */
   toggleWorktreeSection: (sectionId: string) => void
+  /** Toggle the collapsed/expanded state of a project's idle-sessions rollup. */
+  toggleIdleSection: (scopeId: string) => void
   setLastExpanded: (id: string) => void
   setActiveProject: (id: string | null) => void
   setProjectGitState: (id: string, patch: ProjectGitPanelState) => void
@@ -68,6 +80,9 @@ interface ProjectState {
   addProjectTag: (id: string, tag: string) => void
   /** Convenience: remove a single tag. No-op if not present. */
   removeProjectTag: (id: string, tag: string) => void
+  /** Set (hex) or clear (null) the project-wide tab color applied to all of
+   *  this project's tabs. Persists with the project list. */
+  setProjectTabColor: (id: string, color: string | null) => void
   startAISession: (project: Project, providerId?: string) => Promise<string | null>
   updateProjectWorktreeOverrides: (
     projectId: string,
@@ -80,6 +95,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
   projects: [],
   expandedProjectIds: new Set(),
   collapsedWorktreeSections: new Set(),
+  expandedIdleSections: new Set(),
   lastExpandedProjectId: null,
   activeProjectId: null,
   loaded: false,
@@ -149,6 +165,13 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     const next = projects.map((p) =>
       p.id === projectId ? { ...p, worktreeOverrides: overrides ?? undefined } : p
     )
+    set({ projects: next })
+    persistProjects()
+  },
+
+  setProjectTabColor: (id, color) => {
+    const { projects, persistProjects } = get()
+    const next = projects.map((p) => (p.id === id ? { ...p, tabColor: color ?? undefined } : p))
     set({ projects: next })
     persistProjects()
   },
@@ -409,6 +432,19 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
       if (next.has(sectionId)) next.delete(sectionId)
       else next.add(sectionId)
       return { collapsedWorktreeSections: next }
+    })
+  },
+
+  // Toggle a project/worktree idle-rollup's expansion. Ephemeral (session-only,
+  // like worktree-section collapse) — the idle list is a convenience surface,
+  // not workspace state worth persisting. Defaults to collapsed, so a scope is
+  // present in the set only while its idle sessions are being shown.
+  toggleIdleSection: (scopeId) => {
+    set((state) => {
+      const next = new Set(state.expandedIdleSections)
+      if (next.has(scopeId)) next.delete(scopeId)
+      else next.add(scopeId)
+      return { expandedIdleSections: next }
     })
   },
 

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -213,6 +213,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   },
   editorAutoSave: 'manual',
   focusFilterMode: 'dim',
+  applyTabColorToContent: true,
   skippedUpdateVersion: null
 }
 

--- a/src/renderer/src/stores/terminalStore.ts
+++ b/src/renderer/src/stores/terminalStore.ts
@@ -132,6 +132,9 @@ interface TerminalState {
   setActiveGroup: (groupId: string) => void
   setActiveTerminalInGroup: (groupId: string, terminalId: string) => void
   renameTerminal: (terminalId: string, title: string) => void
+  /** Set (hex string) or clear (null) a tab's user-chosen color. Applies to
+   *  any tab kind; the choice is persisted with the workspace. */
+  setTabColor: (tabId: string, color: string | null) => void
   splitGroup: (groupId: string, direction: 'horizontal' | 'vertical', cwd?: string) => string
   moveTerminalToGroup: (terminalId: string, targetGroupId: string, insertIndex?: number) => void
   moveTerminalToNewSplit: (
@@ -328,6 +331,19 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       groups: state.groups.map((g) => ({
         ...g,
         tabs: g.tabs.map((t) => (t.id === terminalId ? { ...t, title } : t))
+      }))
+    }))
+  },
+
+  setTabColor: (tabId, color) => {
+    set((state) => ({
+      groups: state.groups.map((g) => ({
+        ...g,
+        // `color ?? undefined` clears the key when passed null; JSON.stringify
+        // drops undefined so cleared tabs don't carry an empty `color` field.
+        tabs: g.tabs.map((t) =>
+          t.id === tabId ? ({ ...t, color: color ?? undefined } as EditorTab) : t
+        )
       }))
     }))
   },
@@ -948,7 +964,7 @@ function serializeWorkspace(): unknown {
         })
         .map((t) => {
           if (isDashboardTab(t)) {
-            return { kind: 'dashboard' as const, id: t.id, title: t.title }
+            return { kind: 'dashboard' as const, id: t.id, title: t.title, color: t.color }
           }
           if (isFileDiffTab(t)) {
             return {
@@ -959,7 +975,8 @@ function serializeWorkspace(): unknown {
               repoLabel: t.repoLabel,
               scope: t.scope,
               file: t.file,
-              sideBySide: t.sideBySide
+              sideBySide: t.sideBySide,
+              color: t.color
             }
           }
           if (isFileEditorTab(t)) {
@@ -969,7 +986,8 @@ function serializeWorkspace(): unknown {
               title: t.title,
               rootFs: t.rootFs,
               rootLabel: t.rootLabel,
-              relPath: t.relPath
+              relPath: t.relPath,
+              color: t.color
             }
           }
           return {
@@ -980,7 +998,8 @@ function serializeWorkspace(): unknown {
             sessionId: t.sessionId,
             providerId: t.providerId,
             worktreePath: t.worktreePath,
-            worktreeBranch: t.worktreeBranch
+            worktreeBranch: t.worktreeBranch,
+            color: t.color
           }
         }),
       activeTabId: g.activeTabId

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -12,6 +12,7 @@ export interface TerminalTab {
   pid?: number // PTY process PID, used for PID→session mapping
   worktreePath?: string // Canonical worktree path if this tab was launched against a worktree
   worktreeBranch?: string // Worktree branch at launch time (display hint, not authoritative)
+  color?: string // Optional user-chosen tab color (hex). Drives the tab's accent stripe. Set via the tab context menu.
 }
 
 export type DiffScopePersisted = DiffScopeFromIPC
@@ -39,6 +40,8 @@ export interface FileDiffTab {
   preview?: boolean
   /** UI preference per tab. */
   sideBySide?: boolean
+  /** Optional user-chosen tab color (hex). Set via the tab context menu. */
+  color?: string
 }
 
 export type EditorTab = TerminalTab | FileDiffTab | FileEditorTab | DashboardTab
@@ -52,6 +55,8 @@ export interface DashboardTab {
   id: string
   title: string
   kind: 'dashboard'
+  /** Optional user-chosen tab color (hex). Set via the tab context menu. */
+  color?: string
 }
 
 /**
@@ -74,6 +79,8 @@ export interface FileEditorTab {
   preview?: boolean
   /** True when the editor has unsaved changes (drives the dirty dot). */
   dirty?: boolean
+  /** Optional user-chosen tab color (hex). Set via the tab context menu. */
+  color?: string
 }
 
 export function isFileDiffTab(tab: EditorTab): tab is FileDiffTab {
@@ -233,6 +240,13 @@ export interface AppSettings {
    */
   focusFilterMode: 'dim' | 'isolate'
   /**
+   * Whether a tab's color also tints its breadcrumb header (project · path)
+   * and its content area. When `false`, a colored tab still shows its color on
+   * the tab itself, but the header and content keep the theme's default
+   * background. Default `true`.
+   */
+  applyTabColorToContent: boolean
+  /**
    * Version the user explicitly chose to skip from the update banner.
    * Honored only for `manualDownload` flows (macOS, .deb) — auto-install
    * platforms surface the banner only after the bytes are already on
@@ -293,6 +307,10 @@ export interface Project {
    *  deduped. Used for filtering the projects sidebar and for fuzzy matching
    *  in the command palette. Absent / empty array both mean "no tags". */
   tags?: string[]
+  /** User-chosen color (hex) applied to all of this project's tabs (main
+   *  checkout + worktrees). Individual tabs can still override it via the tab
+   *  context menu. Absent means "no project color". */
+  tabColor?: string
   /** Git panel UI state scoped to this project. Persists across sessions
    *  so the user lands back on the file they last opened. Validated on
    *  each refresh — stale paths fall back to the first changed file. */

--- a/src/renderer/src/utils/projectStatus.ts
+++ b/src/renderer/src/utils/projectStatus.ts
@@ -33,50 +33,34 @@ export function getRailBackground(status: ProjectStatus, isExpanded: boolean): s
 }
 
 /**
- * Palette for rich-mode avatars. Picked to be legible on light + dark themes.
- * Each entry is a [background-rgba, foreground-hex, border-rgba] triple —
- * background uses alpha so it tints nicely against any panel color; the
- * border uses the same hue at higher alpha to give the avatar a defined
- * shape even on themes where the soft bg fade becomes invisible.
- */
-const AVATAR_PALETTE: Array<[string, string, string]> = [
-  ['rgba(124,156,255,0.11)', '#94a8d8', 'rgba(124,156,255,0.32)'],
-  ['rgba(139,92,246,0.11)', '#a394d4', 'rgba(139,92,246,0.32)'],
-  ['rgba(60,207,145,0.11)', '#6fb796', 'rgba(60,207,145,0.32)'],
-  ['rgba(240,179,90,0.11)', '#c9a474', 'rgba(240,179,90,0.32)'],
-  ['rgba(239,106,106,0.11)', '#c98a8a', 'rgba(239,106,106,0.32)'],
-  ['rgba(93,209,206,0.11)', '#7fb5b3', 'rgba(93,209,206,0.32)'],
-  ['rgba(236,112,176,0.11)', '#c990b0', 'rgba(236,112,176,0.32)'],
-  ['rgba(176,196,120,0.11)', '#a0ad8a', 'rgba(176,196,120,0.32)']
-]
-
-function hashString(s: string): number {
-  let h = 0
-  for (let i = 0; i < s.length; i++) {
-    h = (h * 31 + s.charCodeAt(i)) | 0
-  }
-  return Math.abs(h)
-}
-
-/**
- * Deterministic avatar color derived from a stable project identity.
- * Hashing the project id (not the name) keeps colors stable across renames
- * and prevents name collisions across unrelated repos.
+ * Avatar colour for a project. Projects are neutral **grey by default** — a
+ * project only takes on colour once the user assigns it a tab colour
+ * (`Project.tabColor`), at which point its avatar adopts that hue. Keeping the
+ * default neutral means colour in the sidebar always *means something* (the
+ * user chose it) rather than being decorative noise.
  *
- * Returns:
- *   - `bg`: low-alpha background tint
- *   - `fg`: muted foreground for the initials
- *   - `border`: medium-alpha border that uses the same hue as the bg, so
- *     the avatar has a defined silhouette even when the panel background
- *     absorbs the soft tint (notably on darker non-v2 themes).
+ * Returns a `{ bg, fg, border }` triple consumed by the avatar components:
+ *   - grey default → theme tokens so it reads on light + dark
+ *   - coloured → a soft same-hue tint (`bg`), same-hue border, and the colour
+ *     itself for the initials.
  */
-export function getAvatarColor(projectId: string): {
+export function deriveAvatarColor(tabColor?: string): {
   bg: string
   fg: string
   border: string
 } {
-  const [bg, fg, border] = AVATAR_PALETTE[hashString(projectId) % AVATAR_PALETTE.length]
-  return { bg, fg, border }
+  if (!tabColor) {
+    return {
+      bg: 'var(--dplex-bg-elev-2)',
+      fg: 'var(--dplex-text-dim)',
+      border: 'var(--dplex-border)'
+    }
+  }
+  return {
+    bg: `${tabColor}26`,
+    fg: tabColor,
+    border: `${tabColor}5C`
+  }
 }
 
 /**

--- a/src/renderer/src/utils/projectTags.ts
+++ b/src/renderer/src/utils/projectTags.ts
@@ -5,10 +5,10 @@ import type { Project } from '../types'
 export const MAX_TAG_LENGTH = 32
 
 /**
- * Theme-safe palette used by tag pills. Same pattern as `AVATAR_PALETTE` in
- * `projectStatus.ts` — translucent background so the pill tints any panel
- * color cleanly, plus a saturated foreground that reads on both light and
- * dark themes. Each entry's `id` is what gets persisted in `tagColors`.
+ * Theme-safe palette used by tag pills — translucent background so the pill
+ * tints any panel color cleanly, plus a saturated foreground that reads on both
+ * light and dark themes. Each entry's `id` is what gets persisted in
+ * `tagColors`.
  *
  * Order is the order shown in the color picker swatch grid; keep it stable
  * because users will memorize positions ("third swatch = my client tag").

--- a/src/renderer/src/utils/tabColors.ts
+++ b/src/renderer/src/utils/tabColors.ts
@@ -1,0 +1,22 @@
+/**
+ * Fixed palette offered by the tab context menu's "Tab color" picker. Stored
+ * as raw hex on `EditorTab.color` so the choice is theme-independent and
+ * survives workspace serialization untouched. Values are drawn from the DPlex
+ * accent ramp so they read clearly against both the dark and light chrome.
+ */
+export interface TabColorOption {
+  id: string
+  label: string
+  value: string
+}
+
+export const TAB_COLORS: TabColorOption[] = [
+  { id: 'red', label: 'Red', value: '#F87171' },
+  { id: 'orange', label: 'Orange', value: '#FB923C' },
+  { id: 'amber', label: 'Amber', value: '#F59E0B' },
+  { id: 'green', label: 'Green', value: '#34D399' },
+  { id: 'cyan', label: 'Cyan', value: '#22D3EE' },
+  { id: 'blue', label: 'Blue', value: '#60A5FA' },
+  { id: 'violet', label: 'Violet', value: '#A78BFA' },
+  { id: 'pink', label: 'Pink', value: '#F472B6' }
+]

--- a/src/renderer/src/utils/tabProject.ts
+++ b/src/renderer/src/utils/tabProject.ts
@@ -1,7 +1,7 @@
 import type { EditorTab, Project } from '../types'
 import { isFileDiffTab, isFileEditorTab, isDashboardTab } from '../types'
 import { normalizePath } from './normalizePath'
-import { getAvatarColor, getAvatarInitials } from './projectStatus'
+import { deriveAvatarColor, getAvatarInitials } from './projectStatus'
 
 /**
  * Return the filesystem path that a tab should be associated with for the
@@ -54,20 +54,29 @@ export interface TabProjectIdentity {
   initials: string
 }
 
+/**
+ * The project whose color a given project should adopt: its parent origin for
+ * a worktree (so a repo's main checkout + worktrees form one color group),
+ * else the project itself. Orphan worktrees (parent not registered) fall back
+ * to themselves. Use this anywhere a project surface needs its effective tab
+ * color so worktrees stay consistent with `getTabIdentity`.
+ */
+export function colorSourceProject(project: Project, projects: readonly Project[]): Project {
+  if (!project.parentProjectId) return project
+  return projects.find((p) => p.id === project.parentProjectId) ?? project
+}
+
 export function getTabIdentity(
   tab: EditorTab,
   projects: readonly Project[]
 ): TabProjectIdentity | undefined {
   const matched = findProjectForTab(tab, projects)
   if (!matched) return undefined
-  const parent = matched.parentProjectId
-    ? projects.find((p) => p.id === matched.parentProjectId)
-    : undefined
-  const colorProject = parent ?? matched
+  const colorProject = colorSourceProject(matched, projects)
   return {
     matched,
     colorProject,
-    color: getAvatarColor(colorProject.id),
+    color: deriveAvatarColor(colorProject.tabColor),
     initials: getAvatarInitials(colorProject.name)
   }
 }

--- a/tests/unit/project-idle-sections.test.ts
+++ b/tests/unit/project-idle-sections.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { useProjectStore } from '../../src/renderer/src/stores/projectStore'
+
+// The idle-sessions rollup ("Idle · N resumable") shown inside each expanded
+// project / worktree scope is collapsed by default. Its per-scope expansion
+// lives in projectStore.expandedIdleSections, where presence == expanded.
+
+beforeEach(() => {
+  useProjectStore.setState({ expandedIdleSections: new Set() } as never)
+})
+
+afterEach(() => {
+  useProjectStore.setState({ expandedIdleSections: new Set() } as never)
+})
+
+describe('projectStore idle-section rollup', () => {
+  it('defaults to collapsed (scope absent from the set)', () => {
+    expect(useProjectStore.getState().expandedIdleSections.has('proj-1')).toBe(false)
+  })
+
+  it('toggleIdleSection expands then collapses a scope', () => {
+    const { toggleIdleSection } = useProjectStore.getState()
+    toggleIdleSection('proj-1')
+    expect(useProjectStore.getState().expandedIdleSections.has('proj-1')).toBe(true)
+    toggleIdleSection('proj-1')
+    expect(useProjectStore.getState().expandedIdleSections.has('proj-1')).toBe(false)
+  })
+
+  it('tracks scopes independently (project id vs worktree section id)', () => {
+    const { toggleIdleSection } = useProjectStore.getState()
+    toggleIdleSection('proj-1')
+    expect(useProjectStore.getState().expandedIdleSections.has('proj-1')).toBe(true)
+    expect(useProjectStore.getState().expandedIdleSections.has('proj-1::main')).toBe(false)
+
+    toggleIdleSection('proj-1::main')
+    expect(useProjectStore.getState().expandedIdleSections.has('proj-1')).toBe(true)
+    expect(useProjectStore.getState().expandedIdleSections.has('proj-1::main')).toBe(true)
+  })
+
+  it('produces a new Set reference on toggle (immutable update)', () => {
+    const before = useProjectStore.getState().expandedIdleSections
+    useProjectStore.getState().toggleIdleSection('proj-1')
+    const after = useProjectStore.getState().expandedIdleSections
+    expect(after).not.toBe(before)
+  })
+})

--- a/tests/unit/project-status.test.ts
+++ b/tests/unit/project-status.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
-  getAvatarColor,
+  deriveAvatarColor,
   getAvatarInitials,
   getProjectStatus,
   getRailBackground
@@ -49,22 +49,19 @@ describe('projectStatus', () => {
     })
   })
 
-  describe('getAvatarColor', () => {
-    it('is deterministic for the same id', () => {
-      expect(getAvatarColor('proj-abc')).toEqual(getAvatarColor('proj-abc'))
+  describe('deriveAvatarColor', () => {
+    it('returns a neutral grey (theme tokens) when no colour is set', () => {
+      const c = deriveAvatarColor(undefined)
+      expect(c.bg).toBe('var(--dplex-bg-elev-2)')
+      expect(c.fg).toBe('var(--dplex-text-dim)')
+      expect(c.border).toBe('var(--dplex-border)')
     })
 
-    it('yields different colors for different ids (usually)', () => {
-      const a = getAvatarColor('proj-aaa')
-      const b = getAvatarColor('proj-zzz')
-      // Can't guarantee difference for 2 random ids, but these two should land in different buckets.
-      expect(a).not.toEqual(b)
-    })
-
-    it('returns both bg and fg as non-empty strings', () => {
-      const c = getAvatarColor('x')
-      expect(c.bg).toMatch(/rgba/)
-      expect(c.fg).toMatch(/^#/)
+    it('derives a same-hue tint from the given colour', () => {
+      const c = deriveAvatarColor('#F87171')
+      expect(c.fg).toBe('#F87171')
+      expect(c.bg).toBe('#F8717126')
+      expect(c.border).toBe('#F871715C')
     })
   })
 

--- a/tests/unit/project-tab-color.test.ts
+++ b/tests/unit/project-tab-color.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useProjectStore } from '../../src/renderer/src/stores/projectStore'
+import type { Project } from '../../src/renderer/src/types'
+
+// `setProjectTabColor` sets a project-wide tab colour (inherited by all of the
+// project's tabs) and persists the change via window.dplex.settings.merge.
+
+let merge: ReturnType<typeof vi.fn>
+
+function installWindow(): void {
+  merge = vi.fn().mockResolvedValue(undefined)
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: { settings: { getAll: vi.fn().mockResolvedValue({}), merge } }
+  }
+}
+
+function makeProject(id: string): Project {
+  return { id, name: id, path: `/${id}`, addedAt: new Date().toISOString() } as Project
+}
+
+function project(id: string): Project | undefined {
+  return useProjectStore.getState().projects.find((p) => p.id === id)
+}
+
+beforeEach(() => {
+  installWindow()
+  useProjectStore.setState({
+    projects: [makeProject('p1'), makeProject('p2')],
+    loaded: true
+  } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('setProjectTabColor', () => {
+  it('sets a colour on the target project only, and persists', () => {
+    useProjectStore.getState().setProjectTabColor('p1', '#F87171')
+    expect(project('p1')?.tabColor).toBe('#F87171')
+    expect(project('p2')?.tabColor).toBeUndefined()
+    expect(merge).toHaveBeenCalled()
+  })
+
+  it('clears the colour when passed null', () => {
+    useProjectStore.getState().setProjectTabColor('p1', '#34D399')
+    expect(project('p1')?.tabColor).toBe('#34D399')
+
+    useProjectStore.getState().setProjectTabColor('p1', null)
+    expect(project('p1')?.tabColor).toBeUndefined()
+  })
+})

--- a/tests/unit/tab-project.test.ts
+++ b/tests/unit/tab-project.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  colorSourceProject,
   findProjectForTab,
   getTabIdentity,
   getTabProjectPath
 } from '../../src/renderer/src/utils/tabProject'
 import type { FileDiffTab, Project, TerminalTab } from '../../src/renderer/src/types'
-import { getAvatarColor } from '../../src/renderer/src/utils/projectStatus'
+import { deriveAvatarColor } from '../../src/renderer/src/utils/projectStatus'
 
 function makeProject(partial: Partial<Project> & Pick<Project, 'id' | 'name' | 'path'>): Project {
   return {
@@ -94,7 +95,7 @@ describe('getTabIdentity', () => {
     expect(identity).toBeDefined()
     expect(identity!.matched.id).toBe('p-wt')
     expect(identity!.colorProject.id).toBe('p-app')
-    expect(identity!.color).toEqual(getAvatarColor('p-app'))
+    expect(identity!.color).toEqual(deriveAvatarColor(undefined))
   })
 
   it('uses matched project color when not a worktree', () => {
@@ -105,5 +106,38 @@ describe('getTabIdentity', () => {
 
   it('returns undefined for unmatched tabs', () => {
     expect(getTabIdentity(makeTerminalTab({ id: 't', cwd: '/x' }), PROJECTS)).toBeUndefined()
+  })
+})
+
+describe('colorSourceProject', () => {
+  it('returns the parent origin for a worktree', () => {
+    const wt = PROJECTS.find((p) => p.id === 'p-wt')!
+    expect(colorSourceProject(wt, PROJECTS).id).toBe('p-app')
+  })
+
+  it('returns the project itself when it is an origin', () => {
+    const app = PROJECTS.find((p) => p.id === 'p-app')!
+    expect(colorSourceProject(app, PROJECTS).id).toBe('p-app')
+  })
+
+  it('falls back to the project itself for an orphan worktree (parent missing)', () => {
+    const orphan = makeProject({ id: 'o', name: 'orphan', path: '/o', parentProjectId: 'missing' })
+    expect(colorSourceProject(orphan, PROJECTS).id).toBe('o')
+  })
+
+  it('worktree tabs inherit the origin tab color', () => {
+    const colored: Project[] = [
+      makeProject({ id: 'p-app', name: 'DPlex', path: '/code/dplex', tabColor: '#34D399' }),
+      makeProject({
+        id: 'p-wt',
+        name: 'feature-x',
+        path: '/code/dplex-wt',
+        parentProjectId: 'p-app'
+      })
+    ]
+    const tab = makeTerminalTab({ id: 't', worktreePath: '/code/dplex-wt' })
+    const identity = getTabIdentity(tab, colored)
+    expect(identity!.colorProject.tabColor).toBe('#34D399')
+    expect(identity!.color).toEqual(deriveAvatarColor('#34D399'))
   })
 })

--- a/tests/unit/terminal-tab-color.test.ts
+++ b/tests/unit/terminal-tab-color.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Unit tests for per-tab colour in `terminalStore`:
+ *   - `setTabColor` sets / clears a colour on the target tab only
+ *   - the chosen colour survives workspace serialization (and is dropped
+ *     once cleared, so cleared tabs don't carry an empty `color` field).
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  useTerminalStore,
+  _serializeWorkspaceForTests
+} from '../../src/renderer/src/stores/terminalStore'
+
+function setupWindow(): void {
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: {
+      sessions: {
+        saveWorkspace: vi.fn().mockResolvedValue(undefined),
+        saveWorkspaceSync: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined)
+      },
+      pty: { destroy: vi.fn() }
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}
+
+beforeEach(() => {
+  setupWindow()
+  useTerminalStore.setState({
+    groups: [],
+    layout: { type: 'group', groupId: '' },
+    activeGroupId: null,
+    restored: false
+  } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+function tabById(id: string): { id: string; color?: string } | undefined {
+  for (const g of useTerminalStore.getState().groups) {
+    const t = g.tabs.find((x) => x.id === id)
+    if (t) return t as { id: string; color?: string }
+  }
+  return undefined
+}
+
+function serializedTab(id: string): { id: string; color?: string } | undefined {
+  const snap = _serializeWorkspaceForTests() as {
+    groups: Array<{ tabs: Array<{ id: string; color?: string }> }>
+  }
+  return snap.groups.flatMap((g) => g.tabs).find((t) => t.id === id)
+}
+
+describe('setTabColor', () => {
+  it('sets a colour on the target tab and clears it with null', () => {
+    const id = useTerminalStore.getState().createTerminal()
+    expect(tabById(id)?.color).toBeUndefined()
+
+    useTerminalStore.getState().setTabColor(id, '#F87171')
+    expect(tabById(id)?.color).toBe('#F87171')
+
+    useTerminalStore.getState().setTabColor(id, null)
+    expect(tabById(id)?.color).toBeUndefined()
+  })
+
+  it('only colours the matching tab', () => {
+    const a = useTerminalStore.getState().createTerminal()
+    const b = useTerminalStore.getState().createTerminal()
+
+    useTerminalStore.getState().setTabColor(a, '#60A5FA')
+    expect(tabById(a)?.color).toBe('#60A5FA')
+    expect(tabById(b)?.color).toBeUndefined()
+  })
+})
+
+describe('serializeWorkspace — tab colour', () => {
+  it('persists a colour on a session (command) tab and omits it once cleared', () => {
+    // Session tabs (those with a `command`) are the ones we persist.
+    const id = useTerminalStore.getState().createTerminal(undefined, 'Copilot', 'copilot')
+
+    useTerminalStore.getState().setTabColor(id, '#A78BFA')
+    expect(serializedTab(id)?.color).toBe('#A78BFA')
+
+    useTerminalStore.getState().setTabColor(id, null)
+    const cleared = serializedTab(id)
+    expect(cleared?.color).toBeUndefined()
+    // Cleared tabs must not serialize a lingering `color` key.
+    expect(JSON.stringify(cleared)).not.toContain('color')
+  })
+})


### PR DESCRIPTION
Bumps to **v0.29.0** (MINOR — new user-visible features).

## Features
- **Per-tab color** — right-click a tab → pick a color (or clear). The whole tab is tinted (top stripe shows only on the active tab); the menu also offers **Rename** and **Close**. Persisted with the workspace across restarts.
- **Project-wide color** — right-click a project in the sidebar → **Tab color** to tint all of that project's tabs (across worktrees) and its avatar. Project avatars are now **neutral grey by default** and only take on a color you choose.
- **Header + content tint** — the active tab's breadcrumb header (project · path) and content area pick up a subtle matching tint, **toggleable in Settings → Appearance** (`applyTabColorToContent`, default on).

## Improvements
- **Collapsible "Idle · N resumable" rollup** per project/worktree, closed by default, so live sessions stay front and centre.
- **Compact theme picker** in Settings → Appearance (extracted a `ThemeTile`), so the settings below it are visible without scrolling.

## Internals
- New store actions: `terminalStore.setTabColor`, `projectStore.setProjectTabColor` / `.toggleIdleSection` (+ `expandedIdleSections`).
- `deriveAvatarColor` replaces the hash-based `getAvatarColor` (grey by default, else the chosen hue).
- `colorSourceProject` centralises **worktree → origin** color inheritance so tabs, pickers, and avatars all resolve the same color.
- Tab `color` serialized/restored for every tab kind.

## Testing
- `npm run typecheck`, `npm run build` ✅
- `npm run test:unit` — **628 passing** (6 pre-existing skips), incl. new tests for `setTabColor` (+ serialize), `setProjectTabColor`, `toggleIdleSection`, `deriveAvatarColor`, and `colorSourceProject`.
- ESLint clean on changed files (one pre-existing `set-state-in-effect` warning in `ProjectItem`, unrelated to this change).

## Review
Ran a dual-model code review (Claude Opus 4.7 + GPT-5.5). Claude: clean. GPT flagged worktree color-inheritance inconsistencies (picker/avatars used the worktree's own color instead of the origin's) — fixed via the shared `colorSourceProject` resolver, with tests.

_Note: the pre-existing Dependabot alerts on `main` are unrelated to this PR._