### PR TITLE
feat: Context Spaces — group projects, sessions & layout into switchable Spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,41 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.29.0] — 2026-07-09
+## [0.31.1] — 2026-07-14
+
+### Improvements
+
+- Spaces created automatically for work you start without picking one are now named "Untitled Space 1", "Untitled Space 2", and so on — a clear, neutral label you can rename anytime — while still linking the project you started from.
+
+## [0.31.0] — 2026-07-12
 
 ### Features
 
+- Start a session or terminal for any of a Space's projects right from the new **New session** button in the Space bar — no more detouring through the Projects tab. A brand-new Space now also greets you with its projects, ready to launch.
+- Find and switch to any Space from global search and the command palette (⌘/Ctrl+P) — by its name or a project it contains — and create a new Space or jump to the Overview without leaving the palette.
+- Drag the sidebar's activity-bar icons to reorder them — or right-click an icon to move it up or down — with **Spaces** leading the rail by default. Your arrangement is remembered across restarts.
+
+### Improvements
+
+- The Space bar across the top of the workspace is roomier and easier to read.
+- Starting work from the Overview now automatically wraps it in its own Space, linked to the project you started it from, so nothing is left unattached.
+- Starting a project's session or terminal from a Space now adds that project to the Space automatically, so its project list keeps up with the work running inside it.
+- The Spaces sidebar now mirrors the Projects and Sessions panels — your current Space sits in a dedicated Focused section at the top, the rest follow under All spaces (most-recently-used first), each row shows its projects and session count at a glance, and a tidy right-click/hover menu handles rename, resume, minimize, and delete.
+- The Space picker at the top of the workspace is lighter and cleaner — the current Space now reads as a simple breadcrumb (no boxy outline), the switch list drops its noisy status badges, and the current Space is marked with a checkmark.
+
+### Bug Fixes
+
+- A session you start for a project now reliably opens in the Space you launched it from, even if you switch Spaces while it's still starting up.
+- Clicking a session that's running in another Space now jumps to that Space and focuses it, instead of starting a second copy — and deleting such a session cleanly closes it wherever it's parked.
+- Fixed Space cards on the Overview overlapping each other, rendering at uneven heights, and clipping their action buttons on smaller screens — the grid now scrolls cleanly with evenly sized cards.
+
+## [0.30.0] — 2026-07-12
+
+### Features
+
+- **Spaces** — group everything a piece of work needs (its projects, AI sessions, terminals, and the exact tab and split layout) into a named, color-coded Space, and switch between Spaces without losing your place. Switching never restarts or interrupts a running session: the Space you leave keeps working in the background and still nudges you when one of its sessions needs your attention. Create, rename, recolor, reorder, and delete Spaces from the new Spaces sidebar, and jump straight to one with ⌘/Ctrl+Shift+1–9.
+- **Overview** — a home base showing all your Spaces at a glance: which are live, the projects each holds, and which ones need you right now. Step away from your current Space to land here, then resume any Space exactly as you left it.
+- A single Space can span **multiple projects**, so work that touches more than one repository stays together in one place. Your existing sessions and layout are carried over automatically into a starter "My Work" Space the first time you open this version.
 - Give any tab its own color: right-click a tab and pick a color (or clear it). The whole tab is tinted with the color — even when it's not the active one — and the active tab's breadcrumb header (project · path) and content area pick up a subtle matching tint (which you can turn off in Settings → Appearance if you prefer the tint on the tab only). Your choices are remembered across restarts. The right-click menu also offers quick Rename and Close.
 - Set a color for a whole project: right-click a project in the sidebar and pick a "Tab color" to tint every one of that project's tabs (across its worktrees too) and its avatar. Project avatars are now neutral grey by default and take on the color you choose, so color in the sidebar always means something you picked. Individual tabs can still override, and the choice is remembered across restarts.
 
@@ -645,7 +676,10 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.29.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.31.1...HEAD
+[0.31.1]: https://github.com/Ron537/DPlex/compare/v0.31.0...v0.31.1
+[0.31.0]: https://github.com/Ron537/DPlex/compare/v0.30.0...v0.31.0
+[0.30.0]: https://github.com/Ron537/DPlex/compare/v0.29.0...v0.30.0
 [0.29.0]: https://github.com/Ron537/DPlex/compare/v0.28.1...v0.29.0
 [0.28.1]: https://github.com/Ron537/DPlex/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/Ron537/DPlex/compare/v0.27.1...v0.28.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.29.0",
+  "version": "0.31.1",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,11 @@ import {
   type PersistedWorkspace
 } from './services/sessionPersistence'
 import {
+  loadOrMigrateSpaces,
+  saveSpaces,
+  type PersistedSpacesFile
+} from './services/spacesPersistence'
+import {
   applyNotificationSettings,
   clearNotificationState,
   handleAttentionEvent,
@@ -564,6 +569,18 @@ function registerIpcHandlers(): void {
   // Sync version for reliable save on quit (blocks until written)
   ipcMain.on('sessions:saveWorkspaceSync', (event, data: PersistedWorkspace) => {
     saveWorkspace(data)
+    event.returnValue = true
+  })
+
+  // Spaces persistence (Projects · Spaces · Sessions). A Space bundles the
+  // whole workspace arrangement; spaces.json supersedes the flat sessions.json,
+  // migrating it on first run.
+  ipcMain.handle('spaces:load', () => loadOrMigrateSpaces())
+  ipcMain.handle('spaces:save', (_event, data: PersistedSpacesFile) => {
+    saveSpaces(data)
+  })
+  ipcMain.on('spaces:saveSync', (event, data: PersistedSpacesFile) => {
+    saveSpaces(data)
     event.returnValue = true
   })
   ipcMain.handle(

--- a/src/main/services/providers/baseProvider.ts
+++ b/src/main/services/providers/baseProvider.ts
@@ -122,7 +122,7 @@ export abstract class BaseSessionProvider implements SessionProvider {
     limit: number
   ): Promise<SessionPrompt[]>
 
-  abstract getResumeCommand(sessionId: string): string
+  abstract getResumeCommand(sessionId: string): string | null
   abstract getNewSessionCommand(): string
 
   // ── Default storage layout (Copilot convention) ──────────────────

--- a/src/main/services/providers/claudeCodeProvider.ts
+++ b/src/main/services/providers/claudeCodeProvider.ts
@@ -304,7 +304,10 @@ export class ClaudeCodeProvider extends BaseSessionProvider {
 
   // ── CLI invocation ───────────────────────────────────────────────
 
-  getResumeCommand(sessionId: string): string {
+  getResumeCommand(sessionId: string): string | null {
+    // Session ids come from filesystem entry names, so refuse to interpolate an
+    // unsafe id into a shell-executed command (see validateSessionId).
+    if (!this.validateSessionId(sessionId)) return null
     return `claude --resume ${sessionId}`
   }
 

--- a/src/main/services/providers/copilotProvider.ts
+++ b/src/main/services/providers/copilotProvider.ts
@@ -97,7 +97,10 @@ export class CopilotProvider extends BaseSessionProvider {
     return extractCopilotPrompts(sessionDir, limit)
   }
 
-  getResumeCommand(sessionId: string): string {
+  getResumeCommand(sessionId: string): string | null {
+    // Session ids come from filesystem entry names, so refuse to interpolate an
+    // unsafe id into a shell-executed command (see validateSessionId).
+    if (!this.validateSessionId(sessionId)) return null
     return `copilot --resume=${sessionId}`
   }
 

--- a/src/main/services/providers/types.ts
+++ b/src/main/services/providers/types.ts
@@ -97,8 +97,9 @@ export interface SessionProvider {
   /** Find the most recently active session matching the given CWD. */
   resolveSessionByCwd(cwd: string): Promise<ResolvedSession | null>
 
-  /** Return the CLI command string to resume a session (e.g. "copilot --resume=abc123"). */
-  getResumeCommand(sessionId: string): string
+  /** Return the CLI command string to resume a session (e.g. "copilot --resume=abc123"),
+   *  or null when the session id is unsafe to interpolate into a shell command. */
+  getResumeCommand(sessionId: string): string | null
 
   /** Return the CLI command string to start a new session (e.g. "copilot"). */
   getNewSessionCommand(): string

--- a/src/main/services/spacesPersistence.ts
+++ b/src/main/services/spacesPersistence.ts
@@ -1,0 +1,200 @@
+import * as fs from 'fs'
+import { app } from 'electron'
+import * as path from 'path'
+import { loadWorkspace } from './sessionPersistence'
+
+const SPACES_FILENAME = 'spaces.json'
+const SPACES_VERSION = 1
+
+/** Default identity for the Space that legacy workspaces migrate into. */
+const MIGRATED_SPACE_ID = 'space-my-work'
+const MIGRATED_SPACE_NAME = 'My Work'
+const MIGRATED_SPACE_COLOR = '#6E8BFF'
+
+function spacesPath(): string {
+  return path.join(app.getPath('userData'), SPACES_FILENAME)
+}
+
+/**
+ * A Space as stored on disk. `workspace` is the lossy persisted workspace form
+ * (same shape written to the legacy sessions.json); it is treated opaquely
+ * here — the renderer owns its schema and reconstructs it on load.
+ */
+export interface PersistedSpace {
+  id: string
+  name: string
+  color: string
+  glyph?: string
+  projectIds: string[]
+  workspace: unknown
+  createdAt: number
+  updatedAt: number
+  lastActiveAt: number
+  archived?: boolean
+}
+
+export interface PersistedSpacesFile {
+  version: number
+  spaces: PersistedSpace[]
+  activeSpaceId: string | null
+}
+
+function isValidSpacesFile(value: unknown): value is PersistedSpacesFile {
+  if (!value || typeof value !== 'object') return false
+  const v = value as Record<string, unknown>
+  // Require a known, positive-integer schema version. Reject future versions (an
+  // older build must not load a newer file and silently down-convert it on the
+  // next save) as well as bogus versions (0, negatives, fractions).
+  if (
+    typeof v.version !== 'number' ||
+    !Number.isInteger(v.version) ||
+    v.version < 1 ||
+    v.version > SPACES_VERSION
+  ) {
+    return false
+  }
+  if (!Array.isArray(v.spaces)) return false
+  // Every entry must be a non-null object — a malformed element (e.g. `null`)
+  // would otherwise crash the renderer's hydrate when it reads `.workspace`.
+  if (!v.spaces.every((s) => !!s && typeof s === 'object')) return false
+  const active = v.activeSpaceId
+  return active === null || typeof active === 'string'
+}
+
+/**
+ * Outcome of reading spaces.json. These states must be handled differently: a
+ * valid file is used as-is (even when its `spaces` array is empty); a genuinely
+ * absent file is safe to migrate a legacy workspace into; a corrupt or
+ * newer-schema ("unsupported") file must be preserved, never overwritten.
+ */
+type SpacesLoadOutcome =
+  | { status: 'ok'; file: PersistedSpacesFile }
+  | { status: 'absent' }
+  | { status: 'corrupt' }
+  | { status: 'unsupported' }
+
+function readSpacesFile(): SpacesLoadOutcome {
+  const p = spacesPath()
+  let raw: string
+  try {
+    if (!fs.existsSync(p)) return { status: 'absent' }
+    raw = fs.readFileSync(p, 'utf-8')
+  } catch {
+    // Present but unreadable (permissions / transient IO) — treat as corrupt so
+    // we never migrate over it.
+    return { status: 'corrupt' }
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { status: 'corrupt' }
+  }
+  if (isValidSpacesFile(parsed)) return { status: 'ok', file: parsed }
+  const version = (parsed as { version?: unknown } | null)?.version
+  if (typeof version === 'number' && version > SPACES_VERSION) {
+    return { status: 'unsupported' }
+  }
+  return { status: 'corrupt' }
+}
+
+/** Load and validate spaces.json, returning the parsed file or null when it is
+ *  absent, corrupt, or written by an unsupported (newer) schema version. Does
+ *  not migrate or move anything aside — use loadOrMigrateSpaces for boot. */
+export function loadSpaces(): PersistedSpacesFile | null {
+  const outcome = readSpacesFile()
+  return outcome.status === 'ok' ? outcome.file : null
+}
+
+export function saveSpaces(data: PersistedSpacesFile): void {
+  try {
+    const p = spacesPath()
+    const tmpPath = p + '.tmp'
+    fs.writeFileSync(tmpPath, JSON.stringify(data, null, 2))
+    fs.renameSync(tmpPath, p)
+  } catch (err) {
+    // The next debounced/sync save will retry, but log so a persistent failure
+    // (e.g. a read-only userData dir) is diagnosable rather than silent.
+    console.error('[spaces] failed to save spaces.json:', err)
+  }
+}
+
+/** Move an unusable (corrupt or newer-schema) spaces.json aside so its data is
+ *  never silently overwritten by the fresh file the renderer will persist. */
+function preserveUnusableSpacesFile(kind: 'corrupt' | 'unsupported'): void {
+  try {
+    const p = spacesPath()
+    if (!fs.existsSync(p)) return
+    const stamp = new Date().toISOString().replace(/[:.]/g, '-')
+    const backup = `${p}.${kind}-${stamp}.bak`
+    try {
+      // Move it aside so the path is free for the fresh file the renderer writes.
+      fs.renameSync(p, backup)
+    } catch {
+      // Rename can fail on some filesystems or under a transient lock — fall back
+      // to a copy so the original data still survives the next save that
+      // overwrites the file in place.
+      fs.copyFileSync(p, backup)
+    }
+    console.error(`[spaces] preserved ${kind} spaces.json as ${backup}`)
+  } catch (err) {
+    // Best-effort — if we can't move it aside we leave it in place and still
+    // start fresh in the renderer.
+    console.error('[spaces] failed to preserve unusable spaces.json:', err)
+  }
+}
+
+/**
+ * One-time migration: if no spaces.json exists yet but a legacy flat
+ * sessions.json workspace does, wrap that workspace into a single "My Work"
+ * Space and make it active. The legacy file is left untouched (read-only) until
+ * the renderer performs its first spaces.json write, so nothing is lost if the
+ * migration is interrupted. Returns null when there is nothing to migrate.
+ */
+export function migrateLegacyWorkspace(): PersistedSpacesFile | null {
+  const legacy = loadWorkspace()
+  if (!legacy) return null
+  const now = Date.now()
+  return {
+    version: SPACES_VERSION,
+    activeSpaceId: MIGRATED_SPACE_ID,
+    spaces: [
+      {
+        id: MIGRATED_SPACE_ID,
+        name: MIGRATED_SPACE_NAME,
+        color: MIGRATED_SPACE_COLOR,
+        projectIds: [],
+        workspace: legacy,
+        createdAt: now,
+        updatedAt: now,
+        lastActiveAt: now
+      }
+    ]
+  }
+}
+
+/** Load persisted spaces, migrating a legacy workspace on first run. Returns
+ *  null when there is no usable file and nothing to migrate — or when an
+ *  existing file is corrupt/unsupported (in which case it is preserved, not
+ *  overwritten, and the renderer starts fresh in memory). */
+export function loadOrMigrateSpaces(): PersistedSpacesFile | null {
+  const outcome = readSpacesFile()
+  if (outcome.status === 'ok') return outcome.file
+  if (outcome.status === 'corrupt' || outcome.status === 'unsupported') {
+    // Never migrate over or down-convert a file we can't use — move it aside so
+    // nothing is silently lost, then start fresh. The next real workspace change
+    // persists a clean spaces.json in its place.
+    preserveUnusableSpacesFile(outcome.status)
+    return null
+  }
+  // Genuinely absent → safe to migrate a legacy workspace (if any exists).
+  const migrated = migrateLegacyWorkspace()
+  if (migrated) {
+    // Persist the migrated file immediately. Otherwise a workspace autosave
+    // fired during the renderer's async boot could overwrite the legacy
+    // sessions.json with an empty workspace before spaces.json exists,
+    // losing the migration source with nothing durable to replace it.
+    saveSpaces(migrated)
+  }
+  return migrated
+}

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -2,6 +2,7 @@ import { contextBridge, ipcRenderer } from 'electron'
 import { electronAPI } from '@electron-toolkit/preload'
 import type { AttentionSnapshot } from './attentionTypes'
 import type { UpdateState } from './updateTypes'
+import type { PersistedSpacesFile } from '../main/services/spacesPersistence'
 import type {
   CreateWorktreeOptions,
   CreateWorktreeResult,
@@ -165,6 +166,11 @@ export interface DplexAPI {
       }) => void
     ) => () => void
     onSessionRemoved: (callback: (sessionId: string, providerId: string) => void) => () => void
+  }
+  spaces: {
+    load: () => Promise<PersistedSpacesFile | null>
+    save: (data: PersistedSpacesFile) => Promise<void>
+    saveSync: (data: PersistedSpacesFile) => void
   }
   settings: {
     getAll: () => Promise<Record<string, unknown>>
@@ -357,6 +363,11 @@ const dplexAPI: DplexAPI = {
       ipcRenderer.on('sessions:removed', handler)
       return () => ipcRenderer.removeListener('sessions:removed', handler)
     }
+  },
+  spaces: {
+    load: () => ipcRenderer.invoke('spaces:load'),
+    save: (data) => ipcRenderer.invoke('spaces:save', data),
+    saveSync: (data) => ipcRenderer.sendSync('spaces:saveSync', data)
   },
   settings: {
     getAll: () => ipcRenderer.invoke('settings:getAll'),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -9,6 +9,7 @@ import { useProjectStore } from './stores/projectStore'
 import { useProvidersStore } from './stores/providersStore'
 import { useUpdateStore } from './stores/updateStore'
 import { useCommandPaletteStore } from './stores/commandPaletteStore'
+import { useSpaceStore } from './stores/spaceStore'
 import { requestCloseTab } from './stores/closeConfirmStore'
 import { getFileEditorHandle } from './services/fileEditorRegistry'
 import { isFileEditorTab } from './types'
@@ -50,6 +51,9 @@ function App(): React.JSX.Element {
 
       if (meta && e.key === 't') {
         e.preventDefault()
+        // Suppress until Spaces hydrate: a tab spawned now would be discarded
+        // (and its PTY leaked) by the pending hydrate's workspace swap.
+        if (!useSpaceStore.getState().loaded) return
         void openInheritedTerminal(state.activeGroupId ?? undefined)
       }
 
@@ -151,7 +155,14 @@ function App(): React.JSX.Element {
         if (state.activeGroupId) void openInheritedSplit(state.activeGroupId, 'vertical')
       }
 
-      if (meta && e.key >= '1' && e.key <= '9') {
+      // Key off the physical digit (e.code) so numeric tab-switching works on
+      // every keyboard layout — on AZERTY the number row needs Shift to emit
+      // '1'..'9', so an e.key range check would silently break it there. Require
+      // NO shift and NO alt: the Space quick-switch (AppLayout) is
+      // Cmd/Ctrl+Shift+Digit1..9, and excluding Alt keeps AltGr (Ctrl+Alt on
+      // Windows/Linux) number-row input from being hijacked as a tab switch.
+      const tabDigit = meta && !e.shiftKey && !e.altKey ? /^Digit([1-9])$/.exec(e.code) : null
+      if (tabDigit) {
         e.preventDefault()
         // Flatten groups in visual (layout-tree) order, then concatenate
         // their tabs so CMD/CTRL+1..9 selects the Nth tab globally across
@@ -181,7 +192,7 @@ function App(): React.JSX.Element {
         const flatTabs = orderedGroups.flatMap((g) =>
           g.tabs.filter(isVisible).map((t) => ({ groupId: g.id, tabId: t.id }))
         )
-        const idx = parseInt(e.key) - 1
+        const idx = parseInt(tabDigit[1], 10) - 1
         if (idx < flatTabs.length) {
           const target = flatTabs[idx]
           setActiveGroup(target.groupId)

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -759,3 +759,105 @@ body {
   animation: dplex-setting-pulse 3s ease-out 1;
   border-radius: 6px;
 }
+
+/* ============================================================ Spaces feature
+   Shared presentation for the Spaces switcher, sidebar panel, mission-control
+   overview, create/rename modal, and background-attention toasts. */
+
+@keyframes dplex-pop {
+  from {
+    opacity: 0;
+    transform: scale(0.97) translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.dplex-pop {
+  animation: dplex-pop 0.16s ease;
+}
+
+@keyframes dplex-rise {
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+@keyframes dplex-slidein {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+.dplex-slidein {
+  animation: dplex-slidein 0.3s cubic-bezier(0.2, 0.7, 0.3, 1);
+}
+
+/* Pulsing ring on a space avatar that is calling for attention. */
+@keyframes dplex-space-ping {
+  0%,
+  100% {
+    box-shadow: 0 0 0 0 color-mix(in srgb, var(--dplex-status-approval) 60%, transparent);
+  }
+  50% {
+    box-shadow: 0 0 0 6px transparent;
+  }
+}
+.dplex-space-ping {
+  animation: dplex-space-ping 2s ease-in-out infinite;
+}
+
+/* Mission-control card entrance — staggered via inline --dplex-card-i. */
+.dplex-space-card {
+  opacity: 0;
+  transform: translateY(14px);
+  animation: dplex-rise 0.5s cubic-bezier(0.2, 0.7, 0.3, 1) forwards;
+  animation-delay: calc(var(--dplex-card-i, 0) * 55ms);
+}
+
+/* Uppercase field label used in the space modal. */
+.dplex-field-label {
+  display: block;
+  margin-bottom: 7px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--dplex-text-faint);
+}
+
+/* Color swatch in the space modal. */
+.dplex-swatch {
+  width: 28px;
+  height: 28px;
+  border-radius: 9px;
+  position: relative;
+  transition: transform 0.14s;
+}
+.dplex-swatch:hover {
+  transform: scale(1.1);
+}
+.dplex-swatch[aria-selected='true']::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 12px;
+  border: 2px solid var(--dplex-text);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dplex-pop,
+  .dplex-slidein,
+  .dplex-space-ping,
+  .dplex-space-card {
+    animation: none;
+    opacity: 1;
+    transform: none;
+  }
+}

--- a/src/renderer/src/components/layout/ActivityBar.tsx
+++ b/src/renderer/src/components/layout/ActivityBar.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useMemo, useRef, useState, type DragEvent } from 'react'
 import {
   FolderOpen,
   Clock,
@@ -6,34 +6,39 @@ import {
   Settings,
   Search,
   Files,
-  LayoutDashboard
+  LayoutDashboard,
+  Layers,
+  ArrowUp,
+  ArrowDown
 } from 'lucide-react'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useGitPanelStore } from '../../stores/gitPanelStore'
 import { useProjectStore } from '../../stores/projectStore'
 import { useAttentionStore } from '../../stores/attentionStore'
 import { useTerminalStore } from '../../stores/terminalStore'
-import { isDashboardTab } from '../../types'
+import { isDashboardTab, type ActivityBarId } from '../../types'
 import { MOD, SHIFT } from '../../utils/shortcuts'
-
-type ActivityId = 'search' | 'projects' | 'sessions' | 'git' | 'explorer'
+import { useBackgroundAttention } from '../../hooks/useSpaceAttention'
+import { attentionColorVar } from '../spaces/spaceVisuals'
+import { PopoverMenu } from '../common/PopoverMenu'
+import { reconcileActivityBarOrder, reorderActivityBar } from '../../utils/activityBarOrder'
 
 interface ActivityItem {
-  id: ActivityId
   label: string
   shortcut?: string
   Icon: typeof FolderOpen
 }
 
-const ITEMS: ActivityItem[] = [
-  { id: 'projects', label: 'Projects', Icon: FolderOpen },
+const ITEM_BY_ID: Record<ActivityBarId, ActivityItem> = {
+  projects: { label: 'Projects', Icon: FolderOpen },
+  spaces: { label: 'Spaces', Icon: Layers },
   // Plain Clock matches the v2 mockup; reads as "recent / past sessions"
   // and stays visually distinct from the GitBranch "history" association.
-  { id: 'sessions', label: 'Sessions', Icon: Clock },
-  { id: 'explorer', label: 'Explorer', shortcut: `${MOD}${SHIFT}E`, Icon: Files },
-  { id: 'git', label: 'Source Control', shortcut: `${MOD}${SHIFT}G`, Icon: GitBranch },
-  { id: 'search', label: 'Search', shortcut: `${MOD}${SHIFT}F`, Icon: Search }
-]
+  sessions: { label: 'Sessions', Icon: Clock },
+  explorer: { label: 'Explorer', shortcut: `${MOD}${SHIFT}E`, Icon: Files },
+  git: { label: 'Source Control', shortcut: `${MOD}${SHIFT}G`, Icon: GitBranch },
+  search: { label: 'Search', shortcut: `${MOD}${SHIFT}F`, Icon: Search }
+}
 
 // v2 rail — wider footprint for the larger active-state stripe + glow.
 const BAR_WIDTH = 56
@@ -45,7 +50,94 @@ interface ActivityBarProps {
 export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Element {
   const activeTab = useSettingsStore((s) => s.settings.sidebarActiveTab)
   const panelCollapsed = useSettingsStore((s) => s.settings.sidebarPanelCollapsed)
+  const activityBarOrder = useSettingsStore((s) => s.settings.activityBarOrder)
   const updateSettings = useSettingsStore((s) => s.updateSettings)
+
+  // The rendered order, normalized against the canonical set so unknown/missing
+  // ids never break the rail (robust across added or removed views).
+  const order = useMemo(() => reconcileActivityBarOrder(activityBarOrder), [activityBarOrder])
+
+  // Drag-to-reorder state. `dropTarget` holds the item under the cursor and
+  // which edge the dragged icon would land on, driving the insertion line.
+  const [dragId, setDragId] = useState<ActivityBarId | null>(null)
+  const [dropTarget, setDropTarget] = useState<{ id: ActivityBarId; after: boolean } | null>(null)
+
+  // Keyboard/right-click reorder: a context menu with Move up / Move down, an
+  // accessible alternative to drag (mirrors the projects list). Anchored to the
+  // icon that opened it.
+  const [menuId, setMenuId] = useState<ActivityBarId | null>(null)
+  const menuAnchorRef = useRef<HTMLButtonElement | null>(null)
+
+  const persistOrder = (next: ActivityBarId[]): void => {
+    if (next.some((id, i) => id !== order[i])) updateSettings({ activityBarOrder: next })
+  }
+
+  const isReorderDrag = (e: DragEvent): boolean =>
+    e.dataTransfer.types.includes('dplex/activity-id')
+
+  const handleDragStart = (e: DragEvent, id: ActivityBarId): void => {
+    e.dataTransfer.setData('dplex/activity-id', id)
+    e.dataTransfer.effectAllowed = 'move'
+    setDragId(id)
+  }
+
+  const handleDragOver = (e: DragEvent, id: ActivityBarId): void => {
+    if (!isReorderDrag(e)) return
+    // Accept the drop; without preventDefault the browser rejects it.
+    e.preventDefault()
+    e.dataTransfer.dropEffect = 'move'
+    if (id === dragId) {
+      setDropTarget(null)
+      return
+    }
+    const rect = e.currentTarget.getBoundingClientRect()
+    const after = e.clientY > rect.top + rect.height / 2
+    setDropTarget((cur) => (cur?.id === id && cur.after === after ? cur : { id, after }))
+  }
+
+  const handleDragLeave = (id: ActivityBarId): void => {
+    setDropTarget((cur) => (cur?.id === id ? null : cur))
+  }
+
+  const handleDrop = (e: DragEvent, targetId: ActivityBarId): void => {
+    if (!isReorderDrag(e)) return
+    e.preventDefault()
+    const draggedId = (e.dataTransfer.getData('dplex/activity-id') || dragId) as ActivityBarId | ''
+    const rect = e.currentTarget.getBoundingClientRect()
+    const after = e.clientY > rect.top + rect.height / 2
+    setDragId(null)
+    setDropTarget(null)
+    if (!draggedId || draggedId === targetId) return
+    persistOrder(reorderActivityBar(order, draggedId, targetId, after ? 'after' : 'before'))
+  }
+
+  const handleDragEnd = (): void => {
+    setDragId(null)
+    setDropTarget(null)
+  }
+
+  const openMenu = (e: React.MouseEvent<HTMLButtonElement>, id: ActivityBarId): void => {
+    e.preventDefault()
+    menuAnchorRef.current = e.currentTarget
+    setMenuId(id)
+  }
+
+  const moveItem = (id: ActivityBarId, dir: 'up' | 'down'): void => {
+    const i = order.indexOf(id)
+    const targetId = dir === 'up' ? order[i - 1] : order[i + 1]
+    setMenuId(null)
+    if (!targetId) return
+    persistOrder(reorderActivityBar(order, id, targetId, dir === 'up' ? 'before' : 'after'))
+  }
+
+  const select = (id: ActivityBarId): void => {
+    if (id === activeTab && !panelCollapsed) {
+      // Click active item again → collapse the panel (VSCode behavior).
+      updateSettings({ sidebarPanelCollapsed: true })
+      return
+    }
+    updateSettings({ sidebarActiveTab: id, sidebarPanelCollapsed: false })
+  }
 
   // Source-control change count for the active project.
   const byRepo = useGitPanelStore((s) => s.byRepo)
@@ -62,6 +154,9 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
   // Sessions attention dot — show whenever the inbox has any active events.
   const attentionCount = useAttentionStore((s) => s.active.length)
 
+  // Spaces ring — pings when a backgrounded space needs a decision.
+  const bgAttention = useBackgroundAttention()
+
   // Whether the focused editor tab is the Overview Dashboard.
   const dashboardActive = useTerminalStore((s) => {
     const group = s.groups.find((g) => g.id === s.activeGroupId)
@@ -70,15 +165,6 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
     return !!tab && isDashboardTab(tab)
   })
   const openDashboard = useTerminalStore((s) => s.openOrFocusDashboardTab)
-
-  const select = (id: ActivityId): void => {
-    if (id === activeTab && !panelCollapsed) {
-      // Click active item again → collapse the panel (VSCode behavior).
-      updateSettings({ sidebarPanelCollapsed: true })
-      return
-    }
-    updateSettings({ sidebarActiveTab: id, sidebarPanelCollapsed: false })
-  }
 
   return (
     <div
@@ -137,12 +223,20 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
           backgroundColor: 'var(--dplex-border-subtle)'
         }}
       />
-      {ITEMS.map(({ id, label, shortcut, Icon }) => {
+      {order.map((id) => {
+        const { label, shortcut, Icon } = ITEM_BY_ID[id]
         const isActive = activeTab === id && !panelCollapsed
         const badge =
           id === 'git' && gitCount > 0 ? (gitCount > 99 ? '99+' : String(gitCount)) : null
         const showAttn = id === 'sessions' && attentionCount > 0
+        const spacesAttnColor =
+          id === 'spaces' && bgAttention.total > 0 && bgAttention.topKind
+            ? attentionColorVar(bgAttention.topKind)
+            : null
         const title = shortcut ? `${label} (${shortcut})` : label
+        const isDragging = dragId === id
+        const showInsertBefore = dropTarget?.id === id && !dropTarget.after
+        const showInsertAfter = dropTarget?.id === id && dropTarget.after
         return (
           <button
             key={id}
@@ -151,7 +245,14 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
             aria-selected={isActive}
             aria-label={label}
             title={title}
+            draggable
             onClick={() => select(id)}
+            onContextMenu={(e) => openMenu(e, id)}
+            onDragStart={(e) => handleDragStart(e, id)}
+            onDragOver={(e) => handleDragOver(e, id)}
+            onDragLeave={() => handleDragLeave(id)}
+            onDrop={(e) => handleDrop(e, id)}
+            onDragEnd={handleDragEnd}
             data-testid={`activity-bar-${id}`}
             className="relative grid place-items-center transition-colors"
             style={{
@@ -159,6 +260,8 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
               height: 40,
               marginBottom: 4,
               borderRadius: 10,
+              cursor: 'grab',
+              opacity: isDragging ? 0.4 : 1,
               color: isActive ? 'var(--dplex-accent)' : 'var(--dplex-text-dim)',
               backgroundColor: isActive ? 'var(--dplex-accent-soft)' : 'transparent'
             }}
@@ -177,6 +280,23 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
                 : 'var(--dplex-text-dim)'
             }}
           >
+            {(showInsertBefore || showInsertAfter) && (
+              <span
+                data-testid={`activity-bar-${id}-drop`}
+                aria-hidden
+                className="absolute"
+                style={{
+                  left: 2,
+                  right: 2,
+                  height: 2,
+                  borderRadius: 1,
+                  top: showInsertBefore ? -3 : undefined,
+                  bottom: showInsertAfter ? -3 : undefined,
+                  backgroundColor: 'var(--dplex-accent)',
+                  boxShadow: '0 0 8px var(--dplex-accent-glow)'
+                }}
+              />
+            )}
             {isActive && (
               <span
                 aria-hidden
@@ -237,9 +357,53 @@ export function ActivityBar({ onOpenSettings }: ActivityBarProps): React.JSX.Ele
                 }}
               />
             )}
+            {spacesAttnColor && (
+              <span
+                data-testid="activity-bar-spaces-attn"
+                aria-hidden
+                className="absolute dplex-pulse-dot"
+                style={{
+                  top: 5,
+                  right: 5,
+                  width: 7,
+                  height: 7,
+                  borderRadius: '50%',
+                  backgroundColor: spacesAttnColor,
+                  boxShadow: `0 0 0 2px var(--dplex-bg-activity), 0 0 8px ${spacesAttnColor}`
+                }}
+              />
+            )}
           </button>
         )
       })}
+      {menuId && (
+        <PopoverMenu
+          anchorRef={menuAnchorRef}
+          open
+          onClose={() => setMenuId(null)}
+          align="left"
+          className="min-w-[150px]"
+        >
+          <button
+            type="button"
+            disabled={order.indexOf(menuId) === 0}
+            onClick={() => moveItem(menuId, 'up')}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            <ArrowUp size={11} /> Move up
+          </button>
+          <button
+            type="button"
+            disabled={order.indexOf(menuId) === order.length - 1}
+            onClick={() => moveItem(menuId, 'down')}
+            className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)] disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-transparent"
+            style={{ color: 'var(--dplex-text)' }}
+          >
+            <ArrowDown size={11} /> Move down
+          </button>
+        </PopoverMenu>
+      )}
       <div className="flex-1" />
       <button
         type="button"

--- a/src/renderer/src/components/layout/AppLayout.tsx
+++ b/src/renderer/src/components/layout/AppLayout.tsx
@@ -4,7 +4,7 @@ import { useTerminalStore } from '../../stores/terminalStore'
 import { persistWorkspaceNow } from '../../stores/terminalStore'
 import { useSettingsStore, applyCssVarsSync } from '../../stores/settingsStore'
 import { useAttentionStore } from '../../stores/attentionStore'
-import { useCommandPaletteStore } from '../../stores/commandPaletteStore'
+import { useSpaceStore } from '../../stores/spaceStore'
 import { SidePanel } from './SidePanel'
 import { ActivityBar } from './ActivityBar'
 import { StatusBar } from './StatusBar'
@@ -15,9 +15,15 @@ import { ExternalResumeConfirmModal } from '../common/ExternalResumeConfirmModal
 import { AttentionBellButton } from '../attention/AttentionBellButton'
 import { ProjectFocusControl } from './ProjectFocusControl'
 import { DPlexLogo } from '../common/DPlexLogo'
+import { SpaceSwitcher } from '../spaces/SpaceSwitcher'
+import { SpacesOverview } from '../spaces/SpacesOverview'
+import { SpaceWelcome } from '../spaces/SpaceWelcome'
+import { SpaceModal } from '../spaces/SpaceModal'
+import { SpaceDeleteConfirm } from '../spaces/SpaceDeleteConfirm'
+import { SpaceAttentionToasts } from '../spaces/SpaceAttentionToasts'
 import { useSessions } from '../../hooks/useSessions'
 import { getTheme } from '../../services/themes'
-import { MOD } from '../../utils/shortcuts'
+import { isMac } from '../../utils/shortcuts'
 import { focusSessionTab } from '../../utils/sessionTabs'
 import { wireGitPanelGlobals } from '../../stores/gitPanelStore'
 import { wireGitGraphGlobals } from '../../stores/gitGraphStore'
@@ -25,127 +31,14 @@ import { wireFileExplorerGlobals } from '../../stores/fileExplorerStore'
 import { wireFocusController, disableFocus } from '../../stores/tabFocusStore'
 import { useFocusFilter } from '../../hooks/useFocusFilter'
 import { pruneLayoutToGroups } from '../../utils/tabFocus'
-import type {
-  TerminalTab,
-  FileDiffTab,
-  FileEditorTab,
-  DashboardTab,
-  EditorTab,
-  EditorGroup,
-  LayoutNode
-} from '../../types'
 import { isTerminalTab } from '../../types'
-
-async function loadPersistedWorkspace(): Promise<{
-  groups: EditorGroup[]
-  layout: LayoutNode
-  activeGroupId: string | null
-} | null> {
-  try {
-    type PersistedTab =
-      | (TerminalTab & { kind?: 'terminal' })
-      | (FileDiffTab & { kind: 'fileDiff' })
-      | (FileEditorTab & { kind: 'fileEditor' })
-      | (DashboardTab & { kind: 'dashboard' })
-      | { kind: 'diff' } // Legacy repo-level diff tab — quietly dropped on restore.
-    const data = (await window.dplex.sessions.loadWorkspace()) as {
-      groups: Array<{
-        id: string
-        tabs: PersistedTab[]
-        activeTabId: string
-        previewTabId?: string
-      }>
-      layout: LayoutNode
-      activeGroupId: string | null
-    } | null
-    if (!data || !data.groups || !data.layout) return null
-
-    const restoredGroups: EditorGroup[] = []
-    for (const g of data.groups) {
-      // Keep fileDiff tabs as-is; AI terminal tabs (command present) get
-      // resume commands; plain shells are dropped (we never persisted them).
-      // Legacy `kind: 'diff'` repo-level diff tabs are quietly dropped — the
-      // Git panel replaces that experience.
-      const keepers = (g.tabs || []).filter((t) => {
-        if (t.kind === 'diff') return false
-        if (t.kind === 'fileDiff') return true
-        if (t.kind === 'fileEditor') return true
-        if (t.kind === 'dashboard') return true
-        return !!(t as TerminalTab).command
-      })
-      if (keepers.length === 0) continue
-
-      const preparedTabs: EditorTab[] = await Promise.all(
-        keepers.map(async (t): Promise<EditorTab> => {
-          if (t.kind === 'dashboard') {
-            return { ...(t as DashboardTab) }
-          }
-          if (t.kind === 'fileDiff') {
-            const ft = t as FileDiffTab
-            // Restored fileDiff tabs are always permanent — preview tabs
-            // weren't persisted. Defensive scrub in case of future schema drift.
-            return { ...ft, preview: false }
-          }
-          if (t.kind === 'fileEditor') {
-            const fe = t as FileEditorTab
-            // Permanent only; the editor lazy-loads content and renders a
-            // "file missing" state if the path no longer exists.
-            return { ...fe, preview: false, dirty: false }
-          }
-          const tt = t as TerminalTab
-          if (!tt.sessionId) return { ...tt }
-          if (tt.providerId) {
-            try {
-              const cmd = await window.dplex.sessions.getResumeCommand(tt.providerId, tt.sessionId)
-              if (cmd) return { ...tt, command: cmd }
-            } catch {
-              // Provider lookup failed transiently. Preserve the persisted
-              // command as-is rather than blindly applying Copilot's
-              // `--resume=<id>` shape, which is wrong for other providers.
-            }
-            return { ...tt }
-          }
-          if (tt.command && !tt.command.includes('--resume')) {
-            return { ...tt, command: `${tt.command} --resume=${tt.sessionId}` }
-          }
-          return { ...tt }
-        })
-      )
-
-      restoredGroups.push({
-        id: g.id,
-        tabs: preparedTabs,
-        activeTabId: preparedTabs.find((t) => t.id === g.activeTabId)?.id ?? preparedTabs[0].id
-        // previewTabId is intentionally not restored.
-      })
-    }
-
-    if (restoredGroups.length === 0) return null
-
-    // Prune layout to only include valid (non-empty) groups
-    const validIds = new Set(restoredGroups.map((g) => g.id))
-    const prunedLayout = pruneLayoutToGroups(data.layout, validIds)
-    if (!prunedLayout) return null
-
-    // Ensure activeGroupId references a valid group
-    const activeGroupId = validIds.has(data.activeGroupId ?? '')
-      ? data.activeGroupId
-      : restoredGroups[0].id
-
-    return {
-      groups: restoredGroups,
-      layout: prunedLayout,
-      activeGroupId
-    }
-  } catch {
-    return null
-  }
-}
 
 export function AppLayout(): React.JSX.Element {
   const groups = useTerminalStore((s) => s.groups)
   const layout = useTerminalStore((s) => s.layout)
-  const createTerminal = useTerminalStore((s) => s.createTerminal)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  const spaces = useSpaceStore((s) => s.spaces)
+  const spaceLoaded = useSpaceStore((s) => s.loaded)
   const themeId = useSettingsStore((s) => s.settings.theme)
   const [settingsOpen, setSettingsOpen] = useState(false)
 
@@ -163,6 +56,7 @@ export function AppLayout(): React.JSX.Element {
     () => (visibleGroupIds ? pruneLayoutToGroups(layout, visibleGroupIds) : layout),
     [visibleGroupIds, layout]
   )
+  const activeSpace = activeSpaceId ? (spaces.find((s) => s.id === activeSpaceId) ?? null) : null
 
   useEffect(() => {
     const handler = (): void => setSettingsOpen(true)
@@ -181,22 +75,23 @@ export function AppLayout(): React.JSX.Element {
 
   const initialized = useRef(false)
   const settingsLoaded = useSettingsStore((s) => s.loaded)
-  const restored = useTerminalStore((s) => s.restored)
 
+  // Boot: load + migrate Spaces, restore the active space's arrangement, and
+  // ensure a terminal exists if a space is in focus but empty (fresh install /
+  // migrated-empty). When no space is in focus we intentionally do nothing —
+  // the Overview is the home base and must not auto-spawn an orphan terminal.
   useEffect(() => {
-    if (!initialized.current && settingsLoaded && groups.length === 0 && !restored) {
-      initialized.current = true
-      // Try to restore persisted workspace, fall back to fresh terminal
-      loadPersistedWorkspace().then((workspace) => {
-        if (workspace) {
-          useTerminalStore
-            .getState()
-            .restoreWorkspace(workspace.groups, workspace.layout, workspace.activeGroupId)
-        } else {
-          createTerminal()
+    if (initialized.current || !settingsLoaded) return
+    initialized.current = true
+    void useSpaceStore
+      .getState()
+      .hydrate()
+      .then(() => {
+        const { activeSpaceId: activeId } = useSpaceStore.getState()
+        if (activeId && useTerminalStore.getState().groups.length === 0) {
+          useTerminalStore.getState().createTerminal()
         }
       })
-    }
   }, [settingsLoaded])
 
   // Save workspace before the window unloads
@@ -206,6 +101,37 @@ export function AppLayout(): React.JSX.Element {
     }
     window.addEventListener('beforeunload', handleBeforeUnload)
     return () => window.removeEventListener('beforeunload', handleBeforeUnload)
+  }, [])
+
+  // Cmd/Ctrl+Shift+1..9 quick-switches to the Nth space. Keyed off `e.code`
+  // (Digit1..Digit9) so it is layout- and shift-independent, and suppressed
+  // while typing. Cmd/Ctrl+1..9 alone is already bound to tab switching, so
+  // Spaces take the Shift modifier. On macOS, Cmd+Shift+3/4/5 are reserved by
+  // the OS for screenshots (the OS still delivers the event, but acting on it
+  // would fight the screenshot UI), so those three positions are skipped there.
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent): void => {
+      const mod = e.metaKey || e.ctrlKey
+      if (!mod || !e.shiftKey || e.altKey) return
+      const m = /^Digit([1-9])$/.exec(e.code)
+      if (!m) return
+      if (!useSpaceStore.getState().loaded) return
+      const target = e.target as HTMLElement | null
+      if (target) {
+        const tag = target.tagName
+        if (tag === 'INPUT' || tag === 'TEXTAREA' || target.isContentEditable) return
+      }
+      const digit = parseInt(m[1], 10)
+      if (isMac && (digit === 3 || digit === 4 || digit === 5)) return
+      const idx = digit - 1
+      const spaces = useSpaceStore.getState().spaces
+      if (idx < spaces.length) {
+        e.preventDefault()
+        useSpaceStore.getState().switchSpace(spaces[idx].id)
+      }
+    }
+    window.addEventListener('keydown', onKeyDown)
+    return () => window.removeEventListener('keydown', onKeyDown)
   }, [])
 
   // Listen for settings open event from keyboard shortcut
@@ -296,7 +222,9 @@ export function AppLayout(): React.JSX.Element {
   // notification decisions tab-aware (only suppress when user is looking at
   // THIS session). Also auto-ack `finished` when that tab becomes active.
   useEffect(() => {
-    const computeActiveComposite = (state: ReturnType<typeof useTerminalStore.getState>) => {
+    const computeActiveComposite = (
+      state: ReturnType<typeof useTerminalStore.getState>
+    ): string | null => {
       const activeGroup = state.groups.find((g) => g.id === state.activeGroupId)
       if (!activeGroup) return null
       const tab = activeGroup.tabs.find((t) => t.id === activeGroup.activeTabId)
@@ -357,232 +285,56 @@ export function AppLayout(): React.JSX.Element {
         <SidePanel />
 
         <div className="flex flex-col flex-1 min-w-0">
-          <div className="flex-1 min-w-0 min-h-0">
-            {groups.length > 0 ? (
-              effLayout ? (
-                <GroupLayout node={effLayout} />
-              ) : (
-                <div
-                  className="flex items-center justify-center h-full px-6 text-center"
-                  style={{ backgroundColor: 'var(--dplex-bg)' }}
-                >
-                  <div className="flex flex-col items-center gap-4 max-w-sm">
-                    <Focus size={28} style={{ color: 'var(--dplex-text-dim)' }} />
-                    <div className="flex flex-col gap-1">
-                      <p className="text-sm font-medium" style={{ color: 'var(--dplex-text)' }}>
-                        No tabs for this project
-                      </p>
-                      <p className="text-xs" style={{ color: 'var(--dplex-text-muted)' }}>
-                        Focus is isolating a project with no open tabs.
-                      </p>
+          {activeSpaceId === null ? (
+            <div className="flex-1 min-w-0 min-h-0 relative">
+              {/* Hold the Overview until Spaces have hydrated: rendering it
+                  (and its create/switch controls) mid-boot lets the user
+                  mutate state that the pending hydrate would then clobber. */}
+              {spaceLoaded ? <SpacesOverview /> : null}
+            </div>
+          ) : (
+            <>
+              <SpaceSwitcher />
+              <div className="flex-1 min-w-0 min-h-0">
+                {groups.length > 0 ? (
+                  effLayout ? (
+                    <GroupLayout node={effLayout} />
+                  ) : (
+                    <div
+                      className="flex items-center justify-center h-full px-6 text-center"
+                      style={{ backgroundColor: 'var(--dplex-bg)' }}
+                    >
+                      <div className="flex flex-col items-center gap-4 max-w-sm">
+                        <Focus size={28} style={{ color: 'var(--dplex-text-dim)' }} />
+                        <div className="flex flex-col gap-1">
+                          <p className="text-sm font-medium" style={{ color: 'var(--dplex-text)' }}>
+                            No tabs for this project
+                          </p>
+                          <p className="text-xs" style={{ color: 'var(--dplex-text-muted)' }}>
+                            Focus is isolating a project with no open tabs.
+                          </p>
+                        </div>
+                        <button
+                          onClick={() => disableFocus()}
+                          className="inline-flex items-center gap-1.5 px-3 rounded-full transition-colors"
+                          style={{
+                            height: 26,
+                            border: '1px solid var(--dplex-border)',
+                            color: 'var(--dplex-text)',
+                            backgroundColor: 'var(--dplex-bg-elev)'
+                          }}
+                        >
+                          Show all tabs
+                        </button>
+                      </div>
                     </div>
-                    <button
-                      onClick={() => disableFocus()}
-                      className="inline-flex items-center gap-1.5 px-3 rounded-full transition-colors"
-                      style={{
-                        height: 26,
-                        border: '1px solid var(--dplex-border)',
-                        color: 'var(--dplex-text)',
-                        backgroundColor: 'var(--dplex-bg-elev)'
-                      }}
-                    >
-                      Show all tabs
-                    </button>
-                  </div>
-                </div>
-              )
-            ) : (
-              <div
-                className="flex items-center justify-center h-full px-6"
-                style={{
-                  backgroundImage:
-                    'radial-gradient(ellipse 800px 400px at 50% 30%, var(--dplex-accent-faint) 0%, transparent 70%)'
-                }}
-              >
-                <div className="flex flex-col items-center gap-7 text-center max-w-md">
-                  <div
-                    aria-hidden
-                    className="relative flex items-center justify-center"
-                    style={{
-                      filter: 'drop-shadow(0 16px 40px var(--dplex-accent-glow))'
-                    }}
-                  >
-                    <DPlexLogo size={72} />
-                  </div>
-
-                  <div className="flex flex-col gap-2">
-                    <h1
-                      className="text-[28px] font-semibold tracking-tight"
-                      style={{ color: 'var(--dplex-text)', letterSpacing: '-0.02em' }}
-                    >
-                      Welcome to DPlex
-                    </h1>
-                    <p
-                      className="text-[14px] leading-relaxed"
-                      style={{ color: 'var(--dplex-text-muted)' }}
-                    >
-                      Your terminal multiplexer for AI-assisted development. Open a terminal, start
-                      an AI session, or jump straight into your projects.
-                    </p>
-                  </div>
-
-                  <div className="flex flex-col gap-2 w-full">
-                    <button
-                      onClick={() => createTerminal()}
-                      className="flex items-center gap-3 px-4 py-2.5 rounded-lg transition-all"
-                      style={{
-                        background: 'var(--dplex-bg-elev)',
-                        border: '1px solid var(--dplex-border)',
-                        color: 'var(--dplex-text)',
-                        textAlign: 'left',
-                        boxShadow: 'var(--dplex-shadow-sm)'
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.background = 'var(--dplex-bg-elev-2)'
-                        e.currentTarget.style.borderColor = 'var(--dplex-border-strong)'
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.background = 'var(--dplex-bg-elev)'
-                        e.currentTarget.style.borderColor = 'var(--dplex-border)'
-                      }}
-                    >
-                      <span
-                        aria-hidden
-                        className="grid place-items-center flex-shrink-0"
-                        style={{
-                          width: 28,
-                          height: 28,
-                          borderRadius: 8,
-                          background: 'var(--dplex-accent-soft)',
-                          border: '1px solid var(--dplex-accent-ring)',
-                          color: 'var(--dplex-accent)'
-                        }}
-                      >
-                        <svg
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <line x1="12" y1="5" x2="12" y2="19" />
-                          <line x1="5" y1="12" x2="19" y2="12" />
-                        </svg>
-                      </span>
-                      <span className="flex-1 text-[13px] font-medium">Open a new terminal</span>
-                      <kbd
-                        className="text-[10.5px] font-medium"
-                        style={{
-                          fontFamily: 'var(--dplex-font-mono)',
-                          color: 'var(--dplex-text-dim)',
-                          background: 'var(--dplex-bg-elev-2)',
-                          border: '1px solid var(--dplex-border-subtle)',
-                          borderRadius: 4,
-                          padding: '2px 6px'
-                        }}
-                      >
-                        {MOD}T
-                      </kbd>
-                    </button>
-
-                    <button
-                      onClick={() => useCommandPaletteStore.getState().toggle('all')}
-                      className="flex items-center gap-3 px-4 py-2.5 rounded-lg transition-all"
-                      style={{
-                        background: 'var(--dplex-bg-elev)',
-                        border: '1px solid var(--dplex-border)',
-                        color: 'var(--dplex-text)',
-                        textAlign: 'left',
-                        boxShadow: 'var(--dplex-shadow-sm)'
-                      }}
-                      onMouseEnter={(e) => {
-                        e.currentTarget.style.background = 'var(--dplex-bg-elev-2)'
-                        e.currentTarget.style.borderColor = 'var(--dplex-border-strong)'
-                      }}
-                      onMouseLeave={(e) => {
-                        e.currentTarget.style.background = 'var(--dplex-bg-elev)'
-                        e.currentTarget.style.borderColor = 'var(--dplex-border)'
-                      }}
-                    >
-                      <span
-                        aria-hidden
-                        className="grid place-items-center flex-shrink-0"
-                        style={{
-                          width: 28,
-                          height: 28,
-                          borderRadius: 8,
-                          background: 'var(--dplex-accent-soft)',
-                          border: '1px solid var(--dplex-accent-ring)',
-                          color: 'var(--dplex-accent)'
-                        }}
-                      >
-                        <svg
-                          width="14"
-                          height="14"
-                          viewBox="0 0 24 24"
-                          fill="none"
-                          stroke="currentColor"
-                          strokeWidth="2"
-                          strokeLinecap="round"
-                          strokeLinejoin="round"
-                        >
-                          <circle cx="11" cy="11" r="7" />
-                          <line x1="21" y1="21" x2="16.65" y2="16.65" />
-                        </svg>
-                      </span>
-                      <span className="flex-1 text-[13px] font-medium">
-                        Search projects &amp; sessions
-                      </span>
-                      <kbd
-                        className="text-[10.5px] font-medium"
-                        style={{
-                          fontFamily: 'var(--dplex-font-mono)',
-                          color: 'var(--dplex-text-dim)',
-                          background: 'var(--dplex-bg-elev-2)',
-                          border: '1px solid var(--dplex-border-subtle)',
-                          borderRadius: 4,
-                          padding: '2px 6px'
-                        }}
-                      >
-                        {MOD}P
-                      </kbd>
-                    </button>
-                  </div>
-
-                  <p className="text-[11px]" style={{ color: 'var(--dplex-text-faint)' }}>
-                    Press{' '}
-                    <kbd
-                      style={{
-                        fontFamily: 'var(--dplex-font-mono)',
-                        background: 'var(--dplex-bg-elev)',
-                        border: '1px solid var(--dplex-border-subtle)',
-                        borderRadius: 3,
-                        padding: '1px 5px'
-                      }}
-                    >
-                      {MOD},
-                    </kbd>{' '}
-                    to open settings, or{' '}
-                    <kbd
-                      style={{
-                        fontFamily: 'var(--dplex-font-mono)',
-                        background: 'var(--dplex-bg-elev)',
-                        border: '1px solid var(--dplex-border-subtle)',
-                        borderRadius: 3,
-                        padding: '1px 5px'
-                      }}
-                    >
-                      {MOD}B
-                    </kbd>{' '}
-                    to toggle the sidebar
-                  </p>
-                </div>
+                  )
+                ) : activeSpace ? (
+                  <SpaceWelcome space={activeSpace} />
+                ) : null}
               </div>
-            )}
-          </div>
+            </>
+          )}
 
           <StatusBar onOpenSettings={() => setSettingsOpen(true)} />
         </div>
@@ -591,6 +343,9 @@ export function AppLayout(): React.JSX.Element {
       <SettingsModal isOpen={settingsOpen} onClose={() => setSettingsOpen(false)} />
       <CloseConfirmModal />
       <ExternalResumeConfirmModal />
+      <SpaceModal />
+      <SpaceDeleteConfirm />
+      <SpaceAttentionToasts />
     </div>
   )
 }

--- a/src/renderer/src/components/layout/SidePanel.tsx
+++ b/src/renderer/src/components/layout/SidePanel.tsx
@@ -21,6 +21,7 @@ import { SessionPanelFooter } from '../sessions/SessionPanelFooter'
 import { GitSidePanelView } from '../git/GitSidePanelView'
 import { ExplorerSidePanelView } from '../explorer/ExplorerSidePanelView'
 import { SearchSidePanelView } from '../search/SearchSidePanelView'
+import { SpacesPanel } from '../spaces/SpacesPanel'
 
 export type SessionGroupMode = 'time' | 'workspace'
 
@@ -408,6 +409,8 @@ export function SidePanel(): React.JSX.Element | null {
         <ExplorerSidePanelView />
       ) : activeTab === 'search' ? (
         <SearchSidePanelView />
+      ) : activeTab === 'spaces' ? (
+        <SpacesPanel />
       ) : (
         <>
           <div

--- a/src/renderer/src/components/layout/StatusBar.tsx
+++ b/src/renderer/src/components/layout/StatusBar.tsx
@@ -1,7 +1,8 @@
-import { Terminal, PanelLeftOpen, PanelLeftClose, Settings, Search } from 'lucide-react'
+import { Terminal, PanelLeftOpen, PanelLeftClose, Settings, Search, Layers } from 'lucide-react'
 import { useTerminalStore } from '../../stores/terminalStore'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useSessionStore } from '../../stores/sessionStore'
+import { useSpaceStore } from '../../stores/spaceStore'
 import { useCommandPaletteStore } from '../../stores/commandPaletteStore'
 import { MOD } from '../../utils/shortcuts'
 
@@ -19,6 +20,12 @@ export function StatusBar({ onOpenSettings }: StatusBarProps): React.JSX.Element
   const toggleSidebar = useSettingsStore((s) => s.toggleSidebar)
   const sessions = useSessionStore((s) => s.sessions)
   const activeSessionCount = sessions.filter((s) => s.status === 'active').length
+  const activeSpace = useSpaceStore((s) => s.spaces.find((sp) => sp.id === s.activeSpaceId) ?? null)
+  const openSpaces = (): void => {
+    void useSettingsStore
+      .getState()
+      .updateSettings({ sidebarActiveTab: 'spaces', sidebarPanelCollapsed: false })
+  }
 
   return (
     <div
@@ -65,6 +72,33 @@ export function StatusBar({ onOpenSettings }: StatusBarProps): React.JSX.Element
           >
             {MOD}P
           </kbd>
+        </button>
+        <button
+          onClick={openSpaces}
+          data-testid="statusbar-space"
+          className="inline-flex items-center gap-1.5 px-2 rounded-full hover:bg-[var(--dplex-hover)] transition-colors flex-shrink-0 min-w-0"
+          style={{ height: 20, color: 'var(--dplex-text-muted)' }}
+          title={activeSpace ? `Space: ${activeSpace.name}` : 'No space in focus — open Spaces'}
+          aria-label={activeSpace ? `Active space: ${activeSpace.name}` : 'No space in focus'}
+        >
+          {activeSpace ? (
+            <span
+              aria-hidden
+              className="flex-shrink-0"
+              style={{
+                width: 8,
+                height: 8,
+                borderRadius: '50%',
+                backgroundColor: activeSpace.color,
+                boxShadow: `0 0 6px color-mix(in srgb, ${activeSpace.color} 70%, transparent)`
+              }}
+            />
+          ) : (
+            <Layers size={11} className="flex-shrink-0" style={{ opacity: 0.7 }} />
+          )}
+          <span className="truncate" style={{ maxWidth: 160 }}>
+            {activeSpace ? activeSpace.name : 'No space in focus'}
+          </span>
         </button>
       </div>
       <div className="flex items-center gap-3 pr-1 min-w-0">

--- a/src/renderer/src/components/projects/ProjectItem.tsx
+++ b/src/renderer/src/components/projects/ProjectItem.tsx
@@ -37,6 +37,7 @@ import { WorktreeSection } from './WorktreeSection'
 import type { ProjectActivity } from '../../hooks/useProjectSessions'
 import { focusFirstTabForPaths } from '../../utils/sessionTabs'
 import { colorSourceProject } from '../../utils/tabProject'
+import { startProjectSession, openProjectTerminal } from '../../utils/spaceStart'
 import { TAB_COLORS } from '../../utils/tabColors'
 import { PopoverMenu } from '../common/PopoverMenu'
 import { NewWorktreeModal } from '../worktrees/NewWorktreeModal'
@@ -100,10 +101,8 @@ export function ProjectItem({
   const reorderProject = useProjectStore((s) => s.reorderProject)
   const setProjectTabColor = useProjectStore((s) => s.setProjectTabColor)
   const allProjectsForColor = useProjectStore((s) => s.projects)
-  const startAISession = useProjectStore((s) => s.startAISession)
   const setActiveGroup = useTerminalStore((s) => s.setActiveGroup)
   const setActiveTerminalInGroup = useTerminalStore((s) => s.setActiveTerminalInGroup)
-  const createTerminal = useTerminalStore((s) => s.createTerminal)
   const deleteSession = useSessionStore((s) => s.deleteSession)
   const globalDefaults = useSettingsStore((s) => s.settings.worktreeDefaults)
   const defaultAITool = useSettingsStore((s) => s.settings.defaultAITool)
@@ -434,7 +433,7 @@ export function ProjectItem({
               key={primaryProvider.id}
               onClick={(e) => {
                 e.stopPropagation()
-                startAISession(project, primaryProvider.id)
+                startProjectSession(project, primaryProvider.id)
               }}
               className="p-1 hover:bg-[var(--dplex-hover)] rounded transition-colors"
               style={{ color: 'var(--dplex-text-muted)' }}
@@ -506,7 +505,7 @@ export function ProjectItem({
               key={primaryProvider.id}
               onClick={(e) => {
                 e.stopPropagation()
-                startAISession(project, primaryProvider.id)
+                startProjectSession(project, primaryProvider.id)
                 setShowMenu(false)
               }}
               className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
@@ -518,7 +517,7 @@ export function ProjectItem({
           <button
             onClick={(e) => {
               e.stopPropagation()
-              createTerminal(undefined, project.name, undefined, undefined, project.path)
+              openProjectTerminal(project)
               setShowMenu(false)
             }}
             className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
@@ -846,7 +845,8 @@ export function ProjectItem({
               afterCreate: result.afterCreate,
               providerId: result.providerId,
               setupScript: result.setupScript,
-              createdByDplexWorktree: true
+              createdByDplexWorktree: true,
+              originSpaceId: result.originSpaceId
             })
           }}
         />

--- a/src/renderer/src/components/projects/WorktreeSection.tsx
+++ b/src/renderer/src/components/projects/WorktreeSection.tsx
@@ -20,6 +20,7 @@ import { StatusPill } from '../common/StatusPill'
 import { type StatusVisual } from '../../utils/sessionStatusVisual'
 import { isMixedProviderList } from '../../utils/providerHelpers'
 import { pairTabsToSessions, type OpenTabWithGroup } from '../../utils/sessionPairing'
+import { startProjectSession, openProjectTerminal } from '../../utils/spaceStart'
 import { ProjectSessionList } from './ProjectSessionList'
 import { RemoveWorktreeProjectModal } from '../worktrees/RemoveWorktreeProjectModal'
 import { useWorktrees } from '../../hooks/useWorktrees'
@@ -67,8 +68,6 @@ export function WorktreeSection({
   const collapsedSections = useProjectStore((s) => s.collapsedWorktreeSections)
   const toggleWorktreeSection = useProjectStore((s) => s.toggleWorktreeSection)
   const setActiveProject = useProjectStore((s) => s.setActiveProject)
-  const startAISession = useProjectStore((s) => s.startAISession)
-  const createTerminal = useTerminalStore((s) => s.createTerminal)
   const setActiveGroup = useTerminalStore((s) => s.setActiveGroup)
   const setActiveTerminalInGroup = useTerminalStore((s) => s.setActiveTerminalInGroup)
   const deleteSession = useSessionStore((s) => s.deleteSession)
@@ -248,7 +247,7 @@ export function WorktreeSection({
             key={primaryProvider.id}
             onClick={(e) => {
               e.stopPropagation()
-              startAISession(project, primaryProvider.id)
+              startProjectSession(project, primaryProvider.id)
               setShowMenu(false)
             }}
             className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
@@ -260,7 +259,7 @@ export function WorktreeSection({
         <button
           onClick={(e) => {
             e.stopPropagation()
-            createTerminal(undefined, project.name, undefined, undefined, project.path)
+            openProjectTerminal(project)
             setShowMenu(false)
           }}
           className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"

--- a/src/renderer/src/components/search/useGlobalSearch.ts
+++ b/src/renderer/src/components/search/useGlobalSearch.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from 'react'
 import { defaultRegistry } from '../../services/search'
 import type { SearchCategory, SearchResultGroup } from '../../services/search/types'
 import { useProjectStore } from '../../stores/projectStore'
+import { useSpaceStore } from '../../stores/spaceStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useTerminalStore } from '../../stores/terminalStore'
 import { countItems, flattenGroups } from './searchResultUtils'
@@ -65,13 +66,15 @@ export function useGlobalSearch({
   // Subscribe to the upstream stores so results recompute when their data
   // changes (e.g. user adds a project while the palette is open).
   const projects = useProjectStore((s) => s.projects)
+  const spaces = useSpaceStore((s) => s.spaces)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
   const sessions = useSessionStore((s) => s.sessions)
   const groups = useTerminalStore((s) => s.groups)
   const activeGroupId = useTerminalStore((s) => s.activeGroupId)
 
   const ctx = useMemo(
-    () => ({ projects, sessions, groups, activeGroupId }),
-    [projects, sessions, groups, activeGroupId]
+    () => ({ projects, spaces, activeSpaceId, sessions, groups, activeGroupId }),
+    [projects, spaces, activeSpaceId, sessions, groups, activeGroupId]
   )
 
   // While the surface is closed, skip work entirely.

--- a/src/renderer/src/components/spaces/AttentionChip.tsx
+++ b/src/renderer/src/components/spaces/AttentionChip.tsx
@@ -1,0 +1,52 @@
+import type { JSX } from 'react'
+import type { SpaceAttention } from '../../utils/spaceAttention'
+import { attentionColorVar, attentionLabel } from './spaceVisuals'
+
+interface AttentionChipProps {
+  attention: SpaceAttention
+  /** Show only the count (no "to review" text) — for dense rows. */
+  compact?: boolean
+}
+
+/**
+ * Pulsing pill summarizing a space's rolled-up attention. Colored by the
+ * highest-priority pending kind (approval > input > finished). Renders nothing
+ * when the space needs no attention. DPlex surfaces only the attention signal;
+ * it never inspects session content.
+ */
+export function AttentionChip({
+  attention,
+  compact = false
+}: AttentionChipProps): JSX.Element | null {
+  if (attention.total === 0) return null
+  const color = attentionColorVar(attention.topKind)
+  return (
+    <span
+      className="inline-flex items-center gap-1.5 whitespace-nowrap"
+      style={{
+        padding: compact ? '2px 6px' : '2px 7px 2px 6px',
+        borderRadius: 20,
+        fontSize: 10.5,
+        fontWeight: 700,
+        color,
+        backgroundColor: 'color-mix(in srgb, var(--dplex-attn-chip) 16%, transparent)',
+        // `--dplex-attn-chip` is set locally so color-mix can reference the
+        // resolved status color (color-mix can't nest a var() ramp directly).
+        ['--dplex-attn-chip' as string]: color
+      }}
+    >
+      <span
+        aria-hidden
+        className="dplex-pulse-dot"
+        style={{
+          width: 6,
+          height: 6,
+          borderRadius: '50%',
+          backgroundColor: color,
+          boxShadow: `0 0 6px ${color}`
+        }}
+      />
+      {compact ? attention.total : attentionLabel(attention)}
+    </span>
+  )
+}

--- a/src/renderer/src/components/spaces/SpaceAttentionToasts.tsx
+++ b/src/renderer/src/components/spaces/SpaceAttentionToasts.tsx
@@ -1,0 +1,113 @@
+import { type JSX } from 'react'
+import { createPortal } from 'react-dom'
+import { useAttentionStore } from '../../stores/attentionStore'
+import { useSpaceStore } from '../../stores/spaceStore'
+import { makeCompositeId, type AttentionKind } from '../../../../preload/attentionTypes'
+import { aggregateSpaceAttention, attentionKindLabel } from '../../utils/spaceAttention'
+import type { Space } from '../../types'
+import { SpaceAvatar } from './SpaceAvatar'
+import { attentionColorVar, isAiSessionTab, terminalTabs } from './spaceVisuals'
+
+/**
+ * Bottom-right pings for backgrounded spaces that need a decision. A space you
+ * stepped away from can still raise an approval/input request while you work
+ * elsewhere — this surfaces it and offers a one-click Resume. Derived purely
+ * from attention state; a toast clears itself when its space no longer needs
+ * you. DPlex reads only the attention signal, never session content.
+ */
+export function SpaceAttentionToasts(): JSX.Element | null {
+  const spaces = useSpaceStore((s) => s.spaces)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  const events = useAttentionStore((s) => s.active)
+
+  const pings = spaces
+    .filter((s) => s.id !== activeSpaceId)
+    .map((s) => ({ space: s, attention: aggregateSpaceAttention(s, events) }))
+    .filter((p) => p.attention.total > 0)
+    .slice(0, 3)
+
+  if (pings.length === 0) return null
+
+  return createPortal(
+    <div
+      className="fixed z-[2400] flex flex-col items-end"
+      style={{ right: 20, bottom: 44, gap: 10 }}
+    >
+      {pings.map(({ space }) => (
+        <Toast key={space.id} space={space} events={events} />
+      ))}
+    </div>,
+    document.body
+  )
+}
+
+function Toast({
+  space,
+  events
+}: {
+  space: Space
+  events: ReturnType<typeof useAttentionStore.getState>['active']
+}): JSX.Element {
+  // Find the first pending session in this space to describe the ping.
+  const tabs = terminalTabs(space.workspace)
+  let title = 'A session'
+  let kind: AttentionKind = 'waitingForApproval'
+  for (const t of tabs) {
+    if (!isAiSessionTab(t) || !t.providerId || !t.sessionId) continue
+    const e = events.find(
+      (ev) => ev.compositeId === makeCompositeId(t.providerId!, t.sessionId!) && !ev.suppressed
+    )
+    if (e) {
+      title = t.title
+      kind = e.kind
+      break
+    }
+  }
+  const color = attentionColorVar(kind)
+
+  return (
+    <div
+      className="flex items-center gap-3 dplex-slidein"
+      style={{
+        padding: '12px 14px',
+        borderRadius: 13,
+        maxWidth: 340,
+        backgroundColor: 'var(--dplex-bg-elev)',
+        border: `1px solid color-mix(in srgb, ${color} 40%, var(--dplex-border))`,
+        boxShadow: '0 24px 50px -22px rgba(0,0,0,0.7)'
+      }}
+    >
+      <SpaceAvatar space={space} size={32} radius={10} ping />
+      <div className="flex-1 min-w-0">
+        <b
+          className="block truncate"
+          style={{ fontSize: 12.5, fontWeight: 700, color: 'var(--dplex-text)' }}
+        >
+          {space.name}
+        </b>
+        <small
+          className="block truncate"
+          style={{ fontSize: 11, color: 'var(--dplex-text-dim)', marginTop: 1 }}
+        >
+          {title} · {attentionKindLabel(kind, true)}
+        </small>
+      </div>
+      <button
+        type="button"
+        data-testid={`space-toast-resume-${space.id}`}
+        onClick={() => useSpaceStore.getState().switchSpace(space.id)}
+        className="flex-shrink-0 transition-colors"
+        style={{
+          fontSize: 11.5,
+          fontWeight: 700,
+          padding: '6px 10px',
+          borderRadius: 8,
+          color,
+          backgroundColor: `color-mix(in srgb, ${color} 14%, transparent)`
+        }}
+      >
+        Resume ▸
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/spaces/SpaceAvatar.tsx
+++ b/src/renderer/src/components/spaces/SpaceAvatar.tsx
@@ -1,0 +1,59 @@
+import type { CSSProperties, JSX } from 'react'
+import type { Space } from '../../types'
+import { deriveAvatarColor } from '../../utils/projectStatus'
+import { glyphFor } from './spaceVisuals'
+
+interface SpaceAvatarProps {
+  space: Pick<Space, 'name' | 'color' | 'glyph'>
+  /** Square edge length in px. Default 28. */
+  size?: number
+  /** Corner radius in px. Defaults to ~30% of size. */
+  radius?: number
+  /** Pulsing ring — used when the space is calling for attention. */
+  ping?: boolean
+  className?: string
+  style?: CSSProperties
+}
+
+/**
+ * The tinted, bordered tile that identifies a space everywhere it appears
+ * (switcher, sidebar rows, overview cards, status bar, toasts). Reuses the
+ * Project panel's avatar palette (`deriveAvatarColor`) — a soft same-hue fill
+ * plus a tinted border — so spaces and projects share one visual language.
+ * Renders the space's glyph or its name initials in the accent color.
+ */
+export function SpaceAvatar({
+  space,
+  size = 28,
+  radius,
+  ping = false,
+  className,
+  style
+}: SpaceAvatarProps): JSX.Element {
+  const r = radius ?? Math.round(size * 0.3)
+  const c = deriveAvatarColor(space.color)
+  return (
+    <span
+      aria-hidden
+      className={[ping ? 'dplex-space-ping' : '', className].filter(Boolean).join(' ')}
+      style={{
+        width: size,
+        height: size,
+        borderRadius: r,
+        flexShrink: 0,
+        display: 'grid',
+        placeItems: 'center',
+        color: c.fg,
+        fontWeight: 700,
+        fontSize: Math.max(9, Math.round(size * 0.42)),
+        lineHeight: 1,
+        letterSpacing: '0.01em',
+        backgroundColor: c.bg,
+        border: `${size >= 30 ? 1.5 : 1}px solid ${c.border}`,
+        ...style
+      }}
+    >
+      {glyphFor(space)}
+    </span>
+  )
+}

--- a/src/renderer/src/components/spaces/SpaceDeleteConfirm.tsx
+++ b/src/renderer/src/components/spaces/SpaceDeleteConfirm.tsx
@@ -1,0 +1,118 @@
+import type { JSX } from 'react'
+import { createPortal } from 'react-dom'
+import { AlertTriangle } from 'lucide-react'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+import { useSpaceStore, spaceHasUnsavedEditors } from '../../stores/spaceStore'
+import { useSpacesUiStore } from '../../stores/spacesUiStore'
+
+/**
+ * Confirmation for deleting a space. Deleting closes the space's AI sessions
+ * and terminals (they don't leak in the background), so we always confirm.
+ * Mounted once at the app root; driven by `spacesUiStore`.
+ */
+export function SpaceDeleteConfirm(): JSX.Element | null {
+  const request = useSpacesUiStore((s) => s.deleteRequest)
+  const cancel = useSpacesUiStore((s) => s.cancelDelete)
+
+  useEscapeKey(cancel, !!request)
+
+  if (!request) return null
+
+  // A modal read is enough: the user can't edit while it's open, so the
+  // unsaved-work state is effectively static for the dialog's lifetime.
+  const hasUnsaved = spaceHasUnsavedEditors(request.id)
+
+  const confirm = (): void => {
+    useSpaceStore.getState().deleteSpace(request.id)
+    cancel()
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[2650] grid place-items-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(3px)' }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) cancel()
+      }}
+    >
+      <div
+        className="w-[400px] max-w-[92vw] dplex-pop"
+        style={{
+          padding: 20,
+          borderRadius: 14,
+          backgroundColor: 'var(--dplex-bg-elev)',
+          border: '1px solid var(--dplex-border-strong)',
+          boxShadow: '0 40px 90px -30px rgba(0,0,0,0.75)'
+        }}
+      >
+        <div className="flex items-start gap-3">
+          <AlertTriangle
+            size={20}
+            style={{ color: 'var(--dplex-status-error)' }}
+            className="flex-shrink-0 mt-0.5"
+          />
+          <div className="min-w-0">
+            <h3 className="font-semibold" style={{ fontSize: 14, color: 'var(--dplex-text)' }}>
+              Delete “{request.name}”?
+            </h3>
+            <p
+              className="mt-1"
+              style={{ fontSize: 12, color: 'var(--dplex-text-muted)', lineHeight: 1.5 }}
+            >
+              This closes the space&apos;s AI sessions and terminals and removes the space. Your
+              projects and their files are untouched.
+            </p>
+            {hasUnsaved && (
+              <p
+                data-testid="space-delete-unsaved-warning"
+                className="mt-2"
+                style={{
+                  fontSize: 12,
+                  color: 'var(--dplex-status-error)',
+                  lineHeight: 1.5,
+                  fontWeight: 600
+                }}
+              >
+                This space has unsaved editor changes that will be discarded. Save them first if you
+                want to keep them.
+              </p>
+            )}
+          </div>
+        </div>
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={cancel}
+            className="transition-colors hover:bg-[var(--dplex-hover)]"
+            style={{
+              padding: '7px 13px',
+              borderRadius: 8,
+              fontSize: 12,
+              fontWeight: 600,
+              color: 'var(--dplex-text)',
+              border: '1px solid var(--dplex-border)'
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={confirm}
+            data-testid="space-delete-confirm"
+            style={{
+              padding: '7px 13px',
+              borderRadius: 8,
+              fontSize: 12,
+              fontWeight: 600,
+              color: '#fff',
+              backgroundColor: 'var(--dplex-status-error)'
+            }}
+          >
+            Delete space
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/src/components/spaces/SpaceModal.tsx
+++ b/src/renderer/src/components/spaces/SpaceModal.tsx
@@ -1,0 +1,294 @@
+import { useState, type JSX } from 'react'
+import { createPortal } from 'react-dom'
+import { Check, FolderGit2 } from 'lucide-react'
+import { useEscapeKey } from '../../hooks/useEscapeKey'
+import { useProjectStore } from '../../stores/projectStore'
+import { useSpaceStore } from '../../stores/spaceStore'
+import { useSpacesUiStore, type SpaceModalMode } from '../../stores/spacesUiStore'
+import type { Project, Space } from '../../types'
+import { SPACE_COLORS, pickSpaceColor } from '../../utils/spaceColors'
+import { SpaceAvatar } from './SpaceAvatar'
+
+/**
+ * Create / rename a space. Captures name, accent color, and the projects bound
+ * to the space. Mounted once at the app root; driven by `spacesUiStore`. The
+ * outer component only resolves the request; the actual form is a keyed inner
+ * component so opening a new request remounts it with fresh initial state
+ * (no effect-driven setState).
+ */
+export function SpaceModal(): JSX.Element | null {
+  const request = useSpacesUiStore((s) => s.modal)
+  const close = useSpacesUiStore((s) => s.closeModal)
+  const spaces = useSpaceStore((s) => s.spaces)
+  const projects = useProjectStore((s) => s.projects)
+
+  if (!request) return null
+  const editing =
+    request.mode !== 'create' ? (spaces.find((s) => s.id === request.spaceId) ?? null) : null
+  // An edit request whose space vanished (e.g. deleted from another surface):
+  // nothing to edit.
+  if (request.mode !== 'create' && !editing) return null
+
+  return (
+    <SpaceModalForm
+      key={`${request.mode}:${request.spaceId ?? 'new'}`}
+      mode={request.mode}
+      editing={editing}
+      projects={projects}
+      spaces={spaces}
+      onClose={close}
+    />
+  )
+}
+
+interface SpaceModalFormProps {
+  mode: SpaceModalMode
+  editing: Space | null
+  projects: Project[]
+  spaces: Space[]
+  onClose: () => void
+}
+
+/** Per-intent heading, subtitle, and submit label. The 'rename' and 'projects'
+ *  modes drive the same form (name + color + projects); only the framing
+ *  differs so an "Add a project" affordance never reads "Rename space". */
+const MODAL_COPY: Record<SpaceModalMode, { title: string; subtitle: string; cta: string }> = {
+  create: {
+    title: 'New space',
+    subtitle: 'Group projects & sessions into an activity you can leave and return to.',
+    cta: 'Create space'
+  },
+  rename: {
+    title: 'Rename space',
+    subtitle: 'Update how this activity shows up across DPlex.',
+    cta: 'Save'
+  },
+  projects: {
+    title: 'Manage projects',
+    subtitle: 'Choose the projects bound to this space so you can launch their sessions here.',
+    cta: 'Save'
+  }
+}
+
+function SpaceModalForm({
+  mode,
+  editing,
+  projects,
+  spaces,
+  onClose
+}: SpaceModalFormProps): JSX.Element {
+  const [name, setName] = useState(editing ? editing.name : '')
+  const [color, setColor] = useState<string>(editing ? editing.color : pickSpaceColor(spaces))
+  const [projectIds, setProjectIds] = useState<string[]>(editing ? editing.projectIds : [])
+
+  useEscapeKey(onClose, true)
+
+  const canSave = name.trim().length > 0
+  const copy = MODAL_COPY[mode]
+
+  const toggleProject = (id: string): void => {
+    setProjectIds((prev) => (prev.includes(id) ? prev.filter((p) => p !== id) : [...prev, id]))
+  }
+
+  const save = (): void => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    const store = useSpaceStore.getState()
+    if (editing) {
+      store.renameSpace(editing.id, trimmed)
+      store.setSpaceAppearance(editing.id, { color })
+      store.assignProjects(editing.id, projectIds)
+    } else {
+      store.createSpace({ name: trimmed, color, projectIds })
+    }
+    onClose()
+  }
+
+  const onKeyDown = (e: React.KeyboardEvent): void => {
+    if (e.key === 'Enter' && canSave) {
+      e.preventDefault()
+      save()
+    }
+  }
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[2600] grid place-items-center"
+      style={{ backgroundColor: 'rgba(0,0,0,0.55)', backdropFilter: 'blur(3px)' }}
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose()
+      }}
+    >
+      <div
+        className="w-[460px] max-w-[92vw] overflow-hidden dplex-pop"
+        style={{
+          backgroundColor: 'var(--dplex-bg-elev)',
+          border: '1px solid var(--dplex-border-strong)',
+          borderRadius: 16,
+          boxShadow: '0 40px 90px -30px rgba(0,0,0,0.75)'
+        }}
+        onKeyDown={onKeyDown}
+      >
+        <div style={{ padding: '18px 20px 6px' }}>
+          <h3 className="font-extrabold" style={{ fontSize: 16, color: 'var(--dplex-text)' }}>
+            {copy.title}
+          </h3>{' '}
+          <p style={{ fontSize: 12, color: 'var(--dplex-text-dim)', marginTop: 3 }}>
+            {copy.subtitle}
+          </p>
+        </div>
+
+        <div
+          style={{ padding: '14px 20px 4px', display: 'flex', flexDirection: 'column', gap: 16 }}
+        >
+          {/* Name */}
+          <div>
+            <label className="dplex-field-label">Space name</label>
+            <div
+              className="flex items-center gap-2.5"
+              style={{
+                padding: '9px 12px',
+                borderRadius: 10,
+                backgroundColor: 'var(--dplex-bg-input)',
+                border: '1px solid var(--dplex-border)'
+              }}
+            >
+              <SpaceAvatar
+                space={{ name: name || (editing ? editing.name : 'Space'), color, glyph: '' }}
+                size={22}
+                radius={6}
+              />
+              <input
+                autoFocus
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+                placeholder="e.g. Ship OAuth, Fix flaky tests, Perf pass"
+                className="flex-1 bg-transparent outline-none"
+                style={{ color: 'var(--dplex-text)', fontSize: 13 }}
+              />
+            </div>
+          </div>
+
+          {/* Accent */}
+          <div>
+            <label className="dplex-field-label">Accent</label>
+            <div className="flex flex-wrap gap-2">
+              {SPACE_COLORS.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  aria-label={`Accent ${c}`}
+                  aria-selected={c === color}
+                  onClick={() => setColor(c)}
+                  className="dplex-swatch"
+                  style={{ background: c }}
+                />
+              ))}
+            </div>
+          </div>
+
+          {/* Projects */}
+          <div>
+            <label className="dplex-field-label">
+              Projects & worktrees {editing ? '' : '· pick one or many'}
+            </label>
+            {projects.length === 0 ? (
+              <p style={{ fontSize: 12, color: 'var(--dplex-text-dim)' }}>
+                No projects yet — add one from the Projects panel first.
+              </p>
+            ) : (
+              <div
+                className="flex flex-wrap gap-1.5 overflow-y-auto dplex-scroll-autohide"
+                style={{ maxHeight: 150 }}
+              >
+                {projects.map((p) => {
+                  const selected = projectIds.includes(p.id)
+                  return (
+                    <button
+                      key={p.id}
+                      type="button"
+                      aria-selected={selected}
+                      onClick={() => toggleProject(p.id)}
+                      className="inline-flex items-center gap-2 transition-colors"
+                      style={{
+                        padding: '7px 11px',
+                        borderRadius: 9,
+                        fontSize: 12,
+                        fontWeight: 600,
+                        backgroundColor: selected
+                          ? 'var(--dplex-accent-soft)'
+                          : 'var(--dplex-bg-elev-2)',
+                        border: `1px solid ${selected ? 'var(--dplex-accent)' : 'var(--dplex-border)'}`,
+                        color: selected ? 'var(--dplex-accent)' : 'var(--dplex-text-muted)'
+                      }}
+                    >
+                      <span
+                        aria-hidden
+                        className="grid place-items-center"
+                        style={{
+                          width: 15,
+                          height: 15,
+                          borderRadius: 5,
+                          border: `1.5px solid ${selected ? 'var(--dplex-accent)' : 'var(--dplex-border-strong)'}`,
+                          backgroundColor: selected ? 'var(--dplex-accent)' : 'transparent',
+                          color: selected ? '#fff' : 'transparent'
+                        }}
+                      >
+                        <Check size={10} strokeWidth={3} />
+                      </span>
+                      <FolderGit2 size={12} style={{ opacity: 0.7 }} />
+                      {p.name}
+                    </button>
+                  )
+                })}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div
+          className="flex justify-end gap-2.5"
+          style={{ padding: '16px 20px 18px', marginTop: 6 }}
+        >
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex items-center transition-colors hover:bg-[var(--dplex-hover)]"
+            style={{
+              padding: '9px 15px',
+              borderRadius: 10,
+              fontSize: 12.5,
+              fontWeight: 600,
+              backgroundColor: 'var(--dplex-bg-elev)',
+              border: '1px solid var(--dplex-border)',
+              color: 'var(--dplex-text-2)'
+            }}
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={!canSave}
+            data-testid="space-modal-save"
+            className="inline-flex items-center"
+            style={{
+              padding: '9px 15px',
+              borderRadius: 10,
+              fontSize: 12.5,
+              fontWeight: 600,
+              color: '#fff',
+              background: 'linear-gradient(135deg, var(--dplex-accent), var(--dplex-accent-2))',
+              opacity: canSave ? 1 : 0.5,
+              cursor: canSave ? 'pointer' : 'not-allowed',
+              boxShadow: '0 8px 22px -10px var(--dplex-accent-glow)'
+            }}
+          >
+            {copy.cta}
+          </button>
+        </div>
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/src/components/spaces/SpaceQuickStart.tsx
+++ b/src/renderer/src/components/spaces/SpaceQuickStart.tsx
@@ -1,0 +1,217 @@
+import { useRef, useState, type JSX } from 'react'
+import { FolderPlus, Play, Plus, Terminal } from 'lucide-react'
+import { useProjectStore } from '../../stores/projectStore'
+import { useProvidersStore } from '../../stores/providersStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { useSpacesUiStore } from '../../stores/spacesUiStore'
+import { deriveAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
+import { openPlainTerminal, openProjectTerminal, startProjectSession } from '../../utils/spaceStart'
+import type { Project, Space } from '../../types'
+import { PopoverMenu } from '../common/PopoverMenu'
+import { boundProjects } from './spaceVisuals'
+
+/**
+ * "New session" quick-start for the space in focus. Lets the user launch an AI
+ * session or a terminal for any of the space's bound projects without leaving
+ * for the Projects tab — the whole point of a space is that its projects are
+ * already at hand. Falls back to "add a project" / "plain terminal" when the
+ * space has no projects bound yet.
+ */
+export function SpaceQuickStart({ space }: { space: Space }): JSX.Element {
+  const [open, setOpen] = useState(false)
+  const anchorRef = useRef<HTMLButtonElement>(null)
+
+  const projects = useProjectStore((s) => s.projects)
+  const providers = useProvidersStore((s) => s.providers)
+  const defaultAITool = useSettingsStore((s) => s.settings.defaultAITool)
+  const openProjects = useSpacesUiStore((s) => s.openProjects)
+
+  const bound = boundProjects(space, projects)
+  const primaryProvider = providers.find((p) => p.id === defaultAITool) ?? providers[0]
+
+  const close = (): void => setOpen(false)
+
+  return (
+    <>
+      <button
+        ref={anchorRef}
+        type="button"
+        data-testid="space-quick-start"
+        title="Start a session or terminal in this space"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="inline-flex items-center gap-1.5 rounded-lg transition-colors hover:bg-[var(--dplex-accent-soft)]"
+        style={{
+          height: 26,
+          padding: '0 10px',
+          color: 'var(--dplex-accent)',
+          fontSize: 12,
+          fontWeight: 600
+        }}
+      >
+        <Plus size={14} />
+        New session
+      </button>
+
+      <PopoverMenu anchorRef={anchorRef} open={open} onClose={close} align="right">
+        <div style={{ width: 288, padding: 7 }}>
+          <div
+            style={{
+              padding: '4px 8px 8px',
+              fontSize: 10,
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.14em',
+              color: 'var(--dplex-text-faint)'
+            }}
+          >
+            Start in {space.name}
+          </div>
+
+          {bound.length > 0 ? (
+            <div className="max-h-[280px] overflow-y-auto dplex-scroll-autohide">
+              {bound.map((project) => (
+                <ProjectQuickRow
+                  key={project.id}
+                  project={project}
+                  providerLabel={primaryProvider?.name}
+                  onStartSession={() => {
+                    close()
+                    startProjectSession(project, primaryProvider?.id)
+                  }}
+                  onOpenTerminal={() => {
+                    close()
+                    openProjectTerminal(project)
+                  }}
+                />
+              ))}
+            </div>
+          ) : (
+            <div
+              style={{
+                padding: '2px 8px 10px',
+                fontSize: 11.5,
+                lineHeight: 1.5,
+                color: 'var(--dplex-text-dim)'
+              }}
+            >
+              No projects in this space yet. Add one to start sessions here.
+            </div>
+          )}
+
+          <div
+            style={{ height: 1, margin: '5px 4px', backgroundColor: 'var(--dplex-border-subtle)' }}
+          />
+
+          <MenuAction
+            icon={<FolderPlus size={14} />}
+            label={bound.length > 0 ? 'Add a project…' : 'Add a project'}
+            onClick={() => {
+              close()
+              openProjects(space.id)
+            }}
+          />
+          <MenuAction
+            icon={<Terminal size={14} />}
+            label="Plain terminal"
+            onClick={() => {
+              close()
+              openPlainTerminal()
+            }}
+          />
+        </div>
+      </PopoverMenu>
+    </>
+  )
+}
+
+function ProjectQuickRow({
+  project,
+  providerLabel,
+  onStartSession,
+  onOpenTerminal
+}: {
+  project: Project
+  providerLabel?: string
+  onStartSession: () => void
+  onOpenTerminal: () => void
+}): JSX.Element {
+  const color = deriveAvatarColor(project.tabColor)
+  return (
+    <div
+      className="group flex items-center gap-2.5"
+      style={{ padding: '6px 8px', borderRadius: 8 }}
+      onMouseEnter={(e) => (e.currentTarget.style.backgroundColor = 'var(--dplex-hover)')}
+      onMouseLeave={(e) => (e.currentTarget.style.backgroundColor = 'transparent')}
+    >
+      <span
+        className="flex-shrink-0 inline-flex items-center justify-center"
+        style={{
+          width: 24,
+          height: 24,
+          borderRadius: 6,
+          fontSize: 10,
+          fontWeight: 700,
+          color: color.fg,
+          backgroundColor: color.bg,
+          border: `1px solid ${color.border}`
+        }}
+      >
+        {getAvatarInitials(project.name)}
+      </span>
+      <span
+        className="flex-1 min-w-0 truncate"
+        style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--dplex-text)' }}
+      >
+        {project.name}
+      </span>
+      <button
+        type="button"
+        onClick={onStartSession}
+        title={providerLabel ? `Start ${providerLabel}` : 'Start AI session'}
+        className="flex-shrink-0 inline-flex items-center gap-1 rounded-md transition-colors hover:bg-[var(--dplex-accent-soft)]"
+        style={{ padding: '3px 7px', fontSize: 11, fontWeight: 600, color: 'var(--dplex-accent)' }}
+      >
+        <Play size={11} />
+        Start
+      </button>
+      <button
+        type="button"
+        onClick={onOpenTerminal}
+        title="Open a terminal in this project"
+        className="flex-shrink-0 inline-flex items-center justify-center rounded-md transition-colors hover:bg-[var(--dplex-hover)]"
+        style={{ width: 24, height: 24, color: 'var(--dplex-text-muted)' }}
+      >
+        <Terminal size={13} />
+      </button>
+    </div>
+  )
+}
+
+function MenuAction({
+  icon,
+  label,
+  onClick
+}: {
+  icon: JSX.Element
+  label: string
+  onClick: () => void
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="w-full flex items-center gap-2.5 transition-colors hover:bg-[var(--dplex-hover)]"
+      style={{
+        padding: '7px 8px',
+        borderRadius: 8,
+        fontSize: 12,
+        fontWeight: 500,
+        color: 'var(--dplex-text-2)'
+      }}
+    >
+      <span style={{ color: 'var(--dplex-text-dim)' }}>{icon}</span>
+      {label}
+    </button>
+  )
+}

--- a/src/renderer/src/components/spaces/SpaceSwitcher.tsx
+++ b/src/renderer/src/components/spaces/SpaceSwitcher.tsx
@@ -1,0 +1,316 @@
+import { useEffect, useRef, useState, type JSX } from 'react'
+import { Check, ChevronDown, LayoutGrid, Layers, Plus } from 'lucide-react'
+import { useAttentionStore } from '../../stores/attentionStore'
+import { useSpaceStore } from '../../stores/spaceStore'
+import { useTerminalStore } from '../../stores/terminalStore'
+import { useSpacesUiStore } from '../../stores/spacesUiStore'
+import { useSpaceAttention } from '../../hooks/useSpaceAttention'
+import { useSpaceWorkspace } from '../../hooks/useSpaceWorkspace'
+import { aggregateActiveAwareAttention } from '../../utils/spaceAttention'
+import { MOD, SHIFT, isMac } from '../../utils/shortcuts'
+import type { Space } from '../../types'
+import { SpaceAvatar } from './SpaceAvatar'
+import { AttentionChip } from './AttentionChip'
+import { SpaceQuickStart } from './SpaceQuickStart'
+import { sessionCount } from './spaceVisuals'
+
+/**
+ * Always-visible bar above the workspace showing the space in focus plus a
+ * quick-switch dropdown and a "new session" quick-start. Switching from here
+ * auto-backgrounds the current space (it keeps running). Only rendered when a
+ * space is in focus — the Overview is the switch surface when nothing is in
+ * focus.
+ */
+export function SpaceSwitcher(): JSX.Element | null {
+  const spaces = useSpaceStore((s) => s.spaces)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  const active = spaces.find((s) => s.id === activeSpaceId) ?? null
+
+  const [open, setOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+
+  // Close the dropdown on outside click / Escape.
+  useEffect(() => {
+    if (!open) return
+    const onDown = (e: MouseEvent): void => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) setOpen(false)
+    }
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('mousedown', onDown)
+    document.addEventListener('keydown', onKey)
+    return () => {
+      document.removeEventListener('mousedown', onDown)
+      document.removeEventListener('keydown', onKey)
+    }
+  }, [open])
+
+  if (!active) return null
+
+  return (
+    <div
+      ref={rootRef}
+      className="relative flex items-center flex-shrink-0"
+      style={{
+        height: 48,
+        gap: 10,
+        padding: '0 12px',
+        backgroundColor: 'var(--dplex-bg-panel)',
+        borderBottom: '1px solid var(--dplex-border-subtle)'
+      }}
+    >
+      <SwitcherButton space={active} open={open} onToggle={() => setOpen((v) => !v)} />
+      <div className="flex-1" />
+      <SpaceQuickStart space={active} />
+      <div style={{ width: 1, height: 20, backgroundColor: 'var(--dplex-border-subtle)' }} />
+      <button
+        type="button"
+        title="Open Overview — step back and see every space"
+        aria-label="Open Overview"
+        data-testid="space-switcher-overview"
+        onClick={() => useSpaceStore.getState().sendToBackground()}
+        className="inline-flex items-center gap-1.5 rounded-lg transition-colors hover:bg-[var(--dplex-hover)]"
+        style={{
+          height: 28,
+          padding: '0 10px',
+          color: 'var(--dplex-text-muted)',
+          fontSize: 12,
+          fontWeight: 600
+        }}
+      >
+        <LayoutGrid size={14} />
+        Overview
+      </button>
+      {open && <SwitcherDropdown activeSpaceId={activeSpaceId} onClose={() => setOpen(false)} />}
+    </div>
+  )
+}
+
+function SwitcherButton({
+  space,
+  open,
+  onToggle
+}: {
+  space: Space
+  open: boolean
+  onToggle: () => void
+}): JSX.Element {
+  const attention = useSpaceAttention(space)
+  const ws = useSpaceWorkspace(space)
+  const projects = space.projectIds.length
+  const sessions = sessionCount(ws)
+  return (
+    <button
+      type="button"
+      onClick={onToggle}
+      aria-expanded={open}
+      data-testid="space-switcher-button"
+      className="flex items-center gap-2.5 text-left transition-colors"
+      style={{
+        maxWidth: 340,
+        height: 34,
+        padding: '0 9px',
+        borderRadius: 9,
+        backgroundColor: open ? 'var(--dplex-hover)' : 'transparent'
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.backgroundColor = 'var(--dplex-hover)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.backgroundColor = open ? 'var(--dplex-hover)' : 'transparent'
+      }}
+    >
+      <SpaceAvatar space={space} size={22} />
+      <span
+        className="truncate"
+        style={{ fontSize: 13.5, fontWeight: 600, color: 'var(--dplex-text)', maxWidth: 190 }}
+      >
+        {space.name}
+      </span>
+      {attention.total > 0 ? (
+        <AttentionChip attention={attention} />
+      ) : (
+        <span
+          className="tabular-nums flex-shrink-0"
+          style={{ fontSize: 11, color: 'var(--dplex-text-dim)' }}
+        >
+          {projects} proj · {sessions} {sessions === 1 ? 'session' : 'sessions'}
+        </span>
+      )}
+      <ChevronDown
+        size={14}
+        className="flex-shrink-0"
+        style={{
+          color: 'var(--dplex-text-dim)',
+          transition: 'transform 0.2s',
+          transform: open ? 'rotate(180deg)' : 'none'
+        }}
+      />
+    </button>
+  )
+}
+
+function SwitcherDropdown({
+  activeSpaceId,
+  onClose
+}: {
+  activeSpaceId: string | null
+  onClose: () => void
+}): JSX.Element {
+  const spaces = useSpaceStore((s) => s.spaces)
+  const events = useAttentionStore((s) => s.active)
+  // Live groups drive the active space's attention so a just-started session
+  // counts immediately; background spaces read their stashed snapshot.
+  const liveGroups = useTerminalStore((s) => s.groups)
+  const openCreate = useSpacesUiStore((s) => s.openCreate)
+
+  return (
+    <div
+      className="absolute z-40 dplex-pop"
+      style={{
+        left: 10,
+        top: 'calc(100% - 2px)',
+        width: 300,
+        padding: 7,
+        borderRadius: 13,
+        backgroundColor: 'var(--dplex-bg-elev)',
+        border: '1px solid var(--dplex-border-strong)',
+        boxShadow: '0 30px 60px -24px rgba(0,0,0,0.7)'
+      }}
+    >
+      <div className="flex items-center justify-between" style={{ padding: '6px 8px 8px' }}>
+        <span
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            textTransform: 'uppercase',
+            letterSpacing: '0.14em',
+            color: 'var(--dplex-text-faint)'
+          }}
+        >
+          Switch spaces
+        </span>
+        <button
+          type="button"
+          onClick={() => {
+            onClose()
+            openCreate()
+          }}
+          className="inline-flex items-center gap-1.5 rounded-lg transition-colors hover:bg-[var(--dplex-accent-soft)]"
+          style={{
+            padding: '4px 8px',
+            fontSize: 11.5,
+            fontWeight: 600,
+            color: 'var(--dplex-accent)'
+          }}
+        >
+          <Plus size={13} />
+          New space
+        </button>
+      </div>
+
+      <div className="max-h-[300px] overflow-y-auto dplex-scroll-autohide">
+        {spaces.map((s, i) => {
+          const isActive = s.id === activeSpaceId
+          const a = aggregateActiveAwareAttention(
+            s,
+            events,
+            isActive ? { groups: liveGroups } : null
+          )
+          const subtitle =
+            s.projectIds.length > 0
+              ? `${s.projectIds.length} project${s.projectIds.length !== 1 ? 's' : ''}`
+              : 'no projects'
+          return (
+            <button
+              key={s.id}
+              type="button"
+              data-testid={`space-switch-${s.id}`}
+              onClick={() => {
+                onClose()
+                if (!isActive) useSpaceStore.getState().switchSpace(s.id)
+              }}
+              className="w-full flex items-center gap-2.5 text-left transition-colors"
+              style={{
+                padding: '8px 9px',
+                borderRadius: 9,
+                backgroundColor: isActive ? 'var(--dplex-accent-soft)' : 'transparent'
+              }}
+              onMouseEnter={(e) => {
+                if (!isActive) e.currentTarget.style.backgroundColor = 'var(--dplex-hover)'
+              }}
+              onMouseLeave={(e) => {
+                if (!isActive) e.currentTarget.style.backgroundColor = 'transparent'
+              }}
+            >
+              <SpaceAvatar space={s} size={26} ping={a.total > 0 && !isActive} />
+              <span className="flex-1 min-w-0">
+                <span
+                  className="block truncate"
+                  style={{ fontSize: 12.5, fontWeight: 600, color: 'var(--dplex-text)' }}
+                >
+                  {s.name}
+                </span>
+                <span
+                  className="block truncate"
+                  style={{ fontSize: 10.5, color: 'var(--dplex-text-dim)' }}
+                >
+                  {subtitle}
+                </span>
+              </span>
+              {a.total > 0 ? (
+                <AttentionChip attention={a} compact />
+              ) : isActive ? (
+                <Check size={15} style={{ color: 'var(--dplex-accent)', flexShrink: 0 }} />
+              ) : (
+                i < 9 &&
+                !(isMac && (i === 2 || i === 3 || i === 4)) && (
+                  <kbd
+                    className="flex-shrink-0 tabular-nums"
+                    style={{
+                      fontSize: 10,
+                      fontFamily: 'inherit',
+                      color: 'var(--dplex-text-faint)',
+                      padding: '1px 5px',
+                      borderRadius: 5,
+                      border: '1px solid var(--dplex-border)',
+                      backgroundColor: 'var(--dplex-bg-elev-2)',
+                      lineHeight: 1.5
+                    }}
+                  >
+                    {MOD}
+                    {SHIFT}
+                    {i + 1}
+                  </kbd>
+                )
+              )}
+            </button>
+          )
+        })}
+      </div>
+
+      <button
+        type="button"
+        data-testid="space-switcher-open-overview"
+        onClick={() => {
+          onClose()
+          useSpaceStore.getState().sendToBackground()
+        }}
+        className="w-full flex items-center gap-2 transition-colors hover:bg-[var(--dplex-hover)]"
+        style={{
+          marginTop: 4,
+          padding: '8px 9px',
+          borderRadius: 9,
+          fontSize: 12,
+          fontWeight: 600,
+          color: 'var(--dplex-text-2)'
+        }}
+      >
+        <LayoutGrid size={14} style={{ color: 'var(--dplex-text-dim)' }} />
+        Open Overview
+        <Layers size={12} style={{ marginLeft: 'auto', color: 'var(--dplex-text-faint)' }} />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/spaces/SpaceWelcome.tsx
+++ b/src/renderer/src/components/spaces/SpaceWelcome.tsx
@@ -1,0 +1,213 @@
+import type { JSX } from 'react'
+import { FolderPlus, LayoutGrid, Play, Terminal } from 'lucide-react'
+import { useProjectStore } from '../../stores/projectStore'
+import { useProvidersStore } from '../../stores/providersStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { useSpaceStore } from '../../stores/spaceStore'
+import { useSpacesUiStore } from '../../stores/spacesUiStore'
+import { deriveAvatarColor, getAvatarInitials } from '../../utils/projectStatus'
+import { openPlainTerminal, openProjectTerminal, startProjectSession } from '../../utils/spaceStart'
+import type { Project, Space } from '../../types'
+import { SpaceAvatar } from './SpaceAvatar'
+import { boundProjects } from './spaceVisuals'
+
+/**
+ * Empty-workspace state shown when the space in focus has no open tabs. Unlike
+ * the generic welcome, it surfaces the space's own projects so the developer
+ * can start a session or terminal in one click — no detour through the Projects
+ * tab. When the space has no projects bound yet, it invites adding one.
+ */
+export function SpaceWelcome({ space }: { space: Space }): JSX.Element {
+  const projects = useProjectStore((s) => s.projects)
+  const providers = useProvidersStore((s) => s.providers)
+  const defaultAITool = useSettingsStore((s) => s.settings.defaultAITool)
+  const openProjects = useSpacesUiStore((s) => s.openProjects)
+
+  const bound = boundProjects(space, projects)
+  const primaryProvider = providers.find((p) => p.id === defaultAITool) ?? providers[0]
+
+  return (
+    <div
+      className="flex items-center justify-center h-full px-6 overflow-y-auto dplex-scroll-autohide"
+      style={{
+        backgroundImage:
+          'radial-gradient(ellipse 800px 400px at 50% 25%, var(--dplex-accent-faint) 0%, transparent 70%)'
+      }}
+    >
+      <div
+        className="flex flex-col items-center gap-6 text-center w-full"
+        style={{ maxWidth: 460 }}
+      >
+        <div className="flex flex-col items-center gap-3">
+          <SpaceAvatar space={space} size={56} />
+          <div className="flex flex-col gap-1.5">
+            <h1
+              className="text-[24px] font-semibold tracking-tight"
+              style={{ color: 'var(--dplex-text)', letterSpacing: '-0.02em' }}
+            >
+              {space.name}
+            </h1>
+            <p
+              className="text-[13.5px] leading-relaxed"
+              style={{ color: 'var(--dplex-text-muted)' }}
+            >
+              {bound.length > 0
+                ? 'Pick up where you left off — start a session or terminal in one of this space’s projects.'
+                : 'This space is empty. Add a project to launch sessions here, or open a terminal.'}
+            </p>
+          </div>
+        </div>
+
+        {bound.length > 0 && (
+          <div className="flex flex-col gap-2 w-full">
+            {bound.map((project) => (
+              <ProjectStartCard
+                key={project.id}
+                project={project}
+                providerLabel={primaryProvider?.name}
+                onStartSession={() => startProjectSession(project, primaryProvider?.id)}
+                onOpenTerminal={() => openProjectTerminal(project)}
+              />
+            ))}
+          </div>
+        )}
+
+        <div className="flex items-center flex-wrap justify-center gap-2">
+          <SecondaryAction
+            icon={<FolderPlus size={14} />}
+            label="Add a project"
+            primary={bound.length === 0}
+            onClick={() => openProjects(space.id)}
+          />
+          <SecondaryAction
+            icon={<Terminal size={14} />}
+            label="Open a terminal"
+            onClick={() => openPlainTerminal()}
+          />
+          <SecondaryAction
+            icon={<LayoutGrid size={14} />}
+            label="Overview"
+            onClick={() => useSpaceStore.getState().sendToBackground()}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function ProjectStartCard({
+  project,
+  providerLabel,
+  onStartSession,
+  onOpenTerminal
+}: {
+  project: Project
+  providerLabel?: string
+  onStartSession: () => void
+  onOpenTerminal: () => void
+}): JSX.Element {
+  const color = deriveAvatarColor(project.tabColor)
+  return (
+    <div
+      className="flex items-center gap-3 rounded-xl transition-colors"
+      style={{
+        padding: '10px 12px',
+        background: 'var(--dplex-bg-elev)',
+        border: '1px solid var(--dplex-border)',
+        boxShadow: 'var(--dplex-shadow-sm)'
+      }}
+    >
+      <span
+        className="flex-shrink-0 inline-flex items-center justify-center"
+        style={{
+          width: 32,
+          height: 32,
+          borderRadius: 8,
+          fontSize: 12,
+          fontWeight: 700,
+          color: color.fg,
+          backgroundColor: color.bg,
+          border: `1px solid ${color.border}`
+        }}
+      >
+        {getAvatarInitials(project.name)}
+      </span>
+      <span
+        className="flex-1 min-w-0 truncate text-left"
+        style={{ fontSize: 13.5, fontWeight: 600, color: 'var(--dplex-text)' }}
+      >
+        {project.name}
+      </span>
+      <button
+        type="button"
+        onClick={onStartSession}
+        title={providerLabel ? `Start ${providerLabel}` : 'Start AI session'}
+        className="flex-shrink-0 inline-flex items-center gap-1.5 rounded-lg transition-colors"
+        style={{
+          height: 30,
+          padding: '0 12px',
+          fontSize: 12.5,
+          fontWeight: 600,
+          color: 'var(--dplex-accent-fg)',
+          background: 'var(--dplex-accent)'
+        }}
+        onMouseEnter={(e) => (e.currentTarget.style.filter = 'brightness(1.08)')}
+        onMouseLeave={(e) => (e.currentTarget.style.filter = 'none')}
+      >
+        <Play size={12} />
+        Start session
+      </button>
+      <button
+        type="button"
+        onClick={onOpenTerminal}
+        title="Open a terminal in this project"
+        className="flex-shrink-0 inline-flex items-center justify-center rounded-lg transition-colors hover:bg-[var(--dplex-hover)]"
+        style={{ width: 30, height: 30, color: 'var(--dplex-text-muted)' }}
+      >
+        <Terminal size={14} />
+      </button>
+    </div>
+  )
+}
+
+function SecondaryAction({
+  icon,
+  label,
+  onClick,
+  primary
+}: {
+  icon: JSX.Element
+  label: string
+  onClick: () => void
+  primary?: boolean
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="inline-flex items-center gap-1.5 rounded-lg transition-colors"
+      style={{
+        height: 30,
+        padding: '0 12px',
+        fontSize: 12.5,
+        fontWeight: 600,
+        color: primary ? 'var(--dplex-accent-fg)' : 'var(--dplex-text-2)',
+        background: primary ? 'var(--dplex-accent)' : 'var(--dplex-bg-elev)',
+        border: primary ? '1px solid transparent' : '1px solid var(--dplex-border)'
+      }}
+      onMouseEnter={(e) => {
+        if (primary) e.currentTarget.style.filter = 'brightness(1.08)'
+        else e.currentTarget.style.backgroundColor = 'var(--dplex-bg-elev-2)'
+      }}
+      onMouseLeave={(e) => {
+        if (primary) e.currentTarget.style.filter = 'none'
+        else e.currentTarget.style.backgroundColor = 'var(--dplex-bg-elev)'
+      }}
+    >
+      <span style={{ color: primary ? 'var(--dplex-accent-fg)' : 'var(--dplex-text-dim)' }}>
+        {icon}
+      </span>
+      {label}
+    </button>
+  )
+}

--- a/src/renderer/src/components/spaces/SpacesOverview.tsx
+++ b/src/renderer/src/components/spaces/SpacesOverview.tsx
@@ -1,0 +1,419 @@
+import { type JSX } from 'react'
+import { Clock, FolderGit2, Layers, Play, Plus, Terminal } from 'lucide-react'
+import { useAttentionStore } from '../../stores/attentionStore'
+import { useProjectStore } from '../../stores/projectStore'
+import { useSpaceStore } from '../../stores/spaceStore'
+import { useSpacesUiStore } from '../../stores/spacesUiStore'
+import { makeCompositeId, type AttentionEvent } from '../../../../preload/attentionTypes'
+import { aggregateSpaceAttention, attentionKindLabel } from '../../utils/spaceAttention'
+import { ProviderGlyph } from '../common/ProviderGlyph'
+import type { ProviderId } from '../../utils/providerHelpers'
+import type { Space, TerminalTab } from '../../types'
+import { SpaceAvatar } from './SpaceAvatar'
+import {
+  attentionColorVar,
+  boundProjects,
+  isAiSessionTab,
+  relativeTime,
+  shade,
+  terminalTabs
+} from './spaceVisuals'
+
+/**
+ * Mission-control home base, shown in the workspace area when no space is in
+ * focus. A grid of space cards (live status, projects, sessions, attention,
+ * last-active) — the "leave and return" surface. Everything on it keeps
+ * running in the background; resuming a card brings it back into focus without
+ * restarting anything.
+ */
+export function SpacesOverview(): JSX.Element {
+  const spaces = useSpaceStore((s) => s.spaces)
+  const openCreate = useSpacesUiStore((s) => s.openCreate)
+
+  return (
+    <div
+      className="absolute inset-0 flex flex-col overflow-hidden"
+      style={{
+        background:
+          'radial-gradient(1000px 560px at 82% -6%, var(--dplex-accent-faint), transparent 60%), var(--dplex-bg)'
+      }}
+    >
+      <div className="flex items-end gap-4 flex-wrap" style={{ padding: '26px 34px 8px' }}>
+        <div>
+          <h1
+            className="flex items-center gap-3 font-extrabold"
+            style={{ fontSize: 22, letterSpacing: '-0.4px', color: 'var(--dplex-text)' }}
+          >
+            Spaces
+            <span style={{ fontSize: 11, fontWeight: 500, color: 'var(--dplex-text-dim)' }}>
+              — your work, ready to return to
+            </span>
+          </h1>
+          <p
+            style={{ fontSize: 13, fontWeight: 500, color: 'var(--dplex-text-dim)', marginTop: 4 }}
+          >
+            Everything keeps running in the background. Sessions still think, run, and ask for you —
+            DPlex just holds the window.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={openCreate}
+          data-testid="overview-new-space"
+          className="ml-auto inline-flex items-center gap-2"
+          style={{
+            padding: '9px 15px',
+            borderRadius: 10,
+            fontSize: 12.5,
+            fontWeight: 600,
+            color: '#fff',
+            background: 'linear-gradient(135deg, var(--dplex-accent), var(--dplex-accent-2))',
+            boxShadow: '0 8px 22px -10px var(--dplex-accent-glow)'
+          }}
+        >
+          <Plus size={16} />
+          New space
+        </button>
+      </div>
+
+      <div
+        className="flex-1 min-h-0 overflow-y-auto dplex-scroll-autohide"
+        style={{ padding: '16px 30px 30px' }}
+      >
+        <div
+          className="grid"
+          style={{
+            gridTemplateColumns: 'repeat(auto-fill, minmax(304px, 1fr))',
+            gap: 16
+          }}
+        >
+          {spaces.map((s, i) => (
+            <SpaceCard key={s.id} space={s} index={i} />
+          ))}
+          <button
+            type="button"
+            onClick={openCreate}
+            className="dplex-space-card grid place-items-center transition-colors"
+            style={{
+              ['--dplex-card-i' as string]: spaces.length,
+              minHeight: 220,
+              borderRadius: 16,
+              border: '1px dashed var(--dplex-border-strong)',
+              background: 'transparent',
+              color: 'var(--dplex-text-muted)'
+            }}
+            onMouseEnter={(e) => {
+              e.currentTarget.style.borderColor = 'var(--dplex-accent)'
+              e.currentTarget.style.backgroundColor = 'var(--dplex-accent-soft)'
+            }}
+            onMouseLeave={(e) => {
+              e.currentTarget.style.borderColor = 'var(--dplex-border-strong)'
+              e.currentTarget.style.backgroundColor = 'transparent'
+            }}
+          >
+            <span className="text-center">
+              <span
+                className="grid place-items-center mx-auto"
+                style={{
+                  width: 48,
+                  height: 48,
+                  borderRadius: 14,
+                  marginBottom: 12,
+                  backgroundColor: 'var(--dplex-bg-elev)',
+                  border: '1px solid var(--dplex-border)',
+                  color: 'var(--dplex-accent)'
+                }}
+              >
+                <Plus size={22} />
+              </span>
+              <span
+                className="block font-bold"
+                style={{ fontSize: 14, color: 'var(--dplex-text-2)' }}
+              >
+                New space
+              </span>
+              <span className="block" style={{ fontSize: 11.5 }}>
+                Group projects &amp; sessions into a fresh activity
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+function SpaceCard({ space, index }: { space: Space; index: number }): JSX.Element {
+  const events = useAttentionStore((s) => s.active)
+  const attention = aggregateSpaceAttention(space, events)
+  const projects = useProjectStore((s) => s.projects)
+  const rename = useSpacesUiStore((s) => s.openRename)
+  const requestDelete = useSpacesUiStore((s) => s.requestDelete)
+
+  const tabs = terminalTabs(space.workspace)
+  const bound = boundProjects(space, projects)
+
+  const resume = (): void => useSpaceStore.getState().switchSpace(space.id)
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-testid={`space-card-${space.id}`}
+      onClick={resume}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          resume()
+        }
+      }}
+      className="dplex-space-card group relative flex flex-col overflow-hidden cursor-pointer"
+      style={{
+        ['--dplex-card-i' as string]: index,
+        borderRadius: 16,
+        backgroundColor: 'var(--dplex-bg-elev)',
+        border: '1px solid var(--dplex-border)',
+        transition:
+          'transform 0.18s cubic-bezier(0.2,0.7,0.3,1), box-shadow 0.18s, border-color 0.18s'
+      }}
+      onMouseEnter={(e) => {
+        e.currentTarget.style.transform = 'translateY(-4px)'
+        e.currentTarget.style.borderColor = 'var(--dplex-border-strong)'
+        e.currentTarget.style.boxShadow = '0 26px 50px -26px rgba(0,0,0,0.7)'
+      }}
+      onMouseLeave={(e) => {
+        e.currentTarget.style.transform = 'none'
+        e.currentTarget.style.borderColor = 'var(--dplex-border)'
+        e.currentTarget.style.boxShadow = 'none'
+      }}
+    >
+      <div
+        aria-hidden
+        className="absolute inset-0 pointer-events-none"
+        style={{
+          background: `radial-gradient(420px 150px at 20% -10%, color-mix(in srgb, ${space.color} 22%, transparent), transparent 70%)`
+        }}
+      />
+
+      {/* top */}
+      <div className="relative flex items-start gap-3" style={{ padding: '16px 16px 12px' }}>
+        <SpaceAvatar
+          space={space}
+          size={40}
+          radius={12}
+          ping={attention.total > 0}
+          style={{ boxShadow: `0 6px 16px -8px ${shade(space.color, -20)}` }}
+        />
+        <div className="flex-1 min-w-0">
+          <div
+            className="truncate font-extrabold"
+            style={{ fontSize: 15.5, letterSpacing: '-0.2px', color: 'var(--dplex-text)' }}
+          >
+            {space.name}
+          </div>
+          <div
+            className="flex items-center gap-1.5"
+            style={{ fontSize: 11, color: 'var(--dplex-text-dim)', marginTop: 2 }}
+          >
+            <Clock size={11} />
+            {relativeTime(space.lastActiveAt)}
+          </div>
+        </div>
+        <AttentionTag attention={attention.total} />
+      </div>
+
+      {/* body */}
+      <div className="relative flex-1" style={{ padding: '0 16px 14px' }}>
+        <div className="flex flex-wrap gap-1.5" style={{ marginBottom: 12 }}>
+          {bound.length > 0 ? (
+            bound.map((p) => (
+              <span
+                key={p.id}
+                className="inline-flex items-center gap-1"
+                style={{
+                  fontSize: 10,
+                  fontWeight: 600,
+                  color: 'var(--dplex-text-muted)',
+                  backgroundColor: 'var(--dplex-bg-elev-2)',
+                  border: '1px solid var(--dplex-border)',
+                  borderRadius: 6,
+                  padding: '2px 6px'
+                }}
+              >
+                <FolderGit2 size={10} style={{ opacity: 0.7 }} />
+                {p.name}
+              </span>
+            ))
+          ) : (
+            <span style={{ fontSize: 10, color: 'var(--dplex-text-dim)' }}>
+              {tabs.length > 0 ? 'no projects · loose sessions' : 'no projects'}
+            </span>
+          )}
+        </div>
+
+        {tabs.length > 0 && (
+          <div
+            className="flex flex-col overflow-hidden"
+            style={{ borderRadius: 10, border: '1px solid var(--dplex-border-subtle)', gap: 1 }}
+          >
+            {tabs.slice(0, 4).map((t) => (
+              <SessionRow key={t.id} tab={t} events={events} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* footer */}
+      <div
+        className="relative flex items-center gap-2.5"
+        style={{
+          padding: '11px 16px',
+          borderTop: '1px solid var(--dplex-border-subtle)',
+          backgroundColor: 'color-mix(in srgb, var(--dplex-bg-alt) 60%, transparent)'
+        }}
+      >
+        <span
+          className="inline-flex items-center gap-1.5"
+          style={{ fontSize: 11, color: 'var(--dplex-text-dim)', fontWeight: 500 }}
+        >
+          <Layers size={12} />
+          {tabs.length} session{tabs.length !== 1 ? 's' : ''}
+        </span>
+        <span
+          className="inline-flex items-center gap-1.5"
+          style={{ fontSize: 11, color: 'var(--dplex-text-dim)', fontWeight: 500 }}
+        >
+          <FolderGit2 size={12} />
+          {space.projectIds.length} proj
+        </span>
+        <span
+          className="absolute inset-y-0 right-0 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity"
+          style={{
+            paddingLeft: 28,
+            paddingRight: 16,
+            background:
+              'linear-gradient(90deg, transparent, var(--dplex-bg-elev) 22%, var(--dplex-bg-elev) 100%)'
+          }}
+          onClick={(e) => e.stopPropagation()}
+        >
+          <button
+            type="button"
+            onClick={() => rename(space.id)}
+            className="transition-colors"
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              padding: '5px 11px',
+              borderRadius: 8,
+              backgroundColor: 'var(--dplex-bg-elev-2)',
+              color: 'var(--dplex-text-2)'
+            }}
+          >
+            Rename
+          </button>
+          <button
+            type="button"
+            data-testid={`card-delete-${space.id}`}
+            onClick={() => requestDelete({ id: space.id, name: space.name })}
+            className="transition-colors"
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              padding: '5px 11px',
+              borderRadius: 8,
+              backgroundColor: 'var(--dplex-bg-elev-2)',
+              color: 'var(--dplex-text-2)'
+            }}
+          >
+            Delete
+          </button>
+          <button
+            type="button"
+            data-testid={`card-resume-${space.id}`}
+            onClick={resume}
+            className="inline-flex items-center gap-1"
+            style={{
+              fontSize: 11,
+              fontWeight: 700,
+              padding: '5px 11px',
+              borderRadius: 8,
+              color: '#fff',
+              backgroundColor: space.color
+            }}
+          >
+            <Play size={11} />
+            Resume
+          </button>
+        </span>
+      </div>
+    </div>
+  )
+}
+
+function AttentionTag({ attention }: { attention: number }): JSX.Element | null {
+  if (attention <= 0) return null
+  return (
+    <span
+      style={{
+        fontSize: 9.5,
+        fontWeight: 800,
+        textTransform: 'uppercase',
+        letterSpacing: '0.08em',
+        padding: '3px 8px',
+        borderRadius: 20,
+        flexShrink: 0,
+        color: 'var(--dplex-status-approval)',
+        backgroundColor: 'color-mix(in srgb, var(--dplex-status-approval) 16%, transparent)'
+      }}
+    >
+      {attention} need{attention > 1 ? '' : 's'} you
+    </span>
+  )
+}
+
+function SessionRow({
+  tab,
+  events
+}: {
+  tab: TerminalTab
+  events: readonly AttentionEvent[]
+}): JSX.Element {
+  const ai = isAiSessionTab(tab)
+  const event =
+    ai && tab.providerId && tab.sessionId
+      ? events.find(
+          (e) => e.compositeId === makeCompositeId(tab.providerId!, tab.sessionId!) && !e.suppressed
+        )
+      : undefined
+  const color = event ? attentionColorVar(event.kind) : 'var(--dplex-text-dim)'
+  const statusLabel = event ? attentionKindLabel(event.kind) : ai ? 'Session' : 'Shell'
+  return (
+    <div
+      className="flex items-center gap-2.5"
+      style={{ padding: '8px 10px', backgroundColor: 'var(--dplex-bg-elev-2)', fontSize: 11.5 }}
+    >
+      {ai && tab.providerId ? (
+        <ProviderGlyph providerId={tab.providerId as ProviderId} size="xs" />
+      ) : (
+        <Terminal size={13} style={{ color: 'var(--dplex-text-dim)', flexShrink: 0 }} />
+      )}
+      <span
+        className="flex-1 min-w-0 truncate"
+        style={{ color: 'var(--dplex-text-2)', fontWeight: 500 }}
+      >
+        {tab.title}
+      </span>
+      <span
+        className="inline-flex items-center gap-1.5 flex-shrink-0"
+        style={{ fontSize: 10.5, fontWeight: 600, color }}
+      >
+        <span
+          aria-hidden
+          className={event ? 'dplex-pulse-dot' : ''}
+          style={{ width: 7, height: 7, borderRadius: '50%', backgroundColor: color }}
+        />
+        {statusLabel}
+      </span>
+    </div>
+  )
+}

--- a/src/renderer/src/components/spaces/SpacesPanel.tsx
+++ b/src/renderer/src/components/spaces/SpacesPanel.tsx
@@ -1,0 +1,359 @@
+import { useRef, useState, type JSX } from 'react'
+import { Layers, Minimize2, MoreVertical, Pencil, Play, Plus, Trash2 } from 'lucide-react'
+import { useProjectStore } from '../../stores/projectStore'
+import { useSpaceStore } from '../../stores/spaceStore'
+import { useSpacesUiStore } from '../../stores/spacesUiStore'
+import { useSpaceWorkspace } from '../../hooks/useSpaceWorkspace'
+import { useSpaceAttention } from '../../hooks/useSpaceAttention'
+import { PopoverMenu } from '../common/PopoverMenu'
+import type { Space } from '../../types'
+import { SpaceAvatar } from './SpaceAvatar'
+import { AttentionChip } from './AttentionChip'
+import { boundProjects, relativeTime, sessionCount } from './spaceVisuals'
+
+/**
+ * Sidebar view for managing spaces. The space you're currently in is pulled into
+ * its own "Focused" section at the top (mirroring the Projects panel's "Pinned"
+ * group); every other space follows under "All spaces", most-recently-used
+ * first. "Focused" is a viewport role, not a runtime state — every space, on
+ * screen or not, keeps running and keeps reporting attention.
+ *
+ * Rows follow the shared list-row idiom: a 2 px left accent stripe + accent-soft
+ * fill for the focused row, a weight-600 title with a muted subline, and a hover
+ * `⋮` menu for actions — rather than a bordered "card".
+ */
+export function SpacesPanel(): JSX.Element {
+  const spaces = useSpaceStore((s) => s.spaces)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  const openCreate = useSpacesUiStore((s) => s.openCreate)
+
+  const focused = spaces.find((s) => s.id === activeSpaceId) ?? null
+  // Everything except the focused space, most-recently-active first. When no
+  // space is focused this is simply the full list, rendered flat (no headers).
+  const rest = spaces
+    .filter((s) => s.id !== activeSpaceId)
+    .sort((a, b) => b.lastActiveAt - a.lastActiveAt)
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <div
+        className="flex items-center flex-shrink-0"
+        style={{
+          height: 41,
+          padding: '0 12px',
+          borderBottom: '1px solid var(--dplex-border-subtle)'
+        }}
+      >
+        <span
+          className="font-bold uppercase"
+          style={{ fontSize: 11, letterSpacing: '0.08em', color: 'var(--dplex-text-2)' }}
+        >
+          Spaces
+        </span>
+        <button
+          type="button"
+          onClick={openCreate}
+          data-testid="spaces-panel-new"
+          title="New space"
+          className="ml-auto grid place-items-center rounded-md transition-colors hover:bg-[var(--dplex-hover)]"
+          style={{ width: 24, height: 24, color: 'var(--dplex-text-dim)' }}
+        >
+          <Plus size={15} />
+        </button>
+      </div>
+
+      <div className="flex-1 overflow-y-auto dplex-scroll-autohide flex flex-col pt-1 px-2 pb-3">
+        {spaces.length === 0 && (
+          <div className="px-4 py-8 text-center" style={{ color: 'var(--dplex-text-muted)' }}>
+            <div className="flex flex-col items-center gap-2">
+              <Layers size={20} style={{ opacity: 0.4 }} />
+              <div>
+                <div className="text-xs">No spaces yet</div>
+                <div className="text-[10px] mt-0.5" style={{ opacity: 0.7 }}>
+                  Click + to create one
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {focused && (
+          <>
+            <SectionLabel>Focused</SectionLabel>
+            <SpaceRow space={focused} isActive />
+          </>
+        )}
+
+        {rest.length > 0 && (
+          <>
+            {focused && <SectionLabel>All spaces</SectionLabel>}
+            {rest.map((s) => (
+              <SpaceRow key={s.id} space={s} isActive={false} />
+            ))}
+          </>
+        )}
+      </div>
+
+      <button
+        type="button"
+        data-testid="spaces-panel-open-overview"
+        onClick={() => useSpaceStore.getState().sendToBackground()}
+        disabled={!activeSpaceId}
+        className="flex items-center gap-2 flex-shrink-0 transition-colors hover:bg-[var(--dplex-hover)]"
+        style={{
+          height: 34,
+          padding: '0 14px',
+          borderTop: '1px solid var(--dplex-border-subtle)',
+          fontSize: 11.5,
+          fontWeight: 600,
+          color: activeSpaceId ? 'var(--dplex-text-2)' : 'var(--dplex-text-faint)',
+          cursor: activeSpaceId ? 'pointer' : 'default'
+        }}
+        title={activeSpaceId ? 'Step back to the Overview' : 'Already on the Overview'}
+      >
+        <Layers size={13} style={{ color: 'var(--dplex-text-dim)' }} />
+        Open Overview
+      </button>
+    </div>
+  )
+}
+
+function SectionLabel({ children }: { children: string }): JSX.Element {
+  return (
+    <div
+      className="px-2 pt-3 pb-1.5 text-[10px] font-semibold uppercase first:pt-2"
+      style={{ letterSpacing: '0.10em', color: 'var(--dplex-text-faint)' }}
+    >
+      {children}
+    </div>
+  )
+}
+
+function SpaceRow({ space, isActive }: { space: Space; isActive: boolean }): JSX.Element {
+  const attention = useSpaceAttention(space)
+  const ws = useSpaceWorkspace(space)
+  const sessions = sessionCount(ws)
+  const projects = useProjectStore((s) => s.projects)
+  const bound = boundProjects(space, projects)
+
+  const rename = useSpacesUiStore((s) => s.openRename)
+  const requestDelete = useSpacesUiStore((s) => s.requestDelete)
+
+  const [showMenu, setShowMenu] = useState(false)
+  const menuAnchorRef = useRef<HTMLButtonElement>(null)
+
+  const activate = (): void => {
+    if (!isActive) useSpaceStore.getState().switchSpace(space.id)
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      data-testid={`space-row-${space.id}`}
+      onClick={activate}
+      onKeyDown={(e) => {
+        if ((e.key === 'Enter' || e.key === ' ') && !isActive) {
+          e.preventDefault()
+          activate()
+        }
+      }}
+      onContextMenu={(e) => {
+        e.preventDefault()
+        setShowMenu((v) => !v)
+      }}
+      className="group relative flex items-start gap-2.5 mx-0.5 mb-0.5 pl-3 pr-2 py-2 cursor-pointer rounded-lg transition-colors"
+      style={isActive ? { backgroundColor: 'var(--dplex-accent-soft)' } : undefined}
+      onMouseEnter={(e) => {
+        if (!isActive) e.currentTarget.style.backgroundColor = 'var(--dplex-hover)'
+      }}
+      onMouseLeave={(e) => {
+        if (!isActive) e.currentTarget.style.backgroundColor = ''
+      }}
+    >
+      {/* Selected (active) row gets the shared 2 px left accent stripe —
+          matches Project rows, Session rows, activity-bar items, and the
+          search palette. Replaces the previous full color-mix border, which
+          read as a separate "card" rather than a selected list item. */}
+      {isActive && (
+        <span
+          aria-hidden
+          style={{
+            position: 'absolute',
+            left: 0,
+            top: 6,
+            bottom: 6,
+            width: 2,
+            borderRadius: '0 2px 2px 0',
+            backgroundColor: 'var(--dplex-accent)',
+            boxShadow: '0 0 8px var(--dplex-accent-glow)',
+            pointerEvents: 'none'
+          }}
+        />
+      )}
+
+      <SpaceAvatar
+        space={space}
+        size={26}
+        radius={7}
+        ping={attention.total > 0 && !isActive}
+        style={{ marginTop: 2 }}
+      />
+
+      <div className="flex-1 min-w-0 flex flex-col gap-0.5">
+        {/* Line 1 — name · attention · active/time */}
+        <div className="flex items-center gap-1.5 min-w-0">
+          <span
+            className="flex-1 truncate text-[13px] font-semibold"
+            style={{ color: 'var(--dplex-text)', letterSpacing: '-0.005em' }}
+          >
+            {space.name}
+          </span>
+          {attention.total > 0 && <AttentionChip attention={attention} compact />}
+          {!isActive && (
+            <span
+              className="flex-shrink-0 tabular-nums text-[10.5px]"
+              style={{ color: 'var(--dplex-text-dim)' }}
+            >
+              {relativeTime(space.lastActiveAt)}
+            </span>
+          )}
+        </div>
+
+        {/* Line 2 — subline: the primary project (the "where") on the left, and a
+            plain session count (the "what") pinned right. Text count instead of
+            an icon strip — consistent with the Overview and the Space switcher,
+            and keeps the row a tidy two lines like Project/Session rows.
+            One truncating primary pill + a "+N" overflow (mirroring ProjectItem's
+            single-truncating-meta pattern) guarantees a graceful fit at any
+            width; the session count always shows — it reads "0 sessions" when a
+            space has none, matching the Overview card footer. */}
+        <div className="flex items-center gap-1.5 min-w-0" style={{ marginTop: 2 }}>
+          {bound.length > 0 && (
+            <>
+              <span
+                className="truncate text-[10px] font-medium leading-[15px]"
+                style={{
+                  maxWidth: 118,
+                  color: 'var(--dplex-text-muted)',
+                  background: 'var(--dplex-bg-alt)',
+                  border: '1px solid var(--dplex-border)',
+                  borderRadius: 5,
+                  padding: '0 6px'
+                }}
+                title={bound.map((p) => p.name).join(', ')}
+              >
+                {bound[0].name}
+              </span>
+              {bound.length > 1 && (
+                <span
+                  className="flex-shrink-0 text-[10px] font-medium tabular-nums"
+                  style={{ color: 'var(--dplex-text-dim)' }}
+                >
+                  +{bound.length - 1}
+                </span>
+              )}
+            </>
+          )}
+          <span
+            className={`flex-shrink-0 tabular-nums text-[10.5px] ${bound.length > 0 ? 'ml-auto' : ''}`}
+            style={{ color: 'var(--dplex-text-dim)' }}
+          >
+            {sessions} session{sessions === 1 ? '' : 's'}
+          </span>
+        </div>
+      </div>
+
+      {/* Actions — a single hover `⋮` menu, matching the Project and Session
+          rows (replaces the previous always-cramped inline button cluster). */}
+      <button
+        ref={menuAnchorRef}
+        type="button"
+        title="Space actions"
+        aria-label="Space actions"
+        onClick={(e) => {
+          e.stopPropagation()
+          setShowMenu((v) => !v)
+        }}
+        className="opacity-0 group-hover:opacity-100 p-0.5 rounded transition-opacity flex-shrink-0 mt-0.5 hover:bg-[var(--dplex-hover)]"
+        data-testid={`space-menu-${space.id}`}
+      >
+        <MoreVertical size={13} style={{ color: 'var(--dplex-text-muted)' }} />
+      </button>
+
+      <PopoverMenu
+        anchorRef={menuAnchorRef}
+        open={showMenu}
+        onClose={() => setShowMenu(false)}
+        className="min-w-[168px]"
+      >
+        {isActive ? (
+          <SpaceMenuItem
+            icon={<Minimize2 size={11} />}
+            label="Minimize"
+            onClick={() => useSpaceStore.getState().sendToBackground()}
+            close={() => setShowMenu(false)}
+            data-testid={`space-minimize-${space.id}`}
+          />
+        ) : (
+          <SpaceMenuItem
+            icon={<Play size={11} />}
+            label="Resume"
+            onClick={() => useSpaceStore.getState().switchSpace(space.id)}
+            close={() => setShowMenu(false)}
+            data-testid={`space-resume-${space.id}`}
+          />
+        )}
+        <SpaceMenuItem
+          icon={<Pencil size={11} />}
+          label="Rename"
+          onClick={() => rename(space.id)}
+          close={() => setShowMenu(false)}
+          data-testid={`space-rename-${space.id}`}
+        />
+        <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+        <SpaceMenuItem
+          icon={<Trash2 size={11} />}
+          label="Delete"
+          danger
+          onClick={() => requestDelete({ id: space.id, name: space.name })}
+          close={() => setShowMenu(false)}
+          data-testid={`space-delete-${space.id}`}
+        />
+      </PopoverMenu>
+    </div>
+  )
+}
+
+function SpaceMenuItem({
+  icon,
+  label,
+  onClick,
+  close,
+  danger = false,
+  ...rest
+}: {
+  icon: React.ReactNode
+  label: string
+  onClick: () => void
+  close: () => void
+  danger?: boolean
+} & Record<`data-${string}`, string>): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.stopPropagation()
+        close()
+        onClick()
+      }}
+      className={`flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]${
+        danger ? ' text-red-400' : ''
+      }`}
+      style={danger ? undefined : { color: 'var(--dplex-text)' }}
+      {...rest}
+    >
+      {icon} {label}
+    </button>
+  )
+}

--- a/src/renderer/src/components/spaces/spaceVisuals.ts
+++ b/src/renderer/src/components/spaces/spaceVisuals.ts
@@ -1,0 +1,103 @@
+import type { AttentionKind } from '../../../../preload/attentionTypes'
+import {
+  isTerminalTab,
+  type Project,
+  type Space,
+  type TerminalTab,
+  type WorkspaceSnapshot
+} from '../../types'
+import type { SpaceAttention } from '../../utils/spaceAttention'
+
+/** Darken (amt<0) or lighten (amt>0) a hex color by a flat channel offset. */
+export function shade(hex: string, amt: number): string {
+  let c = hex.replace('#', '')
+  if (c.length === 3)
+    c = c
+      .split('')
+      .map((x) => x + x)
+      .join('')
+  const n = parseInt(c, 16)
+  const clamp = (v: number): number => Math.max(0, Math.min(255, v))
+  const r = clamp((n >> 16) + amt)
+  const g = clamp(((n >> 8) & 255) + amt)
+  const b = clamp((n & 255) + amt)
+  return '#' + ((r << 16) | (g << 8) | b).toString(16).padStart(6, '0')
+}
+
+/** Up to two uppercase initials from a space name (for the avatar fallback). */
+export function spaceInitials(name: string): string {
+  const words = name.trim().split(/\s+/).filter(Boolean)
+  if (words.length === 0) return 'S'
+  return words
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase()
+}
+
+/** The glyph to render on a space avatar: explicit glyph, else initials. */
+export function glyphFor(space: Pick<Space, 'name' | 'glyph'>): string {
+  const g = typeof space.glyph === 'string' ? space.glyph.trim() : ''
+  return g.length > 0 ? g : spaceInitials(space.name)
+}
+
+/** CSS var for an attention kind's color (approval > input > finished). */
+export function attentionColorVar(kind: AttentionKind | null): string {
+  switch (kind) {
+    case 'waitingForApproval':
+      return 'var(--dplex-status-approval)'
+    case 'waitingForInput':
+      return 'var(--dplex-status-waiting)'
+    case 'finished':
+      return 'var(--dplex-status-success)'
+    default:
+      return 'var(--dplex-status-idle)'
+  }
+}
+
+/** Short human label for a space's rolled-up attention, e.g. "3 to review". */
+export function attentionLabel(a: SpaceAttention): string {
+  if (a.total === 0) return ''
+  if (a.waitingForApproval > 0 || a.waitingForInput > 0) {
+    const n = a.waitingForApproval + a.waitingForInput
+    return `${n} to review`
+  }
+  return `${a.finished} done`
+}
+
+/** All terminal tabs (AI sessions + plain shells) in a workspace snapshot. */
+export function terminalTabs(ws: WorkspaceSnapshot): TerminalTab[] {
+  const out: TerminalTab[] = []
+  for (const g of ws.groups) for (const t of g.tabs) if (isTerminalTab(t)) out.push(t)
+  return out
+}
+
+/** Count of terminal tabs (AI sessions + shells) in a workspace snapshot. */
+export function sessionCount(ws: WorkspaceSnapshot): number {
+  return terminalTabs(ws).length
+}
+
+/** True when a terminal tab is an AI session (has a resolved provider+session). */
+export function isAiSessionTab(t: TerminalTab): boolean {
+  return !!(t.providerId && t.sessionId)
+}
+
+/** Resolve a space's bound projects to Project objects, in bind order,
+ *  dropping any ids that no longer exist. */
+export function boundProjects(space: Pick<Space, 'projectIds'>, projects: Project[]): Project[] {
+  return space.projectIds
+    .map((id) => projects.find((p) => p.id === id))
+    .filter((p): p is Project => !!p)
+}
+
+/** Compact "time ago" label for a space's last-active timestamp. */
+export function relativeTime(ts: number, now: number = Date.now()): string {
+  const diff = Math.max(0, now - ts)
+  const min = Math.floor(diff / 60000)
+  if (min < 1) return 'just now'
+  if (min < 60) return `${min}m ago`
+  const hr = Math.floor(min / 60)
+  if (hr < 24) return `${hr}h ago`
+  const day = Math.floor(hr / 24)
+  return day === 1 ? 'yesterday' : `${day}d ago`
+}

--- a/src/renderer/src/components/terminal/MonacoEditorPane.tsx
+++ b/src/renderer/src/components/terminal/MonacoEditorPane.tsx
@@ -4,6 +4,7 @@ import { loadMonaco, languageIdForPath } from '../../services/monacoLazy'
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useTerminalStore } from '../../stores/terminalStore'
 import { registerFileEditor } from '../../services/fileEditorRegistry'
+import { takeParkedEditorBuffer, type ParkedEditorBuffer } from '../../services/parkedEditorBuffers'
 import { watchRootMatches } from '../../stores/fileWatchRoots'
 import { RotateCcw, Save, AlertTriangle } from 'lucide-react'
 
@@ -72,15 +73,26 @@ export function MonacoEditorPane({
   const lastSavedMtimeRef = useRef<number>(0)
   const autoSaveModeRef = useRef(autoSaveMode)
   const externallyDeletedRef = useRef(false)
+  const conflictRef = useRef(false)
+  const externallyChangedRef = useRef(false)
   const disposedRef = useRef(false)
 
   // Monotonic tokens to invalidate stale async work.
   const loadTokenRef = useRef(0)
   const verifyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
   const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const saveStateRef = useRef<{ inFlight: boolean; queued: boolean }>({
+  const saveStateRef = useRef<{
+    inFlight: boolean
+    queued: boolean
+    // Captured at park-time when a save is already in-flight: the newest buffer
+    // that must still reach disk even though the pane is about to unmount. The
+    // in-flight write returns early on dispose and can't loop to pick these
+    // keystrokes up, so doSave's finally force-writes this instead.
+    parkFlush: { content: string; root: string; rel: string; eol: '\n' | '\r\n' } | null
+  }>({
     inFlight: false,
-    queued: false
+    queued: false,
+    parkFlush: null
   })
 
   // Stable indirection so the registry/command always call the freshest impl.
@@ -98,6 +110,20 @@ export function MonacoEditorPane({
   useEffect(() => {
     autoSaveModeRef.current = autoSaveMode
   }, [autoSaveMode])
+
+  // Conflict / external-change flags are mirrored into refs *synchronously* (not
+  // via a passive effect) so an async save reads the freshest value: a watcher
+  // detecting an external edit and a pending autosave firing can race within the
+  // same tick, and a lagging ref would let the autosave overwrite the external
+  // change. Always set both through these helpers.
+  const markConflict = (v: boolean): void => {
+    conflictRef.current = v
+    setConflict(v)
+  }
+  const markExternallyChanged = (v: boolean): void => {
+    externallyChangedRef.current = v
+    setExternallyChanged(v)
+  }
 
   const isDirtyNow = (): boolean => {
     const m = modelRef.current
@@ -120,6 +146,24 @@ export function MonacoEditorPane({
       clearTimeout(verifyTimerRef.current)
       verifyTimerRef.current = null
     }
+  }
+
+  // Debounced auto-save (onChange mode). Extracted so both the change listener
+  // and the park → resume restore path can (re)arm it: parking unmounts the
+  // editor, whose cleanup cancels any pending debounce, so a restored dirty
+  // buffer must reschedule its save or an autosave editor's stashed edits would
+  // never reach disk.
+  const scheduleAutoSave = (): void => {
+    if (autoSaveModeRef.current !== 'onChange') return
+    clearDebounce()
+    debounceTimerRef.current = setTimeout(() => {
+      debounceTimerRef.current = null
+      // Re-check the mode: the user may have switched to manual save during the
+      // debounce window, in which case we must not save.
+      if (statusRef.current === 'ready' && autoSaveModeRef.current === 'onChange') {
+        void doSaveRef.current()
+      }
+    }, AUTO_SAVE_DEBOUNCE_MS)
   }
 
   // ---- Boot Monaco once -----------------------------------------------------
@@ -187,6 +231,45 @@ export function MonacoEditorPane({
     monaco.editor.setTheme(isLight ? 'vs' : 'vs-dark')
   }, [themeName, monacoReady])
 
+  /**
+   * Restore a parked buffer for a file that was deleted while its Space was
+   * parked: mount the unsaved edits as a dirty, externally-deleted editor so
+   * they survive and an explicit save recreates the file (mirrors the watcher's
+   * dirty-delete handling below). No auto-save fires for a missing file — the
+   * user saves deliberately. Declared before the load effect that calls it.
+   */
+  const restoreDeletedParkedBuffer = (parked: ParkedEditorBuffer): void => {
+    const monaco = monacoRef.current
+    const ed = editorRef.current
+    if (!monaco || !ed) return
+    changeListenerRef.current?.dispose()
+    changeListenerRef.current = null
+    const prevModel = modelRef.current
+    const model = monaco.editor.createModel(parked.content, languageIdForPath(relPathRef.current))
+    model.setEOL(
+      parked.eol === '\r\n'
+        ? monaco.editor.EndOfLineSequence.CRLF
+        : monaco.editor.EndOfLineSequence.LF
+    )
+    modelRef.current = model
+    ed.setModel(model)
+    prevModel?.dispose()
+    ed.updateOptions({ readOnly: false })
+    eolRef.current = parked.eol
+    lastSavedContentRef.current = parked.baseContent
+    lastSavedMtimeRef.current = parked.baseMtimeMs
+    externallyDeletedRef.current = true
+    setExternallyDeleted(true)
+    markConflict(false)
+    markExternallyChanged(false)
+    setStatus('ready')
+    setDirty(isDirtyNow())
+    changeListenerRef.current = model.onDidChangeContent(() => {
+      if (disposedRef.current) return
+      setDirty(isDirtyNow())
+    })
+  }
+
   // ---- Load (or retarget) on path/mount -------------------------------------
   // A relPath change while the buffer is dirty is a RENAME of the live file
   // (the explorer rewrites the tab's path); we must keep unsaved edits and
@@ -209,8 +292,8 @@ export function MonacoEditorPane({
     const token = ++loadTokenRef.current
     setStatus('loading')
     setErrorMsg(null)
-    setConflict(false)
-    setExternallyChanged(false)
+    markConflict(false)
+    markExternallyChanged(false)
     setExternallyDeleted(false)
     externallyDeletedRef.current = false
     clearDebounce()
@@ -226,8 +309,15 @@ export function MonacoEditorPane({
 
         if (!res.ok) {
           if (res.code === 'NOT_FOUND') {
-            setStatus('missing')
+            // The file was deleted while its Space was parked. If we stashed
+            // unsaved edits, restore them as a dirty, externally-deleted buffer
+            // (an explicit save recreates the file) rather than dropping them.
+            // Consuming the stash here also stops it leaking.
+            const parked = takeParkedEditorBuffer(tabId)
+            if (parked) restoreDeletedParkedBuffer(parked)
+            else setStatus('missing')
           } else {
+            // Leave any stash in place — a later successful remount recovers it.
             setStatus('error')
             setErrorMsg(res.message ?? res.code ?? 'Failed to read file')
           }
@@ -254,7 +344,53 @@ export function MonacoEditorPane({
         ed2.setModel(model)
         prevModel?.dispose()
         ed2.updateOptions({ readOnly })
-        setDirty(false)
+
+        // Restore an unsaved buffer stashed when this editor's Space was parked
+        // (switched away / minimized). Only for editable files — a file that
+        // turned binary/too-large while parked can't host the edits, so we leave
+        // its stash in place (rather than consuming and dropping it): the close
+        // guard still treats the tab as dirty, and it self-heals if the file
+        // becomes editable again. Runs before the change listener attaches
+        // below, so restoring doesn't spuriously trigger onChange auto-save.
+        const parked = readOnly ? null : takeParkedEditorBuffer(tabId)
+        if (parked) {
+          model.setValue(parked.content)
+          model.setEOL(
+            parked.eol === '\r\n'
+              ? monaco2.editor.EndOfLineSequence.CRLF
+              : monaco2.editor.EndOfLineSequence.LF
+          )
+          if (res.content === parked.content) {
+            // Disk already holds exactly our parked edit — an onChange editor
+            // flushed the pending autosave when its Space was parked (or an
+            // external write happened to land identical bytes). Adopt disk as the
+            // clean baseline: nothing to save, and crucially no false conflict.
+            lastSavedContentRef.current = res.content
+            lastSavedMtimeRef.current = res.mtimeMs
+            setDirty(false)
+          } else {
+            // Reinstate the baseline the edits were made against (keeping the OLD
+            // mtime) so a concurrent external write during the park window is
+            // surfaced as a conflict on save instead of being silently
+            // overwritten — the same protection a mounted dirty editor has.
+            lastSavedContentRef.current = parked.baseContent
+            lastSavedMtimeRef.current = parked.baseMtimeMs
+            // Disk diverged from our edit baseline while parked → a hard conflict:
+            // block autosave from overwriting the external change (the user must
+            // Reload or explicitly Overwrite). The mtime tolerance alone can miss
+            // a near-simultaneous external write, so don't rely on STALE here.
+            if (res.content !== parked.baseContent) markConflict(true)
+            setDirty(isDirtyNow())
+            // Parking unmounted the editor and cancelled any pending auto-save. If
+            // the disk still matches the edit baseline (no conflict), re-arm the
+            // autosave so a stashed onChange edit still reaches disk even if the
+            // park-time flush hadn't landed yet; a diverged disk raised a conflict
+            // above, which blocks writes until resolved.
+            if (res.content === parked.baseContent && isDirtyNow()) scheduleAutoSave()
+          }
+        } else {
+          setDirty(false)
+        }
 
         if (res.isBinary) setStatus('binary')
         else if (res.truncated) setStatus('too-large')
@@ -265,17 +401,7 @@ export function MonacoEditorPane({
             if (disposedRef.current) return
             const dirty = isDirtyNow()
             setDirty(dirty)
-            if (dirty && autoSaveModeRef.current === 'onChange') {
-              clearDebounce()
-              debounceTimerRef.current = setTimeout(() => {
-                debounceTimerRef.current = null
-                // Re-check the mode: the user may have switched to manual save
-                // during the debounce window, in which case we must not save.
-                if (statusRef.current === 'ready' && autoSaveModeRef.current === 'onChange') {
-                  void doSaveRef.current()
-                }
-              }, AUTO_SAVE_DEBOUNCE_MS)
-            }
+            if (dirty) scheduleAutoSave()
           })
         }
 
@@ -321,6 +447,17 @@ export function MonacoEditorPane({
       // Only saveable when ready, OR when the file was externally deleted while
       // dirty (save recreates it). Binary/too-large/loading are never saved.
       if (statusRef.current !== 'ready' && !externallyDeletedRef.current) return
+      // A known external change (hard conflict, or the softer watcher/verify
+      // "changed on disk" state) must never be silently overwritten by an
+      // autosave or ⌘S — only an explicit force (the banner's Overwrite / Keep
+      // mine) or a deleted-file recreate may write through it. Guarding on the
+      // watcher state too closes the mtime-tolerance hole where a near-
+      // simultaneous external edit slips past the optimistic-concurrency check.
+      if (
+        (conflictRef.current || externallyChangedRef.current) &&
+        !(opts?.force || externallyDeletedRef.current)
+      )
+        return
       if (saveStateRef.current.inFlight) {
         saveStateRef.current.queued = true
         return
@@ -328,6 +465,10 @@ export function MonacoEditorPane({
       saveStateRef.current.inFlight = true
       const curRoot = rootFsRef.current
       const curRel = relPathRef.current
+      // Our own last successful write's mtime this call, captured before the
+      // dispose bail-out (which skips the ref update below) so the park-flush can
+      // guard against a racing external edit instead of blind-forcing.
+      let lastOkMtimeMs: number | undefined
       try {
         // Loop so edits made mid-write are flushed (latest buffer always wins).
         // Converges once the model is unchanged across a completed write.
@@ -346,12 +487,19 @@ export function MonacoEditorPane({
             eolRef.current,
             expected
           )
-          if (disposedRef.current) return
           // A path switch/rename mid-save: abandon (the new target reloads).
+          // Checked before recording conflict so a stale write against the OLD
+          // target never flags the pane's NEW file.
           if (rootFsRef.current !== curRoot || relPathRef.current !== curRel) return
+          // Record a stale write synchronously — even if this pane has since been
+          // disposed (parked/unmounted) — so the park-flush in `finally` observes
+          // the conflict and never force-overwrites an external edit that landed
+          // during this in-flight write.
+          if (!res.ok && res.code === 'STALE_FILE') markConflict(true)
+          if (res.ok && typeof res.mtimeMs === 'number') lastOkMtimeMs = res.mtimeMs
+          if (disposedRef.current) return
           if (!res.ok) {
-            if (res.code === 'STALE_FILE') setConflict(true)
-            else {
+            if (res.code !== 'STALE_FILE') {
               setStatus('error')
               setErrorMsg(res.message ?? res.code ?? 'Save failed')
             }
@@ -361,8 +509,8 @@ export function MonacoEditorPane({
           if (typeof res.mtimeMs === 'number') lastSavedMtimeRef.current = res.mtimeMs
           externallyDeletedRef.current = false
           setExternallyDeleted(false)
-          setConflict(false)
-          setExternallyChanged(false)
+          markConflict(false)
+          markExternallyChanged(false)
           scheduleVerify(content)
           const stillSame =
             modelRef.current && modelRef.current.getAlternativeVersionId() === versionId
@@ -374,6 +522,31 @@ export function MonacoEditorPane({
         }
       } finally {
         saveStateRef.current.inFlight = false
+        const parkFlush = saveStateRef.current.parkFlush
+        saveStateRef.current.parkFlush = null
+        // The pane parked mid-write: write the captured final keystrokes to disk
+        // so they survive the unmount. Only when actually disposed — otherwise the
+        // loop above already re-wrote the newest content and this stale capture
+        // would regress the file. Guarded (below) by our own last successful
+        // write's mtime rather than forced: if an external edit raced in after
+        // that write, this fails STALE and is dropped instead of clobbering it.
+        // Also skipped on a known conflict/external change. Either way the dirty
+        // buffer was stashed to parkedEditorBuffers on park
+        // (stashAllDirtyFileEditors), so nothing is lost — it's reconciled on resume.
+        if (
+          parkFlush &&
+          disposedRef.current &&
+          !conflictRef.current &&
+          !externallyChangedRef.current
+        ) {
+          void window.dplex.files.writeFile(
+            parkFlush.root,
+            parkFlush.rel,
+            parkFlush.content,
+            parkFlush.eol,
+            lastOkMtimeMs
+          )
+        }
         if (saveStateRef.current.queued && !disposedRef.current) {
           saveStateRef.current.queued = false
           void doSaveRef.current()
@@ -403,7 +576,7 @@ export function MonacoEditorPane({
             return
           }
           // Disk diverged from what we wrote → genuine external edit.
-          if (isDirtyNow()) setExternallyChanged(true)
+          if (isDirtyNow()) markExternallyChanged(true)
           else applyExternalReload(res.content, res.eol, res.mtimeMs)
         })
         .catch(() => {})
@@ -414,16 +587,25 @@ export function MonacoEditorPane({
     const monaco = monacoRef.current
     const model = modelRef.current
     if (!monaco || !model) return
+    // Update the saved baseline BEFORE mutating the model: setValue/setEOL fire
+    // the synchronous onDidChangeContent listener, which reads these refs via
+    // isDirtyNow — a stale baseline would flag the reload as dirty and schedule
+    // a redundant (identical-bytes) autosave. Apply the new content BEFORE the
+    // EOL: setEOL also fires the change listener, and doing it while the model
+    // still holds the OLD content (but the baseline is already the NEW content)
+    // would read as dirty and arm a spurious autosave when both content and EOL
+    // changed. With the value applied first, every change event sees content
+    // that matches the baseline.
     eolRef.current = eol
+    lastSavedContentRef.current = content
+    lastSavedMtimeRef.current = mtimeMs
+    if (model.getValue() !== content) model.setValue(content)
     model.setEOL(
       eol === '\r\n' ? monaco.editor.EndOfLineSequence.CRLF : monaco.editor.EndOfLineSequence.LF
     )
-    if (model.getValue() !== content) model.setValue(content)
-    lastSavedContentRef.current = content
-    lastSavedMtimeRef.current = mtimeMs
     setDirty(false)
-    setExternallyChanged(false)
-    setConflict(false)
+    markExternallyChanged(false)
+    markConflict(false)
   }
 
   // ---- External change detection (watcher) ----------------------------------
@@ -462,7 +644,7 @@ export function MonacoEditorPane({
             lastSavedMtimeRef.current = res.mtimeMs
             return
           }
-          if (isDirtyNow()) setExternallyChanged(true)
+          if (isDirtyNow()) markExternallyChanged(true)
           else applyExternalReload(res.content, res.eol, res.mtimeMs)
         })
         .catch(() => {})
@@ -476,7 +658,51 @@ export function MonacoEditorPane({
   useEffect(() => {
     const unregister = registerFileEditor(tabId, {
       save: () => doSaveRef.current(),
-      isDirty: () => isDirtyNow()
+      isDirty: () => isDirtyNow(),
+      getDirtyBuffer: () =>
+        isDirtyNow() && modelRef.current
+          ? {
+              content: modelRef.current.getValue(),
+              eol: eolRef.current,
+              baseContent: lastSavedContentRef.current,
+              baseMtimeMs: lastSavedMtimeRef.current
+            }
+          : null,
+      // Called when this editor's Space is being parked (switch away / minimize).
+      // In onChange auto-save mode, dispatch the pending debounced save NOW —
+      // while the model is still mounted — so an edit made inside the debounce
+      // window reaches disk before the pane unmounts. Without this, quitting
+      // while parked (before the editor remounts and re-arms the timer on resume)
+      // would drop that edit. A known conflict / external change is deliberately
+      // left untouched for the user to resolve on resume; manual-save mode never
+      // auto-flushes. doSave captures content synchronously before its await, so
+      // this fire-and-forget dispatch reaches disk even though we unmount next.
+      flushIfAutoSave: () => {
+        const model = modelRef.current
+        if (
+          autoSaveModeRef.current === 'onChange' &&
+          statusRef.current === 'ready' &&
+          !conflictRef.current &&
+          !externallyChangedRef.current &&
+          !externallyDeletedRef.current &&
+          model &&
+          isDirtyNow()
+        ) {
+          if (saveStateRef.current.inFlight) {
+            // A save is mid-write and we're about to unmount: that write can't
+            // loop to pick up the newest keystrokes once disposed. Capture them
+            // now (model still mounted) so doSave's finally forces them to disk.
+            saveStateRef.current.parkFlush = {
+              content: model.getValue(),
+              root: rootFsRef.current,
+              rel: relPathRef.current,
+              eol: eolRef.current
+            }
+          } else {
+            void doSaveRef.current()
+          }
+        }
+      }
     })
     return unregister
   }, [tabId])

--- a/src/renderer/src/components/worktrees/ManageWorktreesModal.tsx
+++ b/src/renderer/src/components/worktrees/ManageWorktreesModal.tsx
@@ -256,7 +256,8 @@ export function ManageWorktreesModal({
               afterCreate: result.afterCreate,
               providerId: result.providerId,
               setupScript: result.setupScript,
-              createdByDplexWorktree: true
+              createdByDplexWorktree: true,
+              originSpaceId: result.originSpaceId
             })
             void refresh()
           }}

--- a/src/renderer/src/components/worktrees/NewWorktreeModal.tsx
+++ b/src/renderer/src/components/worktrees/NewWorktreeModal.tsx
@@ -3,6 +3,7 @@ import { X } from 'lucide-react'
 import type { Project, ProviderInfo, WorktreeDefaults } from '../../types'
 import { expandPattern } from '../../utils/worktreePath'
 import { useProjectStore } from '../../stores/projectStore'
+import { useSpaceStore } from '../../stores/spaceStore'
 import { useEscapeKey } from '../../hooks/useEscapeKey'
 
 interface NewWorktreeModalProps {
@@ -18,6 +19,9 @@ interface NewWorktreeModalProps {
     providerId: string | null
     branch: string
     setupScript: string
+    /** Space active when the user initiated creation, captured before the
+     *  create IPC so a switch during creation can't mis-route the tabs. */
+    originSpaceId: string | null
   }) => void
 }
 
@@ -99,6 +103,12 @@ export function NewWorktreeModal({
     if (!trimmedBranch || !location.trim()) return
     setSubmitting(true)
     setError(null)
+    // Capture the active Space BEFORE the create IPC: worktree creation (git
+    // worktree add + optional env copy) can take a moment, and if the user
+    // switches Spaces during it, the setup/afterCreate tabs must still route to
+    // where the worktree was initiated — not wherever focus happens to be when
+    // creation finishes.
+    const originSpaceId = useSpaceStore.getState().activeSpaceId
     try {
       const resp = await window.dplex.worktrees.create({
         repoRoot,
@@ -134,7 +144,8 @@ export function NewWorktreeModal({
         afterCreate,
         providerId: null,
         branch: trimmedBranch,
-        setupScript
+        setupScript,
+        originSpaceId
       })
     } catch (err) {
       setError(err instanceof Error ? err.message : String(err))

--- a/src/renderer/src/hooks/useSpaceAttention.ts
+++ b/src/renderer/src/hooks/useSpaceAttention.ts
@@ -1,0 +1,65 @@
+import { useMemo } from 'react'
+import type { AttentionKind } from '../../../preload/attentionTypes'
+import { useAttentionStore } from '../stores/attentionStore'
+import { useSpaceStore } from '../stores/spaceStore'
+import { useTerminalStore } from '../stores/terminalStore'
+import type { Space } from '../types'
+import {
+  aggregateActiveAwareAttention,
+  aggregateSpaceAttention,
+  pickTopKind,
+  type SpaceAttention
+} from '../utils/spaceAttention'
+
+/**
+ * Rolled-up attention for one space. The active space reads its live session
+ * tabs from the terminal store (so brand-new sessions count immediately);
+ * background spaces read their stashed snapshot.
+ */
+export function useSpaceAttention(space: Space): SpaceAttention {
+  const events = useAttentionStore((s) => s.active)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  const isActiveSpace = space.id === activeSpaceId
+  // Only the active space needs live groups; subscribing background cards to
+  // `groups` would recompute them all on any terminal op elsewhere.
+  const liveGroups = useTerminalStore((s) => (isActiveSpace ? s.groups : null))
+  return useMemo(
+    () => aggregateActiveAwareAttention(space, events, liveGroups ? { groups: liveGroups } : null),
+    [space, events, liveGroups]
+  )
+}
+
+export interface BackgroundAttention {
+  total: number
+  topKind: AttentionKind | null
+  /** Number of background spaces with at least one pending event. */
+  spacesNeedingAttention: number
+}
+
+/**
+ * Attention rolled up across every space that is NOT in focus — powers the
+ * activity-bar ring / badge that pings you when a backgrounded space needs a
+ * decision.
+ */
+export function useBackgroundAttention(): BackgroundAttention {
+  const events = useAttentionStore((s) => s.active)
+  const spaces = useSpaceStore((s) => s.spaces)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  return useMemo(() => {
+    let approval = 0
+    let input = 0
+    let finished = 0
+    let spacesNeedingAttention = 0
+    for (const s of spaces) {
+      if (s.id === activeSpaceId) continue
+      const a = aggregateSpaceAttention(s, events)
+      if (a.total > 0) spacesNeedingAttention += 1
+      approval += a.waitingForApproval
+      input += a.waitingForInput
+      finished += a.finished
+    }
+    const total = approval + input + finished
+    const topKind = pickTopKind(approval, input, finished)
+    return { total, topKind, spacesNeedingAttention }
+  }, [events, spaces, activeSpaceId])
+}

--- a/src/renderer/src/hooks/useSpaceWorkspace.ts
+++ b/src/renderer/src/hooks/useSpaceWorkspace.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react'
+import type { Space, WorkspaceSnapshot } from '../types'
+import { useSpaceStore } from '../stores/spaceStore'
+import { useTerminalStore } from '../stores/terminalStore'
+
+/**
+ * The resolved workspace arrangement for a space. The space in focus reads its
+ * live groups from the terminal store (so counts/tabs update as you work);
+ * background spaces read their stashed snapshot. Keeps every space surface
+ * (switcher, panel, overview) consistent with what is actually running.
+ */
+export function useSpaceWorkspace(space: Space): WorkspaceSnapshot {
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  const liveGroups = useTerminalStore((s) => s.groups)
+  const liveLayout = useTerminalStore((s) => s.layout)
+  const liveActiveGroupId = useTerminalStore((s) => s.activeGroupId)
+  return useMemo(() => {
+    if (space.id === activeSpaceId) {
+      return { groups: liveGroups, layout: liveLayout, activeGroupId: liveActiveGroupId }
+    }
+    return space.workspace
+  }, [space, activeSpaceId, liveGroups, liveLayout, liveActiveGroupId])
+}

--- a/src/renderer/src/hooks/useTerminal.ts
+++ b/src/renderer/src/hooks/useTerminal.ts
@@ -2,7 +2,8 @@ import { useEffect, useRef, useState } from 'react'
 import { useSettingsStore } from '../stores/settingsStore'
 import { useSessionStore } from '../stores/sessionStore'
 import { useTerminalStore } from '../stores/terminalStore'
-import { isTerminalTab } from '../types'
+import { useSpaceStore, patchBackgroundTab } from '../stores/spaceStore'
+import { isTerminalTab, type TerminalTab } from '../types'
 import {
   getOrCreateTerminal,
   updateTerminalFont,
@@ -10,6 +11,8 @@ import {
   applyThemeToAll,
   fireExitHandler,
   registerPtyDataHandler,
+  subscribeTerminalReady,
+  markTerminalReady,
   type TerminalEntry
 } from '../services/terminalRegistry'
 
@@ -26,8 +29,54 @@ const SESSION_RESOLVE_MAX_RETRIES = 6
  */
 const pendingOscTitles = new Map<string, string>()
 
+function findTabAnywhere(terminalId: string): { tab: TerminalTab; active: boolean } | null {
+  const active = useTerminalStore
+    .getState()
+    .groups.flatMap((g) => g.tabs)
+    .find((t) => t.id === terminalId)
+  if (active) return isTerminalTab(active) ? { tab: active, active: true } : null
+  // A tab that has been sent to the background lives in its space's stashed
+  // snapshot, not the active terminal store. It is still owned — treating it as
+  // gone would destroy a still-starting PTY on a Space switch and drop late
+  // session-id / OSC-title resolution for a parked session.
+  const { spaces, activeSpaceId } = useSpaceStore.getState()
+  for (const s of spaces) {
+    // Skip the active space: its live tabs are the terminal store (checked
+    // above), and its stashed `workspace` is a stale snapshot. Matching a tab
+    // there that was already closed would make a still-starting PTY look owned
+    // and leak it — mirrors patchBackgroundTab, which also skips the active space.
+    if (s.id === activeSpaceId) continue
+    for (const g of s.workspace.groups) {
+      for (const t of g.tabs) {
+        if (t.id === terminalId) return isTerminalTab(t) ? { tab: t, active: false } : null
+      }
+    }
+  }
+  return null
+}
+
 function tabExists(terminalId: string): boolean {
-  return useTerminalStore.getState().groups.some((g) => g.tabs.some((t) => t.id === terminalId))
+  return findTabAnywhere(terminalId) !== null
+}
+
+/** Apply resolved terminal metadata to a tab wherever it lives. Active tabs go
+ *  through the terminal store (keeps the on-screen view in sync); backgrounded
+ *  tabs are patched in their space snapshot so resolution isn't lost while the
+ *  space is parked. */
+function applyTabPatch(
+  terminalId: string,
+  patch: { sessionId?: string; title?: string; pid?: number }
+): void {
+  const loc = findTabAnywhere(terminalId)
+  if (!loc) return
+  if (loc.active) {
+    const store = useTerminalStore.getState()
+    if (patch.pid !== undefined) store.setPid(terminalId, patch.pid)
+    if (patch.sessionId) store.associateSessionId(terminalId, patch.sessionId)
+    if (patch.title) store.renameTerminal(terminalId, patch.title)
+  } else {
+    patchBackgroundTab(terminalId, patch)
+  }
 }
 
 async function resolveSessionIdForTab(
@@ -45,11 +94,8 @@ async function resolveSessionIdForTab(
   // authoritative on restore, and overwriting it during slow PID lookups
   // would let CWD fallback misassign a session from a different running
   // instance (or, before the providerId hint, from a different provider).
-  const currentTab = useTerminalStore
-    .getState()
-    .groups.flatMap((g) => g.tabs)
-    .find((t) => t.id === terminalId)
-  if (currentTab && isTerminalTab(currentTab) && currentTab.sessionId) {
+  const loc = findTabAnywhere(terminalId)
+  if (loc && loc.tab.sessionId) {
     pendingOscTitles.delete(terminalId)
     return
   }
@@ -57,14 +103,12 @@ async function resolveSessionIdForTab(
     const result = await window.dplex.sessions.resolveSessionId(pid, cwd, providerId)
     if (result) {
       if (tabExists(terminalId)) {
-        const store = useTerminalStore.getState()
-        store.associateSessionId(terminalId, result.sessionId)
         // If an OSC title arrived before resolution, prefer it — that's
         // typically the AI tool's own summary of what the session is about
         // and is more useful than the provider's truncated-id fallback.
         const pending = pendingOscTitles.get(terminalId)
         const titleToUse = pending ?? result.displayName
-        store.renameTerminal(terminalId, titleToUse)
+        applyTabPatch(terminalId, { sessionId: result.sessionId, title: titleToUse })
         if (pending && providerId) {
           useSessionStore.getState().setLiveTabTitle(providerId, result.sessionId, pending)
         }
@@ -131,7 +175,11 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
       }
     })
 
-    // If already connected to a PTY, we're ready
+    // Reflect terminal readiness even when this hook mounted AFTER the PTY was
+    // created (e.g. a Space switch remounts the tab while it's still starting):
+    // subscribe to the latched ready event and also sync immediately if it has
+    // already fired. Without this, a remount could hang on "Starting terminal…".
+    const unsubReady = subscribeTerminalReady(terminalId, () => setReady(true))
     if (entry.ready) {
       setReady(true)
     }
@@ -191,22 +239,14 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
           removeExitListener()
 
           // Register with centralized dispatcher for O(1) routing + flow control
-          const unregisterHandler = registerPtyDataHandler(
-            ptyId,
-            terminalId,
-            entry,
-            (exitCode) => {
-              entry.term.write('\r\n\x1b[90m[Process exited]\x1b[0m\r\n')
-              fireExitHandler(terminalId, exitCode)
-            },
-            () => {
-              setReady(true)
-            }
-          )
+          const unregisterHandler = registerPtyDataHandler(ptyId, terminalId, entry, (exitCode) => {
+            entry.term.write('\r\n\x1b[90m[Process exited]\x1b[0m\r\n')
+            fireExitHandler(terminalId, exitCode)
+          })
 
           // Store PID on the tab for session ID resolution
           if (tabCommand && pid) {
-            useTerminalStore.getState().setPid(terminalId, pid)
+            applyTabPatch(terminalId, { pid })
           }
 
           // Flush buffered output
@@ -219,8 +259,7 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
           }
           earlyBuffer.length = 0
           if (hadData) {
-            entry.ready = true
-            setReady(true)
+            markTerminalReady(terminalId)
           }
 
           // Connect terminal input → PTY
@@ -245,11 +284,12 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
           // so resolveSessionIdForTab can apply it once the sessionId is
           // known.
           const onTitleDisposable = entry.term.onTitleChange((title) => {
-            if (!title || !tabExists(terminalId)) return
-            const store = useTerminalStore.getState()
-            store.renameTerminal(terminalId, title)
-            const t = store.groups.flatMap((g) => g.tabs).find((tab) => tab.id === terminalId)
-            if (!t || !isTerminalTab(t) || !t.providerId) return
+            if (!title) return
+            const loc = findTabAnywhere(terminalId)
+            if (!loc) return
+            applyTabPatch(terminalId, { title })
+            const t = loc.tab
+            if (!t.providerId) return
             if (t.sessionId) {
               useSessionStore.getState().setLiveTabTitle(t.providerId, t.sessionId, title)
               pendingOscTitles.delete(terminalId)
@@ -284,8 +324,7 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
           removeExitListener()
           entry.creating = false
           entry.term.write('\r\n\x1b[31m[Failed to start terminal]\x1b[0m\r\n')
-          entry.ready = true
-          setReady(true)
+          markTerminalReady(terminalId)
         })
     }
 
@@ -302,6 +341,7 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
     return () => {
       // Only detach the DOM element — do NOT destroy the terminal or PTY
       resizeObserver.disconnect()
+      unsubReady()
       if (container.contains(entry.wrapperEl)) {
         container.removeChild(entry.wrapperEl)
       }

--- a/src/renderer/src/services/fileEditorRegistry.ts
+++ b/src/renderer/src/services/fileEditorRegistry.ts
@@ -12,11 +12,22 @@
  * for the same tab id (can happen under React Strict Mode double-invoke).
  */
 
+import { stashParkedEditorBuffer, type ParkedEditorBuffer } from './parkedEditorBuffers'
+
 export interface FileEditorHandle {
   /** Persist the current buffer to disk. Resolves when the write settles. */
   save: () => Promise<void>
   /** True when the buffer differs from the last saved content. */
   isDirty: () => boolean
+  /** The current unsaved buffer to stash on park, or null when clean. */
+  getDirtyBuffer: () => ParkedEditorBuffer | null
+  /**
+   * Flush a pending onChange auto-save to disk if one is due. No-op in manual
+   * mode, when clean, or when a conflict/external change is unresolved. Called
+   * at park time so an edit made inside the debounce window isn't lost if the
+   * app quits before the editor remounts and re-arms its timer on resume.
+   */
+  flushIfAutoSave: () => void
 }
 
 interface Registration {
@@ -40,4 +51,31 @@ export function registerFileEditor(tabId: string, handle: FileEditorHandle): () 
 /** Look up the handle for a tab, or null when none is mounted. */
 export function getFileEditorHandle(tabId: string): FileEditorHandle | null {
   return registry.get(tabId)?.handle ?? null
+}
+
+/** Whether a mounted editor for this tab currently has unsaved changes. False
+ *  when no editor is mounted for the tab (e.g. it lives in a background space,
+ *  whose unsaved edits live in a stashed buffer instead). */
+export function isFileEditorDirty(tabId: string): boolean {
+  return registry.get(tabId)?.handle.isDirty() ?? false
+}
+
+/**
+ * Stash every mounted editor's unsaved buffer before a Space is parked.
+ *
+ * Only the active Space's editors are mounted, so this captures exactly the
+ * outgoing Space's dirty editors. Each stash is consumed when the editor
+ * remounts (see parkedEditorBuffers). Call this immediately before the terminal
+ * store swaps the active workspace out.
+ */
+export function stashAllDirtyFileEditors(): void {
+  for (const [tabId, reg] of registry) {
+    const buffer = reg.handle.getDirtyBuffer()
+    if (buffer) stashParkedEditorBuffer(tabId, buffer)
+    // onChange editors also flush their pending debounced save to disk at park
+    // time, so an edit within the debounce window survives a quit-while-parked.
+    // The stash above remains the in-session restore + conflict-detection
+    // baseline; the resume path reconciles the two (adopts disk when identical).
+    reg.handle.flushIfAutoSave()
+  }
 }

--- a/src/renderer/src/services/parkedEditorBuffers.ts
+++ b/src/renderer/src/services/parkedEditorBuffers.ts
@@ -1,0 +1,55 @@
+/**
+ * In-memory stash of unsaved (dirty) file-editor buffers, keyed by tab id.
+ *
+ * Switching or minimizing a Space unmounts its editor groups, and Monaco
+ * disposes their text models. With the default `manual` auto-save setting those
+ * edits are never written to disk, so a naive unmount would silently discard
+ * them. The park flow stashes each dirty buffer here just before the workspace
+ * swap, and the editor restores it on remount — so unsaved work survives
+ * leaving and returning to a Space without forcing a disk write (which would
+ * override the user's manual-save preference).
+ *
+ * Session-scoped and never persisted: unsaved manual edits are not expected to
+ * survive an app restart, matching normal editor behaviour.
+ */
+export interface ParkedEditorBuffer {
+  content: string
+  eol: '\n' | '\r\n'
+  /**
+   * The last-saved baseline the unsaved edits were made against, captured at
+   * park time. Restore reinstates this (rather than adopting the current disk
+   * bytes) so a concurrent external write that landed while the Space was parked
+   * is surfaced as a conflict on the next save instead of being silently
+   * overwritten — matching how a mounted dirty editor behaves.
+   */
+  baseContent: string
+  baseMtimeMs: number
+}
+
+const buffers = new Map<string, ParkedEditorBuffer>()
+
+/** Stash a tab's unsaved buffer (one per dirty editor, just before its Space is
+ *  parked). */
+export function stashParkedEditorBuffer(tabId: string, buffer: ParkedEditorBuffer): void {
+  buffers.set(tabId, buffer)
+}
+
+/** Retrieve *and remove* a tab's stashed buffer — consumed once on remount. */
+export function takeParkedEditorBuffer(tabId: string): ParkedEditorBuffer | null {
+  const buffer = buffers.get(tabId)
+  if (buffer) buffers.delete(tabId)
+  return buffer ?? null
+}
+
+/** Whether a tab currently has a stashed unsaved buffer (used to treat an
+ *  unmounted parked editor as dirty for close-confirmation, without consuming
+ *  the stash). */
+export function hasParkedEditorBuffer(tabId: string): boolean {
+  return buffers.has(tabId)
+}
+
+/** Drop a tab's stashed buffer without consuming it (the tab or its Space was
+ *  closed/deleted before it was ever restored). */
+export function clearParkedEditorBuffer(tabId: string): void {
+  buffers.delete(tabId)
+}

--- a/src/renderer/src/services/search/commandsSource.ts
+++ b/src/renderer/src/services/search/commandsSource.ts
@@ -16,7 +16,9 @@ import {
   RefreshCw,
   Files,
   ChevronsDownUp,
-  LayoutDashboard
+  LayoutDashboard,
+  Layers,
+  LayoutGrid
 } from 'lucide-react'
 import type { SearchItem, SearchSource } from './types'
 import { useTerminalStore } from '../../stores/terminalStore'
@@ -25,6 +27,8 @@ import { openInheritedTerminal, openInheritedSplit } from '../../utils/inheritCw
 import { useSettingsStore } from '../../stores/settingsStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useProjectStore } from '../../stores/projectStore'
+import { useSpaceStore } from '../../stores/spaceStore'
+import { useSpacesUiStore } from '../../stores/spacesUiStore'
 import { useFileExplorerStore } from '../../stores/fileExplorerStore'
 import { dispatchOpenSettings } from '../../utils/openSettings'
 import { MOD, SHIFT } from '../../utils/shortcuts'
@@ -62,6 +66,48 @@ const COMMANDS: readonly CommandEntry[] = [
     Icon: FolderPlus,
     run: () => {
       void useProjectStore.getState().addProject()
+    }
+  },
+  {
+    id: 'new-space',
+    label: 'New Space',
+    description: 'Create a new space for a fresh activity',
+    keywords: ['create', 'add', 'workspace', 'context', 'activity'],
+    Icon: Layers,
+    run: () => {
+      useSpacesUiStore.getState().openCreate()
+    }
+  },
+  {
+    id: 'spaces-overview',
+    label: 'Go to Spaces Overview',
+    description: 'Step back to the overview; the current space keeps running',
+    keywords: [
+      'overview',
+      'spaces',
+      'home',
+      'mission control',
+      'switch',
+      'background',
+      'step away'
+    ],
+    Icon: LayoutGrid,
+    run: () => {
+      useSpaceStore.getState().sendToBackground()
+    }
+  },
+  {
+    id: 'show-spaces',
+    label: 'Show Spaces',
+    description: 'Reveal the Spaces view in the sidebar',
+    keywords: ['focus', 'view', 'workspace', 'context'],
+    Icon: Layers,
+    run: () => {
+      useSettingsStore.getState().updateSettings({
+        sidebarActiveTab: 'spaces',
+        sidebarPanelCollapsed: false,
+        sidebarVisible: true
+      })
     }
   },
   {

--- a/src/renderer/src/services/search/index.ts
+++ b/src/renderer/src/services/search/index.ts
@@ -1,5 +1,6 @@
 import { buildRegistry, SearchRegistry } from './searchRegistry'
 import { projectsSource } from './projectsSource'
+import { spacesSource } from './spacesSource'
 import { sessionsSource } from './sessionsSource'
 import { tabsSource } from './tabsSource'
 import { settingsSource } from './settingsSource'
@@ -9,6 +10,7 @@ import { commandsSource } from './commandsSource'
 export const defaultRegistry: SearchRegistry = buildRegistry([
   commandsSource,
   projectsSource,
+  spacesSource,
   sessionsSource,
   tabsSource,
   settingsSource

--- a/src/renderer/src/services/search/spacesSource.ts
+++ b/src/renderer/src/services/search/spacesSource.ts
@@ -1,0 +1,57 @@
+import { createElement } from 'react'
+import type { SearchItem, SearchSource } from './types'
+import { isTerminalTab } from '../../types'
+import { useSpaceStore } from '../../stores/spaceStore'
+import { useSettingsStore } from '../../stores/settingsStore'
+import { SpaceAvatar } from '../../components/spaces/SpaceAvatar'
+import { boundProjects, sessionCount } from '../../components/spaces/spaceVisuals'
+
+/** Switch to a space from search: reveal the Spaces side panel for context,
+ *  then bring the space into focus. `switchSpace` only re-mounts existing
+ *  terminals, so nothing restarts — the previous space auto-backgrounds. */
+function openSpace(spaceId: string): void {
+  useSettingsStore.getState().updateSettings({
+    sidebarActiveTab: 'spaces',
+    sidebarPanelCollapsed: false,
+    sidebarVisible: true
+  })
+  useSpaceStore.getState().switchSpace(spaceId)
+}
+
+/** Pluralize a count with its noun, e.g. `count(2, 'project') → "2 projects"`. */
+function count(n: number, noun: string): string {
+  return `${n} ${noun}${n === 1 ? '' : 's'}`
+}
+
+export const spacesSource: SearchSource = {
+  category: 'spaces',
+  getItems: (ctx): SearchItem[] => {
+    // The active space's live tabs live in the terminal store, not its stashed
+    // snapshot, so count those from the live groups; background spaces read
+    // their (accurate) snapshot.
+    const liveSessions = ctx.groups.reduce(
+      (total, g) => total + g.tabs.filter(isTerminalTab).length,
+      0
+    )
+    return ctx.spaces.map((s) => {
+      const isActive = s.id === ctx.activeSpaceId
+      const projects = boundProjects(s, ctx.projects)
+      const sessions = isActive ? liveSessions : sessionCount(s.workspace)
+      const parts: string[] = []
+      if (projects.length > 0) parts.push(count(projects.length, 'project'))
+      parts.push(count(sessions, 'session'))
+      const item: SearchItem = {
+        id: `space:${s.id}`,
+        category: 'spaces',
+        label: s.name,
+        description: parts.join(' · '),
+        // Find a space by any repo it holds, not just its own name.
+        keywords: ['space', 'workspace', 'context', ...projects.map((p) => p.name)],
+        icon: createElement(SpaceAvatar, { space: s, size: 24 }),
+        run: () => openSpace(s.id)
+      }
+      if (isActive) item.hint = 'In focus'
+      return item
+    })
+  }
+}

--- a/src/renderer/src/services/search/types.ts
+++ b/src/renderer/src/services/search/types.ts
@@ -1,4 +1,4 @@
-import type { Project, AISession, EditorGroup } from '../../types'
+import type { Project, AISession, EditorGroup, Space } from '../../types'
 
 /** Settings tab identifier. Mirrors the `SettingsTab` union used inside
  *  `SettingsModal`. Kept here so the search registry doesn't have to import
@@ -14,10 +14,11 @@ export type SettingsTab =
 
 /** Categories surfaced in the global search UI. Order here drives the
  *  default render order in the grouped result list. */
-export type SearchCategory = 'projects' | 'sessions' | 'tabs' | 'settings' | 'commands'
+export type SearchCategory = 'projects' | 'spaces' | 'sessions' | 'tabs' | 'settings' | 'commands'
 
 export const CATEGORY_LABELS: Record<SearchCategory, string> = {
   projects: 'Projects',
+  spaces: 'Spaces',
   sessions: 'Sessions',
   tabs: 'Open Tabs',
   settings: 'Settings',
@@ -27,6 +28,7 @@ export const CATEGORY_LABELS: Record<SearchCategory, string> = {
 export const CATEGORY_ORDER: SearchCategory[] = [
   'commands',
   'projects',
+  'spaces',
   'sessions',
   'tabs',
   'settings'
@@ -70,6 +72,10 @@ export interface SearchItem {
  *  directly so they stay easy to unit-test. */
 export interface SearchContext {
   projects: Project[]
+  spaces: Space[]
+  /** Id of the space currently in focus, or null on the Overview. Lets the
+   *  spaces source flag the active space and count its live sessions. */
+  activeSpaceId: string | null
   sessions: AISession[]
   groups: EditorGroup[]
   activeGroupId: string | null

--- a/src/renderer/src/services/terminalRegistry.ts
+++ b/src/renderer/src/services/terminalRegistry.ts
@@ -43,11 +43,59 @@ interface PtyDataHandler {
   terminalId: string
   entry: TerminalEntry
   flowController: FlowController
-  onReady: (() => void) | null
 }
 
 const dataHandlers = new Map<string, PtyDataHandler>()
 const exitHandlers = new Map<string, (exitCode: number) => void>()
+
+// ── Terminal readiness subscriptions ────────────────────────────────────
+// A terminal becomes "ready" once its PTY first produces output (or on a
+// start failure, so the UI stops showing "Starting…"). Readiness is a
+// persistent, latched flag on the entry — but a hook can mount AFTER the PTY
+// was created (a Space switch remounts the tab mid-startup), so it can't rely
+// on catching the one-shot flip via a bound callback. Subscribers are keyed by
+// terminalId (stable across remounts); a late subscriber checks entry.ready
+// itself. Replacing the old single onReady callback fixes a "Starting terminal…
+// forever" hang when the original mount unmounted before the first byte.
+const readySubscribers = new Map<string, Set<() => void>>()
+
+/** Subscribe to a terminal's ready event. Returns an unsubscribe fn. The
+ *  callback may fire more than once (idempotent by design). */
+export function subscribeTerminalReady(terminalId: string, cb: () => void): () => void {
+  let subs = readySubscribers.get(terminalId)
+  if (!subs) {
+    subs = new Set()
+    readySubscribers.set(terminalId, subs)
+  }
+  subs.add(cb)
+  return () => {
+    const s = readySubscribers.get(terminalId)
+    if (!s) return
+    s.delete(cb)
+    if (s.size === 0) readySubscribers.delete(terminalId)
+  }
+}
+
+function notifyTerminalReady(terminalId: string): void {
+  const subs = readySubscribers.get(terminalId)
+  if (!subs) return
+  for (const cb of subs) {
+    try {
+      cb()
+    } catch {
+      /* isolate subscriber errors */
+    }
+  }
+}
+
+/** Latch a terminal ready and notify any mounted hooks. Idempotent. Used by the
+ *  early-buffer flush and start-failure paths, where readiness is decided in
+ *  the hook rather than by the global data dispatcher. */
+export function markTerminalReady(terminalId: string): void {
+  const entry = registry.get(terminalId)
+  if (entry) entry.ready = true
+  notifyTerminalReady(terminalId)
+}
 
 let globalDataListenerCleanup: (() => void) | null = null
 
@@ -62,10 +110,7 @@ function ensureGlobalListeners(): void {
 
     if (!handler.entry.ready) {
       handler.entry.ready = true
-      if (handler.onReady) {
-        handler.onReady()
-        handler.onReady = null
-      }
+      notifyTerminalReady(handler.terminalId)
     }
   })
 
@@ -80,8 +125,7 @@ export function registerPtyDataHandler(
   ptyId: string,
   terminalId: string,
   entry: TerminalEntry,
-  onExit: (exitCode: number) => void,
-  onReady?: () => void
+  onExit: (exitCode: number) => void
 ): () => void {
   ensureGlobalListeners()
 
@@ -95,8 +139,7 @@ export function registerPtyDataHandler(
   dataHandlers.set(ptyId, {
     terminalId,
     entry,
-    flowController,
-    onReady: onReady || null
+    flowController
   })
 
   exitHandlers.set(ptyId, onExit)
@@ -310,11 +353,54 @@ export function fireExitHandler(terminalId: string, exitCode: number): void {
   }
 }
 
+/** Discard a pending exit handler WITHOUT firing it. Used for deliberate
+ *  teardown (e.g. a Space is deleted) where a setup script's afterCreate action
+ *  must NOT run — otherwise destroying the still-running setup PTY would fire
+ *  its exit handler and spawn a session/terminal into a Space that no longer
+ *  exists (or re-focus the doomed Space mid-delete). Idempotent.
+ *
+ *  Note: this cancels only the deferred *afterCreate* work. Resource cleanup
+ *  registered via registerDestroyCleanup still runs on destroy, so e.g. a setup
+ *  script's temp file is never leaked even when the handler is cancelled. */
+export function cancelExitHandler(terminalId: string): void {
+  pendingExitHandlers.delete(terminalId)
+}
+
+// ── Destroy cleanups ────────────────────────────────────────────────────
+// Unlike an exit handler (which fires on PTY exit and is cancellable for
+// deliberate teardown), a destroy cleanup ALWAYS runs when the terminal is
+// destroyed — even if the exit handler was cancelled. It's for releasing OS
+// resources (e.g. a setup script's temp file) that must not leak on any path,
+// including Windows where $TMPDIR is not auto-reaped. Cleared after firing.
+const destroyCleanups = new Map<string, () => void>()
+
+export function registerDestroyCleanup(terminalId: string, cleanup: () => void): () => void {
+  destroyCleanups.set(terminalId, cleanup)
+  return () => {
+    if (destroyCleanups.get(terminalId) === cleanup) {
+      destroyCleanups.delete(terminalId)
+    }
+  }
+}
+
+function fireDestroyCleanup(terminalId: string): void {
+  const cleanup = destroyCleanups.get(terminalId)
+  if (!cleanup) return
+  destroyCleanups.delete(terminalId)
+  try {
+    cleanup()
+  } catch {
+    /* isolate cleanup errors */
+  }
+}
+
 export function destroyTerminal(terminalId: string): void {
   const entry = registry.get(terminalId)
   if (!entry) {
-    // Even if the entry never got registered, fire any pending handler so
-    // callers waiting on an exit result get unblocked with a synthetic code.
+    // Even if the entry never got registered, run cleanup + fire any pending
+    // handler so callers waiting on an exit result get unblocked and no temp
+    // resources leak.
+    fireDestroyCleanup(terminalId)
     fireExitHandler(terminalId, -1)
     return
   }
@@ -325,6 +411,10 @@ export function destroyTerminal(terminalId: string): void {
   entry.term.dispose()
   entry.wrapperEl.remove()
   registry.delete(terminalId)
+  readySubscribers.delete(terminalId)
+  // Always release OS resources (temp files etc.) tied to this terminal, even
+  // when the exit handler was cancelled for a deliberate teardown.
+  fireDestroyCleanup(terminalId)
   // If useTerminal hadn't yet wired pty:exit (fast destroy before PTY
   // resolved), still fire pending handlers so tmp files get cleaned up.
   fireExitHandler(terminalId, -1)

--- a/src/renderer/src/services/worktreePostCreate.ts
+++ b/src/renderer/src/services/worktreePostCreate.ts
@@ -1,6 +1,7 @@
 import { useProjectStore } from '../stores/projectStore'
 import { useTerminalStore } from '../stores/terminalStore'
-import { registerExitHandler } from './terminalRegistry'
+import { useSpaceStore } from '../stores/spaceStore'
+import { registerExitHandler, registerDestroyCleanup } from './terminalRegistry'
 import type { Project } from '../types'
 
 export interface WorktreePostCreateInput {
@@ -12,6 +13,14 @@ export interface WorktreePostCreateInput {
   providerId: string | null
   setupScript: string
   createdByDplexWorktree?: boolean
+  /**
+   * The Space in focus when the user *initiated* the worktree — captured before
+   * the (possibly slow) create IPC so a Space switch during creation can't
+   * mis-route the setup/afterCreate tabs. `undefined` when the caller didn't
+   * capture it (falls back to the active Space at handle time); `null` means the
+   * worktree was started from the Overview (no routing).
+   */
+  originSpaceId?: string | null
 }
 
 /**
@@ -31,7 +40,8 @@ export async function handleWorktreeCreated(input: WorktreePostCreateInput): Pro
     afterCreate,
     providerId,
     setupScript,
-    createdByDplexWorktree
+    createdByDplexWorktree,
+    originSpaceId: originSpaceIdInput
   } = input
 
   const newProject = useProjectStore.getState().addWorktreeProject({
@@ -41,17 +51,44 @@ export async function handleWorktreeCreated(input: WorktreePostCreateInput): Pro
     createdByDplexWorktree: createdByDplexWorktree ?? true
   })
 
+  // The Space in focus when the worktree was requested. The setup script can
+  // run for minutes, and its exit handler (runAfterCreate) fires long after —
+  // by then the user may have switched Spaces. Route the deferred tab creation
+  // back to the originating Space so worktree work never lands in an unrelated
+  // Space. Prefer the id captured by the caller *before* the create IPC (a
+  // switch during creation would otherwise be mis-attributed); fall back to the
+  // current active Space only when the caller didn't provide one. Null (worktree
+  // created from the Overview) → no routing.
+  const originSpaceId =
+    originSpaceIdInput !== undefined ? originSpaceIdInput : useSpaceStore.getState().activeSpaceId
+
   const termStore = useTerminalStore.getState()
 
   const runAfterCreate = async (): Promise<void> => {
     if (afterCreate === 'session') {
-      const tabId = await useProjectStore
+      // Resolve the provider + launch command FIRST (async IPC), THEN focus the
+      // origin Space and create the tab — both synchronous, with no await
+      // between, so a concurrent Space switch can't land the session in the
+      // wrong Space. (createTerminal binds to whatever workspace is active at
+      // the moment of creation.)
+      const resolved = await useProjectStore
         .getState()
-        .startAISession(newProject, providerId ?? undefined)
-      if (tabId) {
-        useTerminalStore.getState().setWorktreeMetadata(tabId, worktreePath, branch)
+        .resolveAISession(newProject, providerId ?? undefined)
+      // If the origin Space was deleted during the (brief) resolve above,
+      // focusForDeferredWork is a no-op and the session lands in whatever Space
+      // is active — intentionally kept usable rather than dropped, matching the
+      // "unassigned sessions remain usable" rule. (In the delete-mid-setup path
+      // the exit handler is cancelled outright, so this only covers a *normal*
+      // setup exit racing a concurrent delete.)
+      useSpaceStore.getState().focusForDeferredWork(originSpaceId)
+      if (resolved) {
+        const tabId = useProjectStore.getState().createAISessionTab(resolved)
+        if (tabId) {
+          useTerminalStore.getState().setWorktreeMetadata(tabId, worktreePath, branch)
+        }
       }
     } else if (afterCreate === 'terminal') {
+      useSpaceStore.getState().focusForDeferredWork(originSpaceId)
       const tabId = useTerminalStore
         .getState()
         .createTerminal(undefined, branch, undefined, undefined, worktreePath)
@@ -65,6 +102,7 @@ export async function handleWorktreeCreated(input: WorktreePostCreateInput): Pro
       null
     try {
       prepared = await window.dplex.worktrees.prepareSetupScript(trimmedScript)
+      useSpaceStore.getState().focusForDeferredWork(originSpaceId)
       const setupTabId = termStore.createTerminal(
         undefined,
         `setup · ${branch}`,
@@ -74,9 +112,20 @@ export async function handleWorktreeCreated(input: WorktreePostCreateInput): Pro
       )
       termStore.setWorktreeMetadata(setupTabId, worktreePath, branch)
       const preparedTempPath = prepared.tempPath
+      // Idempotent temp-file cleanup: runs on the setup PTY's exit (below) AND is
+      // registered as an always-run destroy cleanup, so the temp script is never
+      // leaked — including when the exit handler is cancelled because its Space
+      // was deleted mid-setup (Windows %TEMP% is not auto-reaped).
+      let tempCleaned = false
+      const cleanupTemp = (): void => {
+        if (tempCleaned) return
+        tempCleaned = true
+        void window.dplex.worktrees.cleanupSetupScript(preparedTempPath)
+      }
+      registerDestroyCleanup(setupTabId, cleanupTemp)
       registerExitHandler(setupTabId, (exitCode) => {
         void window.dplex.worktrees.recordSetupResult(originProject.path, worktreePath, exitCode)
-        void window.dplex.worktrees.cleanupSetupScript(preparedTempPath)
+        cleanupTemp()
         void runAfterCreate()
       })
     } catch {

--- a/src/renderer/src/stores/closeConfirmStore.ts
+++ b/src/renderer/src/stores/closeConfirmStore.ts
@@ -2,6 +2,7 @@ import { create } from 'zustand'
 import { useTerminalStore } from './terminalStore'
 import { isFileEditorTab } from '../types'
 import { getFileEditorHandle } from '../services/fileEditorRegistry'
+import { hasParkedEditorBuffer } from '../services/parkedEditorBuffers'
 
 interface CloseConfirmState {
   /** Tab pending a dirty-close confirmation, or null. */
@@ -24,7 +25,13 @@ function findTab(tabId: string): { title: string; dirty: boolean } | null {
       if (t.id !== tabId) continue
       if (isFileEditorTab(t)) {
         const handle = getFileEditorHandle(tabId)
-        const dirty = handle ? handle.isDirty() : t.dirty === true
+        // Dirty if EITHER the live editor reports unsaved edits OR a parked
+        // buffer is stashed. A mounted handle can report clean while a stash
+        // still exists — e.g. the file turned binary/too-large while parked (the
+        // editor loads read-only and can't host the edits) or the tab is still
+        // loading — so the stash must be OR'd in regardless of handle presence,
+        // otherwise backgrounded unsaved edits would close without a prompt.
+        const dirty = (handle ? handle.isDirty() : t.dirty === true) || hasParkedEditorBuffer(tabId)
         return { title: t.title, dirty }
       }
       return { title: t.title, dirty: false }
@@ -64,6 +71,17 @@ export const useCloseConfirmStore = create<CloseConfirmState>((set, get) => ({
         set({ pendingTabId: null, pendingTitle: '' })
         return
       }
+    }
+    // A live editor can be mounted-but-unable-to-persist a stashed parked buffer
+    // (the file turned binary/too-large while parked → it loads read-only, or the
+    // model is still booting). handle.save() no-ops there and handle.isDirty()
+    // reports clean, so closing now would drop the stash despite the user picking
+    // "Save". Keep the tab open (dismiss the prompt) rather than silently losing
+    // the edits — the user can retry once it loads, or choose "Don't Save" to
+    // discard explicitly.
+    if (hasParkedEditorBuffer(tabId)) {
+      set({ pendingTabId: null, pendingTitle: '' })
+      return
     }
     set({ pendingTabId: null, pendingTitle: '' })
     useTerminalStore.getState().closeTerminal(tabId)

--- a/src/renderer/src/stores/fileExplorerStore.ts
+++ b/src/renderer/src/stores/fileExplorerStore.ts
@@ -3,6 +3,8 @@ import type { FsEntry } from '../../../preload/index'
 import { useProjectStore } from './projectStore'
 import { useTerminalStore } from './terminalStore'
 import { setCanonicalRoot, clearCanonicalRoot, watchRootMatches } from './fileWatchRoots'
+import { hasParkedEditorBuffer } from '../services/parkedEditorBuffers'
+import { syncBackgroundEditorTabsOnRename } from './spaceStore'
 import type { Project } from '../types'
 
 /**
@@ -270,12 +272,17 @@ function syncTabsOnRename(root: string, fromRel: string, toRel: string): void {
       }
     }
   }
+  // Mirror the rename into background spaces' stashed snapshots too, so a
+  // renamed file doesn't read as "missing" (or get recreated at its old path by
+  // a stashed unsaved buffer) when one of those spaces is later resumed.
+  syncBackgroundEditorTabsOnRename(root, fromRel, toRel)
 }
 
 /**
  * After a delete, close clean editor tabs for the path (or its descendants).
- * Dirty tabs are left open so the editor can surface a "file missing" state
- * rather than silently dropping unsaved work.
+ * Dirty tabs — including an editor holding a stashed parked buffer (unsaved
+ * edits from a backgrounded Space) — are left open so the editor can surface a
+ * "file missing" state rather than silently dropping unsaved work.
  */
 function syncTabsOnDelete(root: string, relPath: string): void {
   const term = useTerminalStore.getState()
@@ -284,7 +291,7 @@ function syncTabsOnDelete(root: string, relPath: string): void {
     for (const t of g.tabs) {
       if (t.kind !== 'fileEditor' || t.rootFs !== root) continue
       const match = t.relPath === relPath || t.relPath.startsWith(prefix)
-      if (match && t.dirty !== true) term.closeTerminal(t.id)
+      if (match && t.dirty !== true && !hasParkedEditorBuffer(t.id)) term.closeTerminal(t.id)
     }
   }
 }

--- a/src/renderer/src/stores/projectStore.ts
+++ b/src/renderer/src/stores/projectStore.ts
@@ -16,6 +16,19 @@ function folderName(folderPath: string): string {
   return parts[parts.length - 1] || folderPath
 }
 
+/**
+ * A provider-resolved AI session ready to be turned into a terminal tab. Split
+ * out from tab creation so the (async) provider lookup can complete before the
+ * (synchronous) `createTerminal`, letting the caller decide which workspace the
+ * tab lands in at creation time rather than at request time.
+ */
+export interface ResolvedAISession {
+  command: string
+  title: string
+  providerId: string
+  cwd: string
+}
+
 interface ProjectState {
   projects: Project[]
   expandedProjectIds: Set<string>
@@ -83,6 +96,20 @@ interface ProjectState {
   /** Set (hex) or clear (null) the project-wide tab color applied to all of
    *  this project's tabs. Persists with the project list. */
   setProjectTabColor: (id: string, color: string | null) => void
+  /**
+   * Resolve the provider + launch command for a project's AI session **without**
+   * touching the terminal store. Async (provider registry + new-session command
+   * are IPC round-trips). Returns null when no provider is registered. Pair with
+   * `createAISessionTab` when you need to control which workspace the tab lands
+   * in (see `utils/spaceStart`).
+   */
+  resolveAISession: (project: Project, providerId?: string) => Promise<ResolvedAISession | null>
+  /** Create the terminal tab for an already-resolved AI session. Synchronous, so
+   *  the tab is bound to whatever workspace is active at the moment of creation. */
+  createAISessionTab: (resolved: ResolvedAISession) => string | null
+  /** Convenience: resolve then immediately create in the active workspace. UI
+   *  entry points that must respect Spaces should prefer the space-aware
+   *  `startProjectSession` (utils/spaceStart) instead. */
   startAISession: (project: Project, providerId?: string) => Promise<string | null>
   updateProjectWorktreeOverrides: (
     projectId: string,
@@ -498,7 +525,7 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     get().persistProjects()
   },
 
-  startAISession: async (project, providerId?) => {
+  resolveAISession: async (project, providerId?) => {
     const settings = useSettingsStore.getState().settings
     const configuredPid = providerId ?? settings.defaultAITool
 
@@ -510,13 +537,32 @@ export const useProjectStore = create<ProjectState>((set, get) => ({
     const pid = resolved.id
 
     const cmd = await window.dplex.sessions.getNewSessionCommand(pid)
-    const command = cmd || resolved.command || pid
-    const title = `${resolved.name} · ${folderName(project.path)}`
+    return {
+      command: cmd || resolved.command || pid,
+      title: `${resolved.name} · ${folderName(project.path)}`,
+      providerId: pid,
+      cwd: project.path
+    }
+  },
 
+  createAISessionTab: (resolved) => {
     const tabId = useTerminalStore
       .getState()
-      .createTerminal(undefined, title, command, undefined, project.path, pid)
+      .createTerminal(
+        undefined,
+        resolved.title,
+        resolved.command,
+        undefined,
+        resolved.cwd,
+        resolved.providerId
+      )
     return tabId ?? null
+  },
+
+  startAISession: async (project, providerId?) => {
+    const resolved = await get().resolveAISession(project, providerId)
+    if (!resolved) return null
+    return get().createAISessionTab(resolved)
   }
 }))
 

--- a/src/renderer/src/stores/settingsStore.ts
+++ b/src/renderer/src/stores/settingsStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import type { AppSettings, WorktreeDefaults } from '../types'
 import { getTheme } from '../services/themes'
+import { DEFAULT_ACTIVITY_BAR_ORDER } from '../utils/activityBarOrder'
 
 // Read cached theme from localStorage synchronously to avoid flash
 function getCachedTheme(): string {
@@ -184,6 +185,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   sidebarWidth: 260,
   sidebarVisible: true,
   sidebarActiveTab: 'projects',
+  activityBarOrder: [...DEFAULT_ACTIVITY_BAR_ORDER],
   sidebarPanelCollapsed: false,
   sessionPollIntervalMs: 5000,
   sessionMaxAgeDays: 7,

--- a/src/renderer/src/stores/spaceStore.ts
+++ b/src/renderer/src/stores/spaceStore.ts
@@ -1,0 +1,922 @@
+import { create } from 'zustand'
+import type { EditorTab, Space, WorkspaceSnapshot } from '../types'
+import { isTerminalTab } from '../types'
+import {
+  EMPTY_WORKSPACE,
+  reconstructWorkspace,
+  serializeWorkspaceSnapshot,
+  type PersistedWorkspaceSnapshot
+} from '../utils/workspaceSnapshot'
+import { DEFAULT_SPACE_COLOR, pickSpaceColor } from '../utils/spaceColors'
+import { findProjectForTab } from '../utils/tabProject'
+import { pruneLayoutToGroups } from '../utils/tabFocus'
+import { useTerminalStore, setWorkspaceSink } from './terminalStore'
+import { useProjectStore } from './projectStore'
+import { useSessionStore } from './sessionStore'
+import { destroyTerminal, cancelExitHandler } from '../services/terminalRegistry'
+import { stashAllDirtyFileEditors, isFileEditorDirty } from '../services/fileEditorRegistry'
+import { clearParkedEditorBuffer, hasParkedEditorBuffer } from '../services/parkedEditorBuffers'
+
+const SPACES_VERSION = 1
+
+/** On-disk Space — identity fields plus the lossy (persisted) workspace. */
+interface PersistedSpace {
+  id: string
+  name: string
+  color: string
+  glyph?: string
+  projectIds: string[]
+  workspace: PersistedWorkspaceSnapshot
+  createdAt: number
+  updatedAt: number
+  lastActiveAt: number
+  archived?: boolean
+}
+
+interface PersistedSpacesFile {
+  version: number
+  spaces: PersistedSpace[]
+  activeSpaceId: string | null
+}
+
+interface CreateSpaceOptions {
+  name: string
+  color?: string
+  glyph?: string
+  projectIds?: string[]
+  /** Switch focus to the new space (auto-backgrounding the current one).
+   *  Defaults to true. */
+  activate?: boolean
+}
+
+export interface SpaceState {
+  spaces: Space[]
+  activeSpaceId: string | null
+  loaded: boolean
+  /** Load + migrate spaces, install the persistence sink, and restore the
+   *  active space's workspace into the terminal store. Runs once at boot. */
+  hydrate: () => Promise<void>
+  createSpace: (opts: CreateSpaceOptions) => string
+  renameSpace: (id: string, name: string) => void
+  setSpaceAppearance: (id: string, patch: { color?: string; glyph?: string | null }) => void
+  assignProjects: (id: string, projectIds: string[]) => void
+  /** Bind a single project to a space, appended after the existing ones so the
+   *  primary (projectIds[0]) is never displaced. No-op when the space is gone
+   *  or already includes the project. Used when work for an unbound project is
+   *  started from within a space. */
+  addProjectToSpace: (id: string, projectId: string) => void
+  /** Remove a project id from every space that references it (called when the
+   *  project is deleted from the Projects panel) so no space keeps a dangling
+   *  binding. If the removed id was a space's primary (projectIds[0]), the next
+   *  bound project becomes primary; the active space re-syncs the Projects/Git
+   *  target. */
+  pruneProject: (projectId: string) => void
+  /** Bring a space into focus. The previous space auto-backgrounds (keeps
+   *  running). Never restarts sessions. */
+  switchSpace: (id: string) => void
+  /** Move the current space out of focus → land on the Overview (no space in
+   *  focus). The space keeps running in the background. */
+  sendToBackground: () => void
+  /** Re-focus the space that initiated a deferred tab creation (a worktree
+   *  setup-script that finishes minutes later, a session resume whose command
+   *  is still resolving) so the resulting terminal lands in that space even if
+   *  the user switched away during the async gap. No-op when that space is
+   *  already active, was deleted, or the work started from the Overview. */
+  focusForDeferredWork: (originSpaceId: string | null) => void
+  deleteSpace: (id: string) => void
+  persist: () => void
+  persistNow: () => void
+}
+
+let spaceIdCounter = 0
+function makeSpaceId(): string {
+  spaceIdCounter += 1
+  return `space-${Date.now()}-${spaceIdCounter}-${Math.random().toString(36).slice(2, 6)}`
+}
+
+function makeSpace(opts: {
+  name: string
+  color?: string
+  glyph?: string
+  projectIds?: string[]
+  workspace?: WorkspaceSnapshot
+}): Space {
+  const now = Date.now()
+  return {
+    id: makeSpaceId(),
+    name: opts.name,
+    color: opts.color ?? DEFAULT_SPACE_COLOR,
+    glyph: opts.glyph,
+    projectIds: opts.projectIds ?? [],
+    workspace: opts.workspace ?? EMPTY_WORKSPACE,
+    createdAt: now,
+    updatedAt: now,
+    lastActiveAt: now
+  }
+}
+
+/** Drive the Projects panel / Git target from a space's primary project. */
+function syncActiveProject(space: Space | null): void {
+  const primary = space?.projectIds[0] ?? null
+  useProjectStore.getState().setActiveProject(primary)
+}
+
+/** Last path segment, tolerant of both POSIX and Windows separators. */
+function basenameOf(p: string): string {
+  const parts = p.split(/[\\/]+/).filter(Boolean)
+  return parts.length ? parts[parts.length - 1] : p
+}
+
+/** Order a snapshot's tabs so the one the user is actually looking at (the
+ *  active group's active tab) is considered first when naming an adopted
+ *  space. */
+function orderedTabsForNaming(snap: WorkspaceSnapshot): EditorTab[] {
+  const activeGroup = snap.groups.find((g) => g.id === snap.activeGroupId) ?? snap.groups[0]
+  const activeTab = activeGroup?.tabs.find((t) => t.id === activeGroup.activeTabId)
+  const rest = snap.groups.flatMap((g) => g.tabs).filter((t) => t !== activeTab)
+  return activeTab ? [activeTab, ...rest] : rest
+}
+
+/** Next unused "Untitled Space N" name (1-based), scanning existing space names
+ *  so consecutively auto-created spaces don't collide (Untitled Space 1, 2, …). */
+function nextUntitledSpaceName(existing: Space[]): string {
+  let max = 0
+  for (const s of existing) {
+    const m = /^Untitled Space (\d+)$/.exec(s.name.trim())
+    if (m) max = Math.max(max, parseInt(m[1], 10))
+  }
+  return `Untitled Space ${max + 1}`
+}
+
+/** Derive the seed for a space auto-created when work starts without a space
+ *  selected (from the Overview, or during the async boot window). The space gets
+ *  a neutral "Untitled Space N" name — the user renames it when they want — but
+ *  is still bound to the triggering tab's project when there is one, so its
+ *  Projects/Git panel isn't empty. */
+function deriveOrphanSpaceSeed(
+  snap: WorkspaceSnapshot,
+  existing: Space[]
+): { name: string; projectIds: string[] } {
+  const name = nextUntitledSpaceName(existing)
+  const projects = useProjectStore.getState().projects
+  for (const t of orderedTabsForNaming(snap)) {
+    const proj = findProjectForTab(t, projects)
+    if (proj) return { name, projectIds: [proj.id] }
+  }
+  return { name, projectIds: [] }
+}
+
+/** Tear down every terminal belonging to a workspace snapshot: close its AI
+ *  session on disk (if any) and destroy the PTY + xterm instance. Used when a
+ *  space is deleted — its background terminals must not leak. */
+function teardownWorkspaceTerminals(snap: WorkspaceSnapshot): void {
+  for (const g of snap.groups) {
+    for (const t of g.tabs) {
+      if (!isTerminalTab(t)) {
+        // A deleted space's editors never remount, so drop any unsaved buffer
+        // stashed while it was parked (otherwise it would leak).
+        clearParkedEditorBuffer(t.id)
+        continue
+      }
+      if (t.sessionId && t.providerId) {
+        void window.dplex.sessions.close(t.sessionId, t.providerId).catch(() => {
+          // Provider may fail if the session is already gone — ignore.
+        })
+        useSessionStore.getState().clearLiveTabTitle(t.providerId, t.sessionId)
+      }
+      // Drop any pending exit handler (e.g. a still-running worktree setup
+      // script) BEFORE destroying the PTY: destroyTerminal fires exit handlers,
+      // and a setup script's handler would re-focus this (being-deleted) Space
+      // and spawn its afterCreate session/terminal into it — leaving a dangling
+      // activeSpaceId and an orphan tab. The setup temp file is left for the OS
+      // to reap in this rare delete-mid-setup case.
+      cancelExitHandler(t.id)
+      destroyTerminal(t.id)
+    }
+  }
+}
+
+/** Adopt whatever live work currently sits in the terminal store — started from
+ *  the Overview, or during the async boot window before any space was focused —
+ *  into a fresh space so its tabs (and running PTYs) are preserved rather than
+ *  swapped away and lost. Returns the new space, or null when the store holds no
+ *  tabs. `activate` focuses the new space (the Overview safety-net path); pass
+ *  false to keep it in the background — used when the user is switching to a
+ *  *different* space, so the orphaned work is preserved out of focus instead of
+ *  being discarded by the incoming swapWorkspace. */
+function adoptCurrentWorkAsSpace(activate: boolean): Space | null {
+  const term = useTerminalStore.getState()
+  const snapshot: WorkspaceSnapshot = {
+    groups: term.groups,
+    layout: term.layout,
+    activeGroupId: term.activeGroupId
+  }
+  if (!snapshot.groups.some((g) => g.tabs.length > 0)) return null
+  const st = useSpaceStore.getState()
+  const seed = deriveOrphanSpaceSeed(snapshot, st.spaces)
+  const space = makeSpace({
+    name: seed.name,
+    color: pickSpaceColor(st.spaces),
+    projectIds: seed.projectIds,
+    workspace: snapshot
+  })
+  useSpaceStore.setState(
+    activate
+      ? { spaces: [...st.spaces, space], activeSpaceId: space.id }
+      : { spaces: [...st.spaces, space] }
+  )
+  if (activate) syncActiveProject(space)
+  useSpaceStore.getState().persist()
+  return space
+}
+
+/** Build the on-disk file. The active space's workspace is read live from the
+ *  terminal store (source of truth); background spaces use their stashed
+ *  snapshot. */
+function buildPersistedFile(state: SpaceState): PersistedSpacesFile {
+  const activeId = state.activeSpaceId
+  const spaces: PersistedSpace[] = state.spaces.map((s) => {
+    const snap = s.id === activeId ? useTerminalStore.getState().snapshotWorkspace() : s.workspace
+    return {
+      id: s.id,
+      name: s.name,
+      color: s.color,
+      glyph: s.glyph,
+      projectIds: s.projectIds,
+      workspace: serializeWorkspaceSnapshot(snap),
+      createdAt: s.createdAt,
+      updatedAt: s.updatedAt,
+      lastActiveAt: s.lastActiveAt,
+      archived: s.archived
+    }
+  })
+  return { version: SPACES_VERSION, spaces, activeSpaceId: activeId }
+}
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null
+
+export const useSpaceStore = create<SpaceState>((set, get) => ({
+  spaces: [],
+  activeSpaceId: null,
+  loaded: false,
+
+  hydrate: async () => {
+    if (get().loaded) return
+
+    const installSink = (): void =>
+      setWorkspaceSink({ save: () => get().persist(), saveSync: () => get().persistNow() })
+
+    // Adopt any workspace the user started during the async boot window: the
+    // Projects/Sessions sidebar stays interactive while spaces load, and the
+    // orphan-adoption net below is dormant until `loaded`. Without this, the
+    // pending swapWorkspace would discard that work (and leak its PTYs). Keeps
+    // the just-loaded spaces (`background`) alive in the background. Returns true
+    // when it takes over hydration — the caller must then stop.
+    const adoptEarlyWork = (background: Space[]): boolean => {
+      const early = useTerminalStore.getState().snapshotWorkspace()
+      if (!early.groups.some((g) => g.tabs.length > 0)) return false
+
+      // Any space the user explicitly created during the boot window (its id is
+      // fresh, so it isn't among the just-loaded `background` set).
+      const pending = get().spaces.filter((p) => !background.some((b) => b.id === p.id))
+
+      // If the user created AND activated a space during that window, the live
+      // terminal work IS that space's work — attach it there rather than spinning
+      // up a throwaway "adopted" space, which would leave the created space empty
+      // and detach the user's work from the space they made for it.
+      const activeId = get().activeSpaceId
+      const activePending = activeId ? pending.find((p) => p.id === activeId) : undefined
+      if (activePending) {
+        const now = Date.now()
+        const merged: Space = {
+          ...activePending,
+          workspace: early,
+          updatedAt: now,
+          lastActiveAt: now
+        }
+        set({
+          spaces: [...background, ...pending.map((p) => (p.id === merged.id ? merged : p))],
+          activeSpaceId: merged.id,
+          loaded: true
+        })
+        installSink()
+        syncActiveProject(merged)
+        get().persist()
+        return true
+      }
+
+      // Otherwise the work is genuinely orphaned (no space was created for it) —
+      // wrap it in a freshly named, project-bound space and make it active.
+      const seed = deriveOrphanSpaceSeed(early, [...background, ...pending])
+      const adopted = makeSpace({
+        name: seed.name,
+        color: pickSpaceColor(background),
+        projectIds: seed.projectIds,
+        workspace: early
+      })
+      set({
+        spaces: [...background, ...pending, adopted],
+        activeSpaceId: adopted.id,
+        loaded: true
+      })
+      installSink()
+      syncActiveProject(adopted)
+      get().persist()
+      return true
+    }
+
+    let file: Awaited<ReturnType<typeof window.dplex.spaces.load>> = null
+    try {
+      file = await window.dplex.spaces.load()
+    } catch {
+      file = null
+    }
+
+    // Commit any space(s) the user created during the async load window when
+    // there is no persisted file to merge them into (absent/corrupt/unsupported,
+    // or a load error). Their live workspace is already in the terminal store,
+    // so don't swap anything — just mark loaded and persist. adoptEarlyWork only
+    // rescues started terminal work, so without this a freshly created empty
+    // space would be clobbered by the "My Work" seed below.
+    const commitPendingSpaces = (): boolean => {
+      if (get().spaces.length === 0) return false
+      set({ loaded: true })
+      installSink()
+      get().persist()
+      return true
+    }
+
+    // Drop any malformed (non-object or array) entries so a corrupt file can't
+    // crash the reconstruction below or resurrect as a bogus empty space (the
+    // main-process validator rejects non-objects too, but an array element
+    // slips past its `typeof === 'object'` check).
+    const validSpaces =
+      file && Array.isArray(file.spaces)
+        ? file.spaces.filter(
+            (ps): ps is PersistedSpace => !!ps && typeof ps === 'object' && !Array.isArray(ps)
+          )
+        : []
+
+    // Fresh install (no usable spaces file, no legacy workspace): seed one empty
+    // space so the app opens ready to work — unless the user already started
+    // something. A file that exists but has zero spaces is NOT a fresh install
+    // (the user deleted them all); that is honoured as the Overview below, so we
+    // don't resurrect a space they intentionally removed.
+    if (!file) {
+      if (adoptEarlyWork([])) return
+      if (commitPendingSpaces()) return
+      const seed = makeSpace({ name: 'My Work' })
+      set({ spaces: [seed], activeSpaceId: seed.id, loaded: true })
+      installSink()
+      return
+    }
+
+    try {
+      // Reconstruct each space's live workspace from its persisted form. AI tabs
+      // are prepared with fresh resume commands but no PTYs spawn until a space's
+      // tabs actually mount (i.e. when it comes into focus).
+      const spaces: Space[] = await Promise.all(
+        validSpaces.map(async (ps) => {
+          const workspace =
+            (await reconstructWorkspace(
+              ps.workspace as Parameters<typeof reconstructWorkspace>[0]
+            )) ?? EMPTY_WORKSPACE
+          return {
+            id: typeof ps.id === 'string' && ps.id ? ps.id : makeSpaceId(),
+            name: typeof ps.name === 'string' && ps.name ? ps.name : 'Space',
+            color: typeof ps.color === 'string' && ps.color ? ps.color : DEFAULT_SPACE_COLOR,
+            glyph: typeof ps.glyph === 'string' ? ps.glyph : undefined,
+            projectIds: Array.isArray(ps.projectIds) ? ps.projectIds : [],
+            workspace,
+            createdAt: ps.createdAt ?? Date.now(),
+            updatedAt: ps.updatedAt ?? Date.now(),
+            lastActiveAt: ps.lastActiveAt ?? Date.now(),
+            archived: ps.archived
+          }
+        })
+      )
+
+      // Keep any work the user started while we were loading (as the new active
+      // space); leave the loaded spaces in the background — never clobber it.
+      if (adoptEarlyWork(spaces)) return
+
+      // Preserve any space the user explicitly created during the async load
+      // window (the sidebar stays interactive; adoptEarlyWork only rescues
+      // started *terminal* work, not a freshly created empty space). Their
+      // in-window activation also wins over the stale persisted pointer.
+      const pending = get().spaces
+      const pendingActiveId = get().activeSpaceId
+      const mergedSpaces = pending.length > 0 ? [...spaces, ...pending] : spaces
+      const pendingIsActive = !!pendingActiveId && pending.some((s) => s.id === pendingActiveId)
+
+      const activeSpaceId: string | null = pendingIsActive
+        ? pendingActiveId
+        : file.activeSpaceId && spaces.some((s) => s.id === file.activeSpaceId)
+          ? file.activeSpaceId
+          : null
+
+      set({ spaces: mergedSpaces, activeSpaceId, loaded: true })
+      installSink()
+
+      // Restore the persisted active space's arrangement — but not when a space
+      // created during the window is already active (its arrangement is already
+      // live in the terminal store; swapping would discard it).
+      if (!pendingIsActive) {
+        const active = spaces.find((s) => s.id === activeSpaceId) ?? null
+        if (active) {
+          useTerminalStore.getState().swapWorkspace(active.workspace)
+          syncActiveProject(active)
+        }
+      }
+      if (pending.length > 0) get().persist()
+    } catch {
+      // A corrupt/unsupported file must never brick the app. Preserve any early
+      // work, else fall back to a fresh space (the on-disk file is left as-is
+      // until the next real workspace change persists over it).
+      if (get().loaded) return
+      if (adoptEarlyWork([])) return
+      if (commitPendingSpaces()) return
+      const seed = makeSpace({ name: 'My Work' })
+      set({ spaces: [seed], activeSpaceId: seed.id, loaded: true })
+      installSink()
+    }
+  },
+
+  createSpace: (opts) => {
+    const activate = opts.activate !== false
+    const space = makeSpace({
+      name: opts.name.trim() || 'New Space',
+      color: opts.color ?? pickSpaceColor(get().spaces),
+      glyph: opts.glyph,
+      projectIds: opts.projectIds
+    })
+    set((state) => ({ spaces: [...state.spaces, space] }))
+    if (activate) {
+      get().switchSpace(space.id)
+    } else {
+      get().persist()
+    }
+    return space.id
+  },
+
+  renameSpace: (id, name) => {
+    const trimmed = name.trim()
+    if (!trimmed) return
+    set((state) => ({
+      spaces: state.spaces.map((s) =>
+        s.id === id ? { ...s, name: trimmed, updatedAt: Date.now() } : s
+      )
+    }))
+    get().persist()
+  },
+
+  setSpaceAppearance: (id, patch) => {
+    set((state) => ({
+      spaces: state.spaces.map((s) =>
+        s.id === id
+          ? {
+              ...s,
+              color: patch.color ?? s.color,
+              glyph: patch.glyph === null ? undefined : (patch.glyph ?? s.glyph),
+              updatedAt: Date.now()
+            }
+          : s
+      )
+    }))
+    get().persist()
+  },
+
+  assignProjects: (id, projectIds) => {
+    const deduped = Array.from(new Set(projectIds))
+    set((state) => ({
+      spaces: state.spaces.map((s) =>
+        s.id === id ? { ...s, projectIds: deduped, updatedAt: Date.now() } : s
+      )
+    }))
+    // If reassigning the active space, keep the Projects panel in sync.
+    if (get().activeSpaceId === id) {
+      const space = get().spaces.find((s) => s.id === id) ?? null
+      syncActiveProject(space)
+    }
+    get().persist()
+  },
+
+  addProjectToSpace: (id, projectId) => {
+    const space = get().spaces.find((s) => s.id === id)
+    if (!space || space.projectIds.includes(projectId)) return
+    set((state) => ({
+      spaces: state.spaces.map((s) =>
+        s.id === id ? { ...s, projectIds: [...s.projectIds, projectId], updatedAt: Date.now() } : s
+      )
+    }))
+    get().persist()
+  },
+
+  pruneProject: (projectId) => {
+    const state = get()
+    if (!state.spaces.some((s) => s.projectIds.includes(projectId))) return
+    const now = Date.now()
+    const activePrimaryBefore =
+      state.spaces.find((s) => s.id === state.activeSpaceId)?.projectIds[0] ?? null
+    const spaces = state.spaces.map((s) =>
+      s.projectIds.includes(projectId)
+        ? { ...s, projectIds: s.projectIds.filter((p) => p !== projectId), updatedAt: now }
+        : s
+    )
+    set({ spaces })
+    // Retarget the Projects panel / Git ONLY when the ACTIVE space's primary
+    // project actually changed (its old primary was the pruned id). Removing a
+    // project bound only to background spaces — or a non-primary member of the
+    // active space — must not disturb the active tab's current project focus.
+    const activeAfter = spaces.find((s) => s.id === state.activeSpaceId) ?? null
+    if (activeAfter && (activeAfter.projectIds[0] ?? null) !== activePrimaryBefore) {
+      syncActiveProject(activeAfter)
+    }
+    get().persist()
+  },
+
+  switchSpace: (id) => {
+    const initial = get()
+    if (initial.activeSpaceId === id) return
+    if (!initial.spaces.some((s) => s.id === id)) return
+
+    // Boot-window / Overview race guard: if nothing is in focus yet but the
+    // terminal store already holds live work (an early restored session that
+    // resolved before hydrate armed the orphan-adoption net, or work started on
+    // the Overview), adopt it into a *background* space FIRST so swapping in the
+    // target below never discards those tabs and their running PTYs. Re-read
+    // state afterwards so the local `spaces` snapshot includes the adopted one.
+    if (initial.activeSpaceId === null) adoptCurrentWorkAsSpace(false)
+
+    const state = get()
+    const target = state.spaces.find((s) => s.id === id)
+    if (!target) return
+
+    const terminal = useTerminalStore.getState()
+    const now = Date.now()
+    let spaces = state.spaces
+
+    // Snapshot the outgoing space's live arrangement so it can be restored
+    // verbatim later (it keeps running in the background).
+    if (state.activeSpaceId) {
+      const outgoing = terminal.snapshotWorkspace()
+      spaces = spaces.map((s) =>
+        s.id === state.activeSpaceId ? { ...s, workspace: outgoing, updatedAt: now } : s
+      )
+    }
+    spaces = spaces.map((s) => (s.id === id ? { ...s, lastActiveAt: now } : s))
+
+    // Mark the target active BEFORE swapping in its tabs. The orphan-adoption
+    // safety net only runs while activeSpaceId===null; updating focus first
+    // stops it from misfiring on the 0→>0 groups transition when switching in
+    // from the Overview (which would burn a space id and double the
+    // active-project sync before this set() clobbers it back).
+    set({ spaces, activeSpaceId: id })
+
+    // Bring the target into focus — swap in its arrangement (never destroys the
+    // outgoing terminals; they detach and keep running). Stash the outgoing
+    // space's unsaved editor buffers first so manual-save edits survive the
+    // unmount and are restored when the space is resumed.
+    stashAllDirtyFileEditors()
+    terminal.swapWorkspace(target.workspace)
+    syncActiveProject(spaces.find((s) => s.id === id) ?? null)
+    get().persist()
+  },
+
+  sendToBackground: () => {
+    const state = get()
+    if (!state.activeSpaceId) return
+    const terminal = useTerminalStore.getState()
+    const now = Date.now()
+    const outgoing = terminal.snapshotWorkspace()
+    const spaces = state.spaces.map((s) =>
+      s.id === state.activeSpaceId ? { ...s, workspace: outgoing, updatedAt: now } : s
+    )
+    // Clear focus → Overview. The space stays alive in the background. Stash
+    // unsaved editor buffers first so they survive the unmount and restore on
+    // resume.
+    stashAllDirtyFileEditors()
+    terminal.swapWorkspace(EMPTY_WORKSPACE)
+    set({ spaces, activeSpaceId: null })
+    useProjectStore.getState().setActiveProject(null)
+    get().persist()
+  },
+
+  focusForDeferredWork: (originSpaceId) => {
+    if (!originSpaceId) return
+    const state = get()
+    if (state.activeSpaceId === originSpaceId) return
+    // The origin space was deleted while the async work ran. We deliberately do
+    // NOT force focus anywhere here:
+    //   • Common case — the origin was the *active* space when deleted, so we
+    //     landed on the Overview (activeSpaceId=null). The next tab created trips
+    //     the orphan-adoption net below, which spins up one fresh dedicated space
+    //     AND keeps every later tab of the same deferred chain (a setup script,
+    //     then the session it launches) together in that single space.
+    //   • Rare case — the user manually switched to an unrelated space B during
+    //     the async gap. The work then lands in B (still fully usable). Forcibly
+    //     stealing focus would be more disruptive, and re-dropping focus per
+    //     deferred tab would scatter a multi-tab chain across several spaces — so
+    //     we leave it be.
+    if (!state.spaces.some((s) => s.id === originSpaceId)) return
+    get().switchSpace(originSpaceId)
+  },
+
+  deleteSpace: (id) => {
+    const state = get()
+    const space = state.spaces.find((s) => s.id === id)
+    if (!space) return
+    const isActive = state.activeSpaceId === id
+
+    // Tear down the space's terminals (live snapshot if active, else stashed).
+    const snap = isActive ? useTerminalStore.getState().snapshotWorkspace() : space.workspace
+    teardownWorkspaceTerminals(snap)
+
+    const spaces = state.spaces.filter((s) => s.id !== id)
+    if (isActive) {
+      // Land on the Overview; nothing else is force-activated.
+      useTerminalStore.getState().swapWorkspace(EMPTY_WORKSPACE)
+      set({ spaces, activeSpaceId: null })
+      useProjectStore.getState().setActiveProject(null)
+    } else {
+      set({ spaces })
+    }
+    get().persist()
+  },
+
+  persist: () => {
+    // Never write during the async boot window (before hydrate commits): a
+    // debounced save fired by work started while loading could otherwise clobber
+    // the real spaces.json with pending-only state before reconstruction lands.
+    if (!get().loaded) return
+    if (persistTimer) clearTimeout(persistTimer)
+    persistTimer = setTimeout(() => {
+      persistTimer = null
+      void window.dplex.spaces.save(buildPersistedFile(get()))
+    }, 500)
+  },
+
+  persistNow: () => {
+    // As with persist(): don't let a quit during the boot window overwrite the
+    // on-disk file (still the source of truth until hydrate commits).
+    if (!get().loaded) return
+    if (persistTimer) {
+      clearTimeout(persistTimer)
+      persistTimer = null
+    }
+    window.dplex.spaces.saveSync(buildPersistedFile(get()))
+  }
+}))
+
+// Safety net: if tabs appear while no space is in focus (e.g. a session resumed
+// or a terminal opened from the Overview), adopt them into a fresh space so
+// nothing is orphaned or lost on reload. The space is named after the work that
+// triggered it (its project / folder / session) — never a generic "Space N".
+// Only fires on the 0 → >0 transition while activeSpaceId=null.
+useTerminalStore.subscribe((s, prev) => {
+  const st = useSpaceStore.getState()
+  if (!st.loaded || st.activeSpaceId !== null) return
+  if (prev.groups.length === 0 && s.groups.length > 0) {
+    adoptCurrentWorkAsSpace(true)
+  }
+})
+
+// Prune deleted projects from every space's binding. Fires only on a genuine
+// removal (a project present in prev but gone in next), so store hydration —
+// which only ADDS projects — can never false-prune a space whose project row
+// simply hasn't loaded yet. pruneProject itself no-ops when nothing references
+// the id, so this is cheap for the common add/reorder cases.
+useProjectStore.subscribe((next, prev) => {
+  if (next.projects === prev.projects || prev.projects.length <= next.projects.length) return
+  const nextIds = new Set(next.projects.map((p) => p.id))
+  for (const p of prev.projects) {
+    if (!nextIds.has(p.id)) useSpaceStore.getState().pruneProject(p.id)
+  }
+})
+
+/**
+ * Patch a terminal tab that currently lives inside a *background* space's
+ * stashed snapshot (not the active workspace, which the terminal store owns).
+ * Used when session-id / OSC-title resolution completes while its space is in
+ * the background — without this the resolved metadata would be written to the
+ * active store (a no-op) and lost, breaking attention correlation and the
+ * persisted resume command for that session. Returns true if the tab was found
+ * and updated. The active workspace is intentionally skipped: its tabs are
+ * mutated through the terminal store so the on-screen view stays in sync.
+ */
+export function patchBackgroundTab(
+  terminalId: string,
+  patch: { sessionId?: string; title?: string; pid?: number }
+): boolean {
+  let found = false
+  let changed = false
+  useSpaceStore.setState((state) => {
+    const spaces = state.spaces.map((s) => {
+      if (s.id === state.activeSpaceId) return s
+      let touched = false
+      const groups = s.workspace.groups.map((g) => {
+        const target = g.tabs.find((t) => t.id === terminalId)
+        if (!target) return g
+        found = true
+        // Skip tabs whose patched fields already match: backgrounded AI tools
+        // re-emit the same OSC title every turn, and rebuilding the store +
+        // scheduling a spaces.json write on each identical tick re-renders every
+        // space surface for nothing.
+        if (!patchChangesTab(target, patch)) return g
+        touched = true
+        changed = true
+        return {
+          ...g,
+          tabs: g.tabs.map((t) => (t.id === terminalId ? { ...t, ...patch } : t))
+        }
+      })
+      return touched ? { ...s, workspace: { ...s.workspace, groups } } : s
+    })
+    return changed ? { spaces } : {}
+  })
+  if (changed) useSpaceStore.getState().persist()
+  return found
+}
+
+/** Whether applying `patch` would actually change any of the tab's fields. Used
+ *  to no-op redundant background-tab updates (e.g. repeated identical OSC
+ *  titles) so they don't churn the store or schedule a needless disk write. */
+function patchChangesTab(
+  tab: EditorTab,
+  patch: { sessionId?: string; title?: string; pid?: number }
+): boolean {
+  if (!isTerminalTab(tab)) return true
+  if (patch.sessionId !== undefined && patch.sessionId !== tab.sessionId) return true
+  if (patch.title !== undefined && patch.title !== tab.title) return true
+  if (patch.pid !== undefined && patch.pid !== tab.pid) return true
+  return false
+}
+
+/**
+ * Mirror a file/folder rename into every *background* space's stashed snapshot:
+ * rewrite the path + title of any fileEditor tab pointing at the renamed file
+ * (or, for a folder rename, its descendants). The active workspace is handled by
+ * the terminal store (fileExplorerStore.syncTabsOnRename) and skipped here.
+ *
+ * Without this a background space keeps the pre-rename path: on resume the file
+ * reads as "missing", and saving a stashed unsaved (parked) buffer would write
+ * to — and so recreate — the old file. Deletes are intentionally NOT mirrored:
+ * a background tab for a deleted file surfaces the same graceful "file missing"
+ * state the active path already leaves dirty/parked tabs in, with no data loss.
+ */
+export function syncBackgroundEditorTabsOnRename(
+  root: string,
+  fromRel: string,
+  toRel: string
+): void {
+  const fromPrefix = fromRel + '/'
+  let changed = false
+  useSpaceStore.setState((state) => {
+    const spaces = state.spaces.map((s) => {
+      if (s.id === state.activeSpaceId) return s
+      let touched = false
+      const groups = s.workspace.groups.map((g) => {
+        let groupTouched = false
+        const tabs = g.tabs.map((t) => {
+          if (t.kind !== 'fileEditor' || t.rootFs !== root) return t
+          if (t.relPath === fromRel) {
+            groupTouched = true
+            return { ...t, relPath: toRel, title: basenameOf(toRel) }
+          }
+          if (t.relPath.startsWith(fromPrefix)) {
+            const next = toRel + '/' + t.relPath.slice(fromPrefix.length)
+            groupTouched = true
+            return { ...t, relPath: next, title: basenameOf(next) }
+          }
+          return t
+        })
+        if (!groupTouched) return g
+        touched = true
+        changed = true
+        return { ...g, tabs }
+      })
+      return touched ? { ...s, workspace: { ...s.workspace, groups } } : s
+    })
+    return changed ? { spaces } : {}
+  })
+  if (changed) useSpaceStore.getState().persist()
+}
+
+/**
+ * Whether deleting this space would silently discard unsaved editor edits —
+ * either a mounted dirty editor (the active space) or a stashed unsaved buffer
+ * left behind when the space was backgrounded. Deleting tears the workspace down
+ * without a per-file save prompt, so the delete confirmation surfaces this to
+ * warn the user before the irreversible action. AI sessions/terminals are not
+ * counted (they hold no unsaved *editor* content — DPlex never touches session
+ * content) and are covered by the dialog's standard copy.
+ */
+export function spaceHasUnsavedEditors(id: string): boolean {
+  const state = useSpaceStore.getState()
+  const space = state.spaces.find((s) => s.id === id)
+  if (!space) return false
+  const snap =
+    id === state.activeSpaceId ? useTerminalStore.getState().snapshotWorkspace() : space.workspace
+  for (const g of snap.groups) {
+    for (const t of g.tabs) {
+      if (t.kind !== 'fileEditor') continue
+      if (isFileEditorDirty(t.id) || hasParkedEditorBuffer(t.id)) return true
+    }
+  }
+  return false
+}
+
+function bgTabMatchesSession(
+  t: EditorTab,
+  sessionId: string,
+  providerId: string,
+  resumeCommand?: string
+): boolean {
+  if (!isTerminalTab(t)) return false
+  if (t.sessionId === sessionId && (t.providerId === providerId || t.providerId === undefined)) {
+    return true
+  }
+  return resumeCommand !== undefined && t.command === resumeCommand
+}
+
+/**
+ * Locate the first tab backing an AI session inside a *background* space's
+ * stashed snapshot. The active space is skipped — its live tabs are the terminal
+ * store's responsibility (sessionTabs searches those first). Returns the owning
+ * space plus group/tab ids so the caller can switch to it and focus the tab.
+ */
+export function findBackgroundSessionTab(
+  sessionId: string,
+  providerId: string,
+  resumeCommand?: string
+): { spaceId: string; groupId: string; tabId: string } | null {
+  const { spaces, activeSpaceId } = useSpaceStore.getState()
+  for (const s of spaces) {
+    if (s.id === activeSpaceId) continue
+    for (const g of s.workspace.groups) {
+      const tab = g.tabs.find((t) => bgTabMatchesSession(t, sessionId, providerId, resumeCommand))
+      if (tab) return { spaceId: s.id, groupId: g.id, tabId: tab.id }
+    }
+  }
+  return null
+}
+
+/**
+ * Close every tab backing an AI session that lives in a *background* space: tear
+ * down its terminal/PTY, close the session on disk, drop the tab from the stashed
+ * snapshot, and prune the layout. The active space is handled by the terminal
+ * store (closeOpenTabsForSession) — this covers the parked spaces so deleting a
+ * session from the Sessions list leaves no dangling parked tab. Returns true if
+ * anything was closed.
+ */
+export function closeBackgroundSessionTabs(
+  sessionId: string,
+  providerId: string,
+  resumeCommand?: string
+): boolean {
+  const { spaces, activeSpaceId } = useSpaceStore.getState()
+  const idsToClose = new Set<string>()
+  for (const s of spaces) {
+    if (s.id === activeSpaceId) continue
+    for (const g of s.workspace.groups) {
+      for (const t of g.tabs) {
+        if (bgTabMatchesSession(t, sessionId, providerId, resumeCommand)) idsToClose.add(t.id)
+      }
+    }
+  }
+  if (idsToClose.size === 0) return false
+
+  // Side effects first, so the setState updater below stays pure.
+  for (const id of idsToClose) destroyTerminal(id)
+  void window.dplex.sessions.close(sessionId, providerId).catch(() => {
+    // Provider may fail if the session is already gone — ignore.
+  })
+  useSessionStore.getState().clearLiveTabTitle(providerId, sessionId)
+
+  useSpaceStore.setState((state) => ({
+    spaces: state.spaces.map((s) => {
+      if (s.id === state.activeSpaceId) return s
+      if (!s.workspace.groups.some((g) => g.tabs.some((t) => idsToClose.has(t.id)))) return s
+      const groups = s.workspace.groups
+        .map((g) => ({ ...g, tabs: g.tabs.filter((t) => !idsToClose.has(t.id)) }))
+        .filter((g) => g.tabs.length > 0)
+        .map((g) => ({
+          ...g,
+          activeTabId: g.tabs.some((t) => t.id === g.activeTabId) ? g.activeTabId : g.tabs[0].id,
+          previewTabId:
+            g.previewTabId && g.tabs.some((t) => t.id === g.previewTabId)
+              ? g.previewTabId
+              : undefined
+        }))
+      if (groups.length === 0) return { ...s, workspace: EMPTY_WORKSPACE }
+      const validIds = new Set(groups.map((g) => g.id))
+      const layout = pruneLayoutToGroups(s.workspace.layout, validIds) ?? EMPTY_WORKSPACE.layout
+      const activeGroupId = validIds.has(s.workspace.activeGroupId ?? '')
+        ? s.workspace.activeGroupId
+        : groups[0].id
+      return { ...s, workspace: { groups, layout, activeGroupId } }
+    })
+  }))
+  useSpaceStore.getState().persist()
+  return true
+}

--- a/src/renderer/src/stores/spacesUiStore.ts
+++ b/src/renderer/src/stores/spacesUiStore.ts
@@ -1,0 +1,43 @@
+import { create } from 'zustand'
+
+export type SpaceModalMode = 'create' | 'rename' | 'projects'
+
+export interface SpaceModalRequest {
+  mode: SpaceModalMode
+  /** Present for 'rename' / 'projects' — the space being edited. */
+  spaceId?: string
+}
+
+export interface SpaceDeleteRequest {
+  id: string
+  name: string
+}
+
+interface SpacesUiState {
+  modal: SpaceModalRequest | null
+  deleteRequest: SpaceDeleteRequest | null
+  openCreate: () => void
+  openRename: (spaceId: string) => void
+  /** Opens the same editor focused on binding projects (heading reflects the
+   *  intent so an "Add a project" affordance never reads "Rename space"). */
+  openProjects: (spaceId: string) => void
+  closeModal: () => void
+  requestDelete: (space: SpaceDeleteRequest) => void
+  cancelDelete: () => void
+}
+
+/**
+ * Cross-surface UI coordination for Spaces. Any surface (switcher dropdown,
+ * sidebar panel, overview) can request the create/rename modal or a delete
+ * confirmation; single instances mounted at the app root render them.
+ */
+export const useSpacesUiStore = create<SpacesUiState>((set) => ({
+  modal: null,
+  deleteRequest: null,
+  openCreate: () => set({ modal: { mode: 'create' } }),
+  openRename: (spaceId) => set({ modal: { mode: 'rename', spaceId } }),
+  openProjects: (spaceId) => set({ modal: { mode: 'projects', spaceId } }),
+  closeModal: () => set({ modal: null }),
+  requestDelete: (space) => set({ deleteRequest: space }),
+  cancelDelete: () => set({ deleteRequest: null })
+}))

--- a/src/renderer/src/stores/terminalStore.ts
+++ b/src/renderer/src/stores/terminalStore.ts
@@ -6,11 +6,14 @@ import type {
   DashboardTab,
   EditorTab,
   EditorGroup,
-  LayoutNode
+  LayoutNode,
+  WorkspaceSnapshot
 } from '../types'
 import { isFileDiffTab, isFileEditorTab, isTerminalTab, isDashboardTab } from '../types'
 import { destroyTerminal } from '../services/terminalRegistry'
+import { clearParkedEditorBuffer } from '../services/parkedEditorBuffers'
 import { useSessionStore } from './sessionStore'
+import { serializeWorkspaceSnapshot } from '../utils/workspaceSnapshot'
 
 let tabCounter = 0
 let groupCounter = 0
@@ -146,11 +149,14 @@ interface TerminalState {
   reorderTab: (groupId: string, fromIndex: number, toIndex: number) => void
   getActiveGroup: () => EditorGroup | undefined
   getAllTerminalIds: () => string[]
-  restoreWorkspace: (
-    groups: EditorGroup[],
-    layout: LayoutNode,
-    activeGroupId: string | null
-  ) => void
+  /** Unconditionally replace the live workspace with a snapshot (Space switch /
+   *  resume / send-to-background). It has no boot
+   *  guard and never destroys terminals — detached terminals keep running in
+   *  the registry and re-attach when their tab mounts again, so switching a
+   *  Space never restarts a session. */
+  swapWorkspace: (snapshot: WorkspaceSnapshot) => void
+  /** Capture the current live workspace (lossless) for stashing on a Space. */
+  snapshotWorkspace: () => WorkspaceSnapshot
   setPid: (terminalId: string, pid: number) => void
   associateSessionId: (terminalId: string, sessionId: string) => void
   setWorktreeMetadata: (
@@ -194,6 +200,26 @@ interface TerminalState {
    * Returns the dashboard tab id.
    */
   openOrFocusDashboardTab: () => string
+}
+
+function syncGroupCounter(groups: EditorGroup[]): void {
+  for (const g of groups) {
+    const num = parseInt(g.id.replace('group-', ''), 10)
+    if (!isNaN(num) && num >= groupCounter) groupCounter = num + 1
+  }
+}
+
+/**
+ * Enforce the previewTabId invariant: undefined, or references an existing tab.
+ * Older serialized workspaces lack the field; reconstructed ones may point at a
+ * tab that was filtered out (preview tabs aren't persisted), so re-validate.
+ */
+function sanitizeGroupPreviews(groups: EditorGroup[]): EditorGroup[] {
+  return groups.map((g) => ({
+    ...g,
+    previewTabId:
+      g.previewTabId && g.tabs.some((t) => t.id === g.previewTabId) ? g.previewTabId : undefined
+  }))
 }
 
 export const useTerminalStore = create<TerminalState>((set, get) => ({
@@ -277,9 +303,22 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       useSessionStore.getState().clearLiveTabTitle(tab.providerId, tab.sessionId)
     }
 
+    if (tab && isFileEditorTab(tab)) {
+      // A closed fileEditor never remounts to consume its parked buffer, so drop
+      // any stash made while its Space was backgrounded — otherwise up to a few
+      // MB of content+baseline would leak in the module map until app restart.
+      clearParkedEditorBuffer(terminalId)
+    }
+
     destroyTerminal(terminalId)
 
-    const updatedGroups = state.groups.map((g) => {
+    // Re-read state AFTER destroyTerminal: it synchronously fires any pending
+    // exit handler (e.g. a running worktree setup script), whose afterCreate can
+    // create a new terminal tab. Computing the removal from the pre-destroy
+    // snapshot would clobber that just-created tab. Work from fresh state so the
+    // only change we apply is removing `terminalId`.
+    const fresh = get()
+    const updatedGroups = fresh.groups.map((g) => {
       const idx = g.tabs.findIndex((t) => t.id === terminalId)
       if (idx === -1) return g
       const newTabs = g.tabs.filter((t) => t.id !== terminalId)
@@ -299,14 +338,14 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     const emptyGroupIds = updatedGroups.filter((g) => g.tabs.length === 0).map((g) => g.id)
     const aliveGroups = updatedGroups.filter((g) => g.tabs.length > 0)
 
-    let newLayout = state.layout
+    let newLayout = fresh.layout
     for (const gid of emptyGroupIds) {
       const pruned = removeGroupFromLayout(newLayout, gid)
       if (pruned) newLayout = pruned
     }
 
     const newActiveGroupId =
-      aliveGroups.find((g) => g.id === state.activeGroupId)?.id ?? aliveGroups[0]?.id ?? null
+      aliveGroups.find((g) => g.id === fresh.activeGroupId)?.id ?? aliveGroups[0]?.id ?? null
 
     set({
       groups: aliveGroups,
@@ -513,25 +552,23 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
     return get().groups.flatMap((g) => g.tabs.map((t) => t.id))
   },
 
-  restoreWorkspace: (groups, layout, activeGroupId) => {
-    // Don't overwrite if terminals were already created during async load
-    if (get().groups.length > 0) return
-    // Sync counters so new tabs/groups don't collide with restored IDs
-    for (const g of groups) {
-      const num = parseInt(g.id.replace('group-', ''), 10)
-      if (!isNaN(num) && num >= groupCounter) groupCounter = num + 1
-    }
-    // Sanitize the previewTabId invariant: must be undefined or refer to an
-    // existing tab in `tabs`. Older serialized workspaces lack the field
-    // entirely (undefined is fine); newer ones may persist a value pointing
-    // to a tab we deliberately filtered out (preview tabs aren't persisted),
-    // so re-validate.
-    const sanitized = groups.map((g) => ({
-      ...g,
-      previewTabId:
-        g.previewTabId && g.tabs.some((t) => t.id === g.previewTabId) ? g.previewTabId : undefined
-    }))
-    set({ groups: sanitized, layout, activeGroupId, restored: true })
+  swapWorkspace: (snapshot) => {
+    // No boot guard: this deliberately replaces whatever is mounted. Detaching
+    // a group's tabs only removes their DOM — the PTYs + xterm instances live
+    // in terminalRegistry and re-attach when the tab mounts again, so switching
+    // Spaces never restarts a session.
+    syncGroupCounter(snapshot.groups)
+    set({
+      groups: sanitizeGroupPreviews(snapshot.groups),
+      layout: snapshot.layout,
+      activeGroupId: snapshot.activeGroupId,
+      restored: true
+    })
+  },
+
+  snapshotWorkspace: () => {
+    const { groups, layout, activeGroupId } = get()
+    return { groups, layout, activeGroupId }
   },
 
   setPid: (terminalId, pid) => {
@@ -948,81 +985,42 @@ export function _serializeWorkspaceForTests(): unknown {
 
 function serializeWorkspace(): unknown {
   const { groups, layout, activeGroupId } = useTerminalStore.getState()
-  return {
-    layout,
-    groups: groups.map((g) => ({
-      id: g.id,
-      tabs: g.tabs
-        // Persist AI session terminal tabs (have a `command`) and
-        // PERMANENT fileDiff / fileEditor tabs. Plain shell terminals and
-        // preview tabs are intentionally NOT persisted.
-        .filter((t) => {
-          if (isFileDiffTab(t)) return t.preview !== true
-          if (isFileEditorTab(t)) return t.preview !== true
-          if (isDashboardTab(t)) return true
-          return isTerminalTab(t) && !!t.command
-        })
-        .map((t) => {
-          if (isDashboardTab(t)) {
-            return { kind: 'dashboard' as const, id: t.id, title: t.title, color: t.color }
-          }
-          if (isFileDiffTab(t)) {
-            return {
-              kind: 'fileDiff' as const,
-              id: t.id,
-              title: t.title,
-              repoRootFs: t.repoRootFs,
-              repoLabel: t.repoLabel,
-              scope: t.scope,
-              file: t.file,
-              sideBySide: t.sideBySide,
-              color: t.color
-            }
-          }
-          if (isFileEditorTab(t)) {
-            return {
-              kind: 'fileEditor' as const,
-              id: t.id,
-              title: t.title,
-              rootFs: t.rootFs,
-              rootLabel: t.rootLabel,
-              relPath: t.relPath,
-              color: t.color
-            }
-          }
-          return {
-            id: t.id,
-            title: t.title,
-            cwd: t.cwd,
-            command: t.command,
-            sessionId: t.sessionId,
-            providerId: t.providerId,
-            worktreePath: t.worktreePath,
-            worktreeBranch: t.worktreeBranch,
-            color: t.color
-          }
-        }),
-      activeTabId: g.activeTabId
-      // previewTabId is deliberately NOT serialized — preview tabs are
-      // transient and their slot is recomputed on first openOrFocusDiffTab
-      // after restore.
-    })),
-    activeGroupId,
-    savedAt: new Date().toISOString()
+  return serializeWorkspaceSnapshot({ groups, layout, activeGroupId })
+}
+
+export interface WorkspaceSink {
+  save: () => void
+  saveSync: () => void
+}
+
+// Where the active workspace snapshot is persisted. Defaults to the flat
+// sessions.json contract; spaceStore replaces this with a sink that embeds the
+// snapshot into the active Space and writes spaces.json instead.
+const defaultWorkspaceSink: WorkspaceSink = {
+  save: () => {
+    void window.dplex.sessions.saveWorkspace(serializeWorkspace())
+  },
+  saveSync: () => {
+    window.dplex.sessions.saveWorkspaceSync(serializeWorkspace())
   }
+}
+let workspaceSink: WorkspaceSink = defaultWorkspaceSink
+
+/** Redirect where the active workspace is persisted. Pass null to restore the
+ *  default (sessions.json) sink. */
+export function setWorkspaceSink(sink: WorkspaceSink | null): void {
+  workspaceSink = sink ?? defaultWorkspaceSink
 }
 
 /** Sync save — blocks until written. Use on beforeunload for reliable quit. */
 export function persistWorkspaceNow(): void {
-  const data = serializeWorkspace()
-  window.dplex.sessions.saveWorkspaceSync(data)
+  workspaceSink.saveSync()
 }
 
 function debouncedPersist(): void {
   if (saveTimer) clearTimeout(saveTimer)
   saveTimer = setTimeout(() => {
-    const data = serializeWorkspace()
-    window.dplex.sessions.saveWorkspace(data)
+    workspaceSink.save()
   }, 2000)
 }
 

--- a/src/renderer/src/types/index.ts
+++ b/src/renderer/src/types/index.ts
@@ -124,6 +124,47 @@ export interface LayoutNode {
   children?: LayoutNode[]
 }
 
+/**
+ * A lossless, in-memory snapshot of the editor workspace: the split layout,
+ * every group with its tabs (including plain shell terminals and preview
+ * tabs), and the active group. This is what a Space holds while it is in the
+ * background — the terminals themselves keep running in `terminalRegistry`;
+ * only this lightweight arrangement is copied. Distinct from the *persisted*
+ * (disk) form, which drops non-resumable tabs.
+ */
+export interface WorkspaceSnapshot {
+  layout: LayoutNode
+  groups: EditorGroup[]
+  activeGroupId: string | null
+}
+
+/**
+ * A Space groups a whole working environment (one or more projects, the AI
+ * sessions + terminals, the tab/split arrangement) so the developer can leave
+ * an activity and return to it without rebuilding their workspace. Exactly one
+ * Space is "in focus" at a time (or none — the Overview). Backgrounded Spaces
+ * keep their sessions running and keep receiving attention updates. DPlex only
+ * manages this arrangement; it never reads session content.
+ */
+export interface Space {
+  id: string
+  name: string
+  /** Accent color (hex) used across the switcher, cards, and status bar. */
+  color: string
+  /** Optional single-character / emoji glyph shown on the space's avatar. */
+  glyph?: string
+  /** Projects bound to this space. The primary project is `projectIds[0]`. */
+  projectIds: string[]
+  /** Live, lossless workspace arrangement for this space. */
+  workspace: WorkspaceSnapshot
+  createdAt: number
+  updatedAt: number
+  /** Last time this space was in focus. Drives "recently used" ordering. */
+  lastActiveAt: number
+  /** Reserved for a future archive/hide feature; not user-facing yet. */
+  archived?: boolean
+}
+
 export type SessionStatus =
   | 'idle'
   | 'thinking'
@@ -146,6 +187,13 @@ export interface AISession {
   toolCallCount?: number
   lastActivityTime?: number
 }
+
+/**
+ * The switchable views in the activity bar (the vertical icon rail). Also the
+ * set of values `sidebarActiveTab` can take. The visible order is
+ * user-reorderable and persisted via `AppSettings.activityBarOrder`.
+ */
+export type ActivityBarId = 'projects' | 'spaces' | 'sessions' | 'git' | 'search' | 'explorer'
 
 export interface AppSettings {
   defaultShell: string
@@ -170,7 +218,14 @@ export interface AppSettings {
   sidebarWidth: number
   sidebarVisible: boolean
   /** Which sidebar view is active in the activity bar. */
-  sidebarActiveTab: 'projects' | 'sessions' | 'git' | 'search' | 'explorer'
+  sidebarActiveTab: ActivityBarId
+  /**
+   * User-defined order of the activity-bar view icons (drag to reorder). Stored
+   * as the full list of {@link ActivityBarId}s; missing/unknown ids are
+   * reconciled against the canonical set at render time, so the app stays
+   * robust across added or removed views.
+   */
+  activityBarOrder: ActivityBarId[]
   /** When true, the panel portion of the sidebar is collapsed (activity bar still visible). */
   sidebarPanelCollapsed: boolean
   sessionPollIntervalMs: number

--- a/src/renderer/src/utils/activityBarOrder.ts
+++ b/src/renderer/src/utils/activityBarOrder.ts
@@ -1,0 +1,71 @@
+import type { ActivityBarId } from '../types'
+
+/**
+ * Canonical default order of the activity-bar view icons. Spaces leads by
+ * design — it is the primary "where am I working" surface — followed by the
+ * remaining views. This is also the source of truth for the full set of valid
+ * {@link ActivityBarId}s used to reconcile any persisted order.
+ */
+export const DEFAULT_ACTIVITY_BAR_ORDER: readonly ActivityBarId[] = [
+  'spaces',
+  'projects',
+  'sessions',
+  'explorer',
+  'git',
+  'search'
+]
+
+/**
+ * Normalize a persisted (or partial/stale) order against the canonical set:
+ * keep the known ids in their saved order, drop anything unknown or duplicated,
+ * then append any canonical ids the saved order is missing. This keeps the rail
+ * complete and de-duplicated even as views are added or removed across
+ * versions, without ever losing the user's chosen order for the ids they did
+ * arrange.
+ */
+export function reconcileActivityBarOrder(
+  saved: readonly ActivityBarId[] | undefined | null,
+  canonical: readonly ActivityBarId[] = DEFAULT_ACTIVITY_BAR_ORDER
+): ActivityBarId[] {
+  const allowed = new Set(canonical)
+  const seen = new Set<ActivityBarId>()
+  const result: ActivityBarId[] = []
+  for (const id of saved ?? []) {
+    if (allowed.has(id) && !seen.has(id)) {
+      seen.add(id)
+      result.push(id)
+    }
+  }
+  for (const id of canonical) {
+    if (!seen.has(id)) {
+      seen.add(id)
+      result.push(id)
+    }
+  }
+  return result
+}
+
+/**
+ * Move `draggedId` to sit relative to `targetId` (classic remove-then-insert
+ * array move, matching the tab reorder). `position` picks the edge of the
+ * target the item lands on — `'before'` (default) or `'after'` — which lets a
+ * vertical rail reach every slot, including the very end. Returns a new array.
+ * No-ops (returning a copy of the input) when either id is absent or they are
+ * the same, so a drop onto self never churns state.
+ */
+export function reorderActivityBar(
+  order: readonly ActivityBarId[],
+  draggedId: ActivityBarId,
+  targetId: ActivityBarId,
+  position: 'before' | 'after' = 'before'
+): ActivityBarId[] {
+  if (draggedId === targetId) return order.slice()
+  const fromIndex = order.indexOf(draggedId)
+  const targetIndex = order.indexOf(targetId)
+  if (fromIndex === -1 || targetIndex === -1) return order.slice()
+  const next = order.slice()
+  next.splice(fromIndex, 1)
+  const insertAt = next.indexOf(targetId) + (position === 'after' ? 1 : 0)
+  next.splice(insertAt, 0, draggedId)
+  return next
+}

--- a/src/renderer/src/utils/inheritCwd.ts
+++ b/src/renderer/src/utils/inheritCwd.ts
@@ -1,5 +1,6 @@
 import { useTerminalStore } from '../stores/terminalStore'
 import { useProjectStore } from '../stores/projectStore'
+import { useSpaceStore } from '../stores/spaceStore'
 import { getTerminalEntry } from '../services/terminalRegistry'
 import { getTabProjectPath, findProjectForTab } from './tabProject'
 import { pickInheritedCwd } from './pickInheritedCwd'
@@ -45,7 +46,12 @@ function inheritSourceGroup(groupId: string | undefined): EditorGroup | undefine
  * callers actually use when opening blank terminals.
  */
 export async function openInheritedTerminal(groupId?: string, shell?: string): Promise<string> {
+  // The cwd probe below is an async IPC round-trip; capture the Space in focus
+  // now so a switch during it routes the new terminal back to its origin (never
+  // into whatever Space happens to be active when the probe resolves).
+  const originSpaceId = useSpaceStore.getState().activeSpaceId
   const cwd = await resolveInheritedCwd(inheritSourceGroup(groupId))
+  useSpaceStore.getState().focusForDeferredWork(originSpaceId)
   return useTerminalStore.getState().createTerminal(groupId, undefined, undefined, shell, cwd)
 }
 
@@ -57,6 +63,8 @@ export async function openInheritedSplit(
   groupId: string,
   direction: 'horizontal' | 'vertical'
 ): Promise<string> {
+  const originSpaceId = useSpaceStore.getState().activeSpaceId
   const cwd = await resolveInheritedCwd(inheritSourceGroup(groupId))
+  useSpaceStore.getState().focusForDeferredWork(originSpaceId)
   return useTerminalStore.getState().splitGroup(groupId, direction, cwd)
 }

--- a/src/renderer/src/utils/sessionTabs.ts
+++ b/src/renderer/src/utils/sessionTabs.ts
@@ -1,6 +1,11 @@
 import type { TerminalTab, EditorTab, EditorGroup, AISession } from '../types'
 import { isTerminalTab } from '../types'
 import { useTerminalStore } from '../stores/terminalStore'
+import {
+  useSpaceStore,
+  findBackgroundSessionTab,
+  closeBackgroundSessionTabs
+} from '../stores/spaceStore'
 import { normalizePath } from './normalizePath'
 
 function tabMatchesSession(t: EditorTab, sessionId: string, providerId: string): boolean {
@@ -54,6 +59,9 @@ export function findFirstTabForSession(
 
 /**
  * Store-aware: focus an existing tab for the given AI session (if any).
+ * Searches the active space first, then every backgrounded space — a session
+ * parked in the background is switched into focus (which keeps every session
+ * running) and focused, rather than being treated as gone.
  * Returns `true` if a tab was found and focused.
  */
 export function focusSessionTab(
@@ -63,14 +71,28 @@ export function focusSessionTab(
 ): boolean {
   const { groups, setActiveGroup, setActiveTerminalInGroup } = useTerminalStore.getState()
   const match = findFirstTabForSession(groups, sessionId, providerId, resumeCommand)
-  if (!match) return false
-  setActiveGroup(match.groupId)
-  setActiveTerminalInGroup(match.groupId, match.tab.id)
-  return true
+  if (match) {
+    setActiveGroup(match.groupId)
+    setActiveTerminalInGroup(match.groupId, match.tab.id)
+    return true
+  }
+  // Not in the active space — it may be parked in a background space. Bring that
+  // space into focus (never restarts sessions) and focus the tab there.
+  const bg = findBackgroundSessionTab(sessionId, providerId, resumeCommand)
+  if (bg) {
+    useSpaceStore.getState().switchSpace(bg.spaceId)
+    const ts = useTerminalStore.getState()
+    ts.setActiveGroup(bg.groupId)
+    ts.setActiveTerminalInGroup(bg.groupId, bg.tabId)
+    return true
+  }
+  return false
 }
 
 /**
- * Store-aware: close any tabs representing the given AI session.
+ * Store-aware: close any tabs representing the given AI session, across the
+ * active space AND every backgrounded space (so deleting a session from the
+ * Sessions list never leaves a dangling parked tab).
  *
  * Accepts an optional `resumeCommand` to also match legacy tabs that were
  * persisted with only a `command` (e.g. restored from workspace) before
@@ -94,13 +116,15 @@ export function closeOpenTabsForSession(
     }
   }
   matchIds.forEach((id) => closeTerminal(id))
-  return matchIds.size > 0
+  const closedBackground = closeBackgroundSessionTabs(sessionId, providerId, resumeCommand)
+  return matchIds.size > 0 || closedBackground
 }
 
-/** Store-aware: does any open tab represent the given AI session? */
+/** Store-aware: does any open tab (in any space) represent the given AI session? */
 export function hasOpenTab(sessionId: string, providerId: string): boolean {
   const { groups } = useTerminalStore.getState()
-  return findTabsForSession(groups, sessionId, providerId).length > 0
+  if (findTabsForSession(groups, sessionId, providerId).length > 0) return true
+  return findBackgroundSessionTab(sessionId, providerId) !== null
 }
 
 /**
@@ -114,9 +138,15 @@ export function hasOpenTab(sessionId: string, providerId: string): boolean {
 export async function resumeOrFocusSession(
   session: Pick<AISession, 'id' | 'aiTool' | 'displayName' | 'cwd'>
 ): Promise<void> {
+  // Capture the Space in focus at request time: getResumeCommand is async and
+  // the user may switch Spaces during that gap. Without this, a newly spawned
+  // resume terminal would land in whatever Space happens to be active when the
+  // command resolves instead of the one the user launched it from.
+  const originSpaceId = useSpaceStore.getState().activeSpaceId
   const cmd = await window.dplex.sessions.getResumeCommand(session.aiTool, session.id)
   if (focusSessionTab(session.id, session.aiTool, cmd ?? undefined)) return
   if (!cmd) return
+  useSpaceStore.getState().focusForDeferredWork(originSpaceId)
   useTerminalStore
     .getState()
     .createTerminal(

--- a/src/renderer/src/utils/spaceAttention.ts
+++ b/src/renderer/src/utils/spaceAttention.ts
@@ -1,0 +1,123 @@
+import type { AttentionEvent, AttentionKind } from '../../../preload/attentionTypes'
+import { makeCompositeId } from '../../../preload/attentionTypes'
+import type { Space, WorkspaceSnapshot } from '../types'
+import { isTerminalTab } from '../types'
+
+/**
+ * Rolled-up attention for a single Space. Aggregated from the shared attention
+ * snapshot (keyed by `providerId:sessionId`) filtered to the space's own
+ * sessions — so a backgrounded space still reports approvals/input waiting on
+ * it with no extra plumbing. DPlex only reads the attention *signal*; it never
+ * inspects session content.
+ */
+export interface SpaceAttention {
+  waitingForApproval: number
+  waitingForInput: number
+  finished: number
+  /** Sum of the three counts above. */
+  total: number
+  /** Highest-priority kind present (approval > input > finished), for the
+   *  ring / badge color. Null when the space needs no attention. */
+  topKind: AttentionKind | null
+}
+
+export const EMPTY_SPACE_ATTENTION: SpaceAttention = {
+  waitingForApproval: 0,
+  waitingForInput: 0,
+  finished: 0,
+  total: 0,
+  topKind: null
+}
+
+/** Human label for an attention kind. Title-case by default (standalone
+ *  badges); pass `lower` for mid-sentence use (e.g. toast bodies). */
+const ATTENTION_KIND_LABEL: Record<AttentionKind, string> = {
+  waitingForApproval: 'Needs approval',
+  waitingForInput: 'Waiting for you',
+  finished: 'Finished'
+}
+
+export function attentionKindLabel(kind: AttentionKind, lower = false): string {
+  const label = ATTENTION_KIND_LABEL[kind]
+  return lower ? label.toLowerCase() : label
+}
+
+/** Highest-priority attention kind present, approval > input > finished.
+ *  Null when nothing needs attention. Single source of the ordering ladder. */
+export function pickTopKind(
+  waitingForApproval: number,
+  waitingForInput: number,
+  finished: number
+): AttentionKind | null {
+  if (waitingForApproval > 0) return 'waitingForApproval'
+  if (waitingForInput > 0) return 'waitingForInput'
+  if (finished > 0) return 'finished'
+  return null
+}
+
+/** Composite attention ids (`providerId:sessionId`) for every AI session tab
+ *  in a workspace snapshot. Only `groups` is read, so callers may pass live
+ *  terminal-store groups directly. */
+export function collectSessionCompositeIds(
+  snapshot: Pick<WorkspaceSnapshot, 'groups'>
+): Set<string> {
+  const ids = new Set<string>()
+  for (const g of snapshot.groups) {
+    for (const t of g.tabs) {
+      if (isTerminalTab(t) && t.providerId && t.sessionId) {
+        ids.add(makeCompositeId(t.providerId, t.sessionId))
+      }
+    }
+  }
+  return ids
+}
+
+/** Aggregate attention events for the given set of composite session ids.
+ *  Suppressed (dismissed) events are ignored. Pure — safe to unit test. */
+export function aggregateAttention(
+  events: readonly AttentionEvent[],
+  ids: ReadonlySet<string>
+): SpaceAttention {
+  if (ids.size === 0) return EMPTY_SPACE_ATTENTION
+  let waitingForApproval = 0
+  let waitingForInput = 0
+  let finished = 0
+  for (const e of events) {
+    if (e.suppressed) continue
+    if (!ids.has(e.compositeId)) continue
+    if (e.kind === 'waitingForApproval') waitingForApproval += 1
+    else if (e.kind === 'waitingForInput') waitingForInput += 1
+    else if (e.kind === 'finished') finished += 1
+  }
+  const total = waitingForApproval + waitingForInput + finished
+  const topKind = pickTopKind(waitingForApproval, waitingForInput, finished)
+  return { waitingForApproval, waitingForInput, finished, total, topKind }
+}
+
+/** Roll up attention for a single space from its own session tabs. Reads the
+ *  space's stashed snapshot — correct for background spaces, but stale for the
+ *  space in focus (whose live tabs live in the terminal store). Prefer
+ *  {@link aggregateActiveAwareAttention} when the active space may be involved. */
+export function aggregateSpaceAttention(
+  space: Space,
+  events: readonly AttentionEvent[]
+): SpaceAttention {
+  return aggregateAttention(events, collectSessionCompositeIds(space.workspace))
+}
+
+/**
+ * Roll up attention for a space, preferring the live terminal groups for the
+ * space in focus (so a brand-new session counts immediately, before the next
+ * snapshot is stashed) and the stashed snapshot for background spaces. Pass the
+ * terminal store's live `groups` for the active space, or `null` otherwise.
+ */
+export function aggregateActiveAwareAttention(
+  space: Space,
+  events: readonly AttentionEvent[],
+  activeGroups: Pick<WorkspaceSnapshot, 'groups'> | null
+): SpaceAttention {
+  const ids = activeGroups
+    ? collectSessionCompositeIds(activeGroups)
+    : collectSessionCompositeIds(space.workspace)
+  return aggregateAttention(events, ids)
+}

--- a/src/renderer/src/utils/spaceColors.ts
+++ b/src/renderer/src/utils/spaceColors.ts
@@ -1,0 +1,41 @@
+import type { Space } from '../types'
+
+/**
+ * Accent palette for Spaces — mirrors the interactive mockup. Each Space gets
+ * one of these; they drive the switcher avatar, overview cards, activity-bar
+ * ring, and status-bar label.
+ */
+export const SPACE_COLORS = [
+  '#22D3EE', // cyan
+  '#3B82F6', // blue
+  '#34D399', // emerald
+  '#F59E0B', // amber
+  '#A78BFA', // violet
+  '#FB923C', // orange
+  '#F472B6', // pink
+  '#F87171' // red
+] as const
+
+export const DEFAULT_SPACE_COLOR: string = SPACE_COLORS[0]
+
+/**
+ * Pick the palette color least used by existing spaces so new spaces stay
+ * visually distinct. Ties resolve to the earliest palette entry.
+ */
+export function pickSpaceColor(existing: Pick<Space, 'color'>[]): string {
+  const counts = new Map<string, number>()
+  for (const c of SPACE_COLORS) counts.set(c, 0)
+  for (const s of existing) {
+    if (counts.has(s.color)) counts.set(s.color, (counts.get(s.color) ?? 0) + 1)
+  }
+  let best: string = SPACE_COLORS[0]
+  let bestN = Infinity
+  for (const c of SPACE_COLORS) {
+    const n = counts.get(c) ?? 0
+    if (n < bestN) {
+      bestN = n
+      best = c
+    }
+  }
+  return best
+}

--- a/src/renderer/src/utils/spaceStart.ts
+++ b/src/renderer/src/utils/spaceStart.ts
@@ -1,0 +1,66 @@
+import type { Project } from '../types'
+import { useProjectStore } from '../stores/projectStore'
+import { useSpaceStore } from '../stores/spaceStore'
+import { useTerminalStore } from '../stores/terminalStore'
+
+/**
+ * Shared "start work" actions used by the Space surfaces (switcher quick-start,
+ * empty-workspace state) and the Projects panel. Each opens a tab in the
+ * terminal store: while a space is in focus the tab joins it; from the Overview
+ * the orphan-adoption net in `spaceStore` adopts it into a fresh space named
+ * after the project.
+ *
+ * Kept as thin store wrappers (not inline in components) so every surface
+ * launches work identically — the provider-resolution logic lives once in
+ * `projectStore`.
+ */
+
+/** Start an AI session for a project. `providerId` overrides the default AI
+ *  tool; otherwise the configured default (or first registered) provider wins.
+ *
+ *  Provider resolution is async (two IPC round-trips). If the user switches to
+ *  another space during it, the freshly created tab would otherwise land in the
+ *  wrong workspace, so we capture the space the launch was requested from and
+ *  re-focus it before creating the tab. Re-focusing never restarts anything —
+ *  `switchSpace` only re-mounts existing terminals. Launches from the Overview
+ *  (no origin space) intentionally land wherever work now goes, so the user
+ *  isn't yanked out of a space they've since opened.
+ *
+ *  When launched from within a space, the project is bound to that space (if it
+ *  wasn't already) so the space's project list stays in step with the work
+ *  running inside it. */
+export function startProjectSession(project: Project, providerId?: string): void {
+  const originSpaceId = useSpaceStore.getState().activeSpaceId
+  void useProjectStore
+    .getState()
+    .resolveAISession(project, providerId)
+    .then((resolved) => {
+      if (!resolved) return
+      const spaces = useSpaceStore.getState()
+      if (originSpaceId && spaces.activeSpaceId !== originSpaceId) {
+        spaces.switchSpace(originSpaceId)
+      }
+      useProjectStore.getState().createAISessionTab(resolved)
+      if (originSpaceId) {
+        useSpaceStore.getState().addProjectToSpace(originSpaceId, project.id)
+      }
+    })
+}
+
+/** Open a plain shell terminal rooted at a project's path. When a space is in
+ *  focus the project is bound to it (if not already), matching the session
+ *  behaviour above. */
+export function openProjectTerminal(project: Project): void {
+  const activeSpaceId = useSpaceStore.getState().activeSpaceId
+  useTerminalStore
+    .getState()
+    .createTerminal(undefined, project.name, undefined, undefined, project.path)
+  if (activeSpaceId) {
+    useSpaceStore.getState().addProjectToSpace(activeSpaceId, project.id)
+  }
+}
+
+/** Open a plain shell terminal with no project association. */
+export function openPlainTerminal(): void {
+  useTerminalStore.getState().createTerminal()
+}

--- a/src/renderer/src/utils/workspaceSnapshot.ts
+++ b/src/renderer/src/utils/workspaceSnapshot.ts
@@ -1,0 +1,238 @@
+import type {
+  DashboardTab,
+  EditorGroup,
+  EditorTab,
+  FileDiffTab,
+  FileEditorTab,
+  LayoutNode,
+  TerminalTab,
+  WorkspaceSnapshot
+} from '../types'
+import { isDashboardTab, isFileDiffTab, isFileEditorTab, isTerminalTab } from '../types'
+import { pruneLayoutToGroups } from './tabFocus'
+
+/**
+ * On-disk / IPC form of a single tab. Terminal tabs carry no `kind` (legacy
+ * shape); the other kinds are discriminated. `kind: 'diff'` is a legacy
+ * repo-level diff tab that is quietly dropped on reconstruction.
+ */
+export type PersistedTab =
+  | (TerminalTab & { kind?: 'terminal' })
+  | (FileDiffTab & { kind: 'fileDiff' })
+  | (FileEditorTab & { kind: 'fileEditor' })
+  | (DashboardTab & { kind: 'dashboard' })
+  | { kind: 'diff' }
+
+/**
+ * Whether a session id is safe to interpolate into a shell-executed resume
+ * command. Session ids originate from filesystem entry names, so a crafted
+ * `.copilot/` / `.claude/` directory could otherwise plant shell metacharacters
+ * that fire on restore. Mirrors the main-process guard (BaseSessionProvider
+ * .validateSessionId); kept local because main/renderer don't share modules.
+ */
+function isShellSafeSessionId(sessionId: string): boolean {
+  return !!sessionId && sessionId.length <= 128 && /^[A-Za-z0-9_-]+$/.test(sessionId)
+}
+
+export interface PersistedGroupSnapshot {
+  id: string
+  tabs: PersistedTab[]
+  activeTabId: string
+}
+
+/**
+ * On-disk / IPC form of a workspace. Lossy by design: plain shell terminals
+ * (no `command`) and preview tabs are dropped because their processes cannot
+ * survive an app restart. Used for `sessions.json` and for each Space inside
+ * `spaces.json`.
+ */
+export interface PersistedWorkspaceSnapshot {
+  layout: LayoutNode
+  groups: PersistedGroupSnapshot[]
+  activeGroupId: string | null
+  savedAt: string
+}
+
+/** An empty workspace — no groups, single placeholder layout node. Used as the
+ *  render state when no Space is in focus (Overview) and as the seed for a new
+ *  empty Space. */
+export const EMPTY_WORKSPACE: WorkspaceSnapshot = {
+  layout: { type: 'group', groupId: 'group-0' },
+  groups: [],
+  activeGroupId: null
+}
+
+/**
+ * Serialize a live workspace snapshot to its persisted (lossy) form. Only AI
+ * session terminal tabs (they carry a `command`) and PERMANENT
+ * fileDiff/fileEditor/dashboard tabs are kept — plain shell terminals and
+ * preview tabs are intentionally not persisted. Pure: no store access.
+ */
+export function serializeWorkspaceSnapshot(snap: WorkspaceSnapshot): PersistedWorkspaceSnapshot {
+  return {
+    layout: snap.layout,
+    groups: snap.groups.map((g) => ({
+      id: g.id,
+      tabs: g.tabs
+        .filter((t): boolean => {
+          if (isFileDiffTab(t)) return t.preview !== true
+          if (isFileEditorTab(t)) return t.preview !== true
+          if (isDashboardTab(t)) return true
+          return isTerminalTab(t) && !!t.command
+        })
+        .map((t): PersistedTab => {
+          if (isDashboardTab(t)) {
+            return { kind: 'dashboard', id: t.id, title: t.title, color: t.color }
+          }
+          if (isFileDiffTab(t)) {
+            return {
+              kind: 'fileDiff',
+              id: t.id,
+              title: t.title,
+              repoRootFs: t.repoRootFs,
+              repoLabel: t.repoLabel,
+              scope: t.scope,
+              file: t.file,
+              sideBySide: t.sideBySide,
+              color: t.color
+            }
+          }
+          if (isFileEditorTab(t)) {
+            return {
+              kind: 'fileEditor',
+              id: t.id,
+              title: t.title,
+              rootFs: t.rootFs,
+              rootLabel: t.rootLabel,
+              relPath: t.relPath,
+              color: t.color
+            }
+          }
+          return {
+            id: t.id,
+            title: t.title,
+            cwd: t.cwd,
+            command: t.command,
+            sessionId: t.sessionId,
+            providerId: t.providerId,
+            worktreePath: t.worktreePath,
+            worktreeBranch: t.worktreeBranch,
+            color: t.color
+          }
+        }),
+      activeTabId: g.activeTabId
+      // previewTabId is deliberately NOT serialized — preview tabs are
+      // transient and their slot is recomputed after reconstruction.
+    })),
+    activeGroupId: snap.activeGroupId,
+    savedAt: new Date().toISOString()
+  }
+}
+
+interface PersistedWorkspaceInput {
+  layout: LayoutNode
+  groups: Array<{ id: string; tabs: PersistedTab[]; activeTabId: string; previewTabId?: string }>
+  activeGroupId: string | null
+}
+
+/**
+ * Reconstruct a live workspace snapshot from its persisted form. AI terminal
+ * tabs get a fresh resume command from their provider; plain shells were never
+ * persisted; legacy `kind: 'diff'` tabs are dropped. Empty groups collapse and
+ * the layout is pruned to the surviving groups. Returns null when nothing
+ * restorable remains. Reused by boot restore and by Space hydration.
+ */
+export async function reconstructWorkspace(
+  data: PersistedWorkspaceInput | null | undefined
+): Promise<WorkspaceSnapshot | null> {
+  try {
+    if (!data || !Array.isArray(data.groups) || !data.layout) return null
+
+    const restoredGroups: EditorGroup[] = []
+    for (const g of data.groups) {
+      // Isolate each group: a single malformed group must not discard the
+      // entire space's workspace (which would then be persisted over as
+      // EMPTY_WORKSPACE, losing every other group's tabs).
+      try {
+        if (!g || typeof g !== 'object' || !Array.isArray(g.tabs)) continue
+        const keepers = g.tabs.filter((t) => {
+          if (!t || typeof t !== 'object') return false
+          if (t.kind === 'diff') return false
+          if (t.kind === 'fileDiff') return true
+          if (t.kind === 'fileEditor') return true
+          if (t.kind === 'dashboard') return true
+          return !!(t as TerminalTab).command
+        })
+        if (keepers.length === 0) continue
+
+        const prepared = await Promise.all(
+          keepers.map(async (t): Promise<EditorTab | null> => {
+            // Isolate each tab too: one bad tab is dropped, not fatal.
+            try {
+              if (t.kind === 'dashboard') {
+                return { ...(t as DashboardTab) }
+              }
+              if (t.kind === 'fileDiff') {
+                const ft = t as FileDiffTab
+                return { ...ft, preview: false }
+              }
+              if (t.kind === 'fileEditor') {
+                const fe = t as FileEditorTab
+                return { ...fe, preview: false, dirty: false }
+              }
+              const tt = t as TerminalTab
+              if (!tt.sessionId) return { ...tt }
+              if (tt.providerId) {
+                try {
+                  const cmd = await window.dplex.sessions.getResumeCommand(
+                    tt.providerId,
+                    tt.sessionId
+                  )
+                  if (cmd) return { ...tt, command: cmd }
+                } catch {
+                  // Provider lookup failed transiently — keep the persisted command.
+                }
+                return { ...tt }
+              }
+              if (
+                tt.command &&
+                !tt.command.includes('--resume') &&
+                isShellSafeSessionId(tt.sessionId)
+              ) {
+                return { ...tt, command: `${tt.command} --resume=${tt.sessionId}` }
+              }
+              return { ...tt }
+            } catch {
+              return null
+            }
+          })
+        )
+
+        const preparedTabs = prepared.filter((t): t is EditorTab => t !== null)
+        if (preparedTabs.length === 0) continue
+
+        restoredGroups.push({
+          id: g.id,
+          tabs: preparedTabs,
+          activeTabId: preparedTabs.find((t) => t.id === g.activeTabId)?.id ?? preparedTabs[0].id
+        })
+      } catch {
+        continue
+      }
+    }
+
+    if (restoredGroups.length === 0) return null
+
+    const validIds = new Set(restoredGroups.map((g) => g.id))
+    const prunedLayout = pruneLayoutToGroups(data.layout, validIds)
+    if (!prunedLayout) return null
+
+    const activeGroupId = validIds.has(data.activeGroupId ?? '')
+      ? data.activeGroupId
+      : restoredGroups[0].id
+
+    return { groups: restoredGroups, layout: prunedLayout, activeGroupId }
+  } catch {
+    return null
+  }
+}

--- a/tests/e2e/activity-bar-order.e2e.spec.ts
+++ b/tests/e2e/activity-bar-order.e2e.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
+import { closeApp, launchApp } from './support/electronApp'
+
+/** Vertical position (top edge) of an activity-bar view button. */
+async function topOf(window: Page, id: string): Promise<number> {
+  const box = await window.getByTestId(`activity-bar-${id}`).boundingBox()
+  if (!box) throw new Error(`activity-bar-${id} not visible`)
+  return box.y
+}
+
+test.describe('DPlex activity bar ordering', () => {
+  let app: ElectronApplication | undefined
+  let window: Page | undefined
+  let userDataDir: string | undefined
+
+  test.afterEach(async () => {
+    await closeApp(app, userDataDir)
+    app = window = userDataDir = undefined
+  })
+
+  test('Spaces leads the rail by default and view icons are draggable', async () => {
+    const launched = await launchApp()
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+
+    const spaces = window.getByTestId('activity-bar-spaces')
+    await expect(spaces).toBeVisible()
+
+    // Spaces sits above Projects in the default order.
+    expect(await topOf(window, 'spaces')).toBeLessThan(await topOf(window, 'projects'))
+
+    // Each view icon exposes the drag-to-reorder affordance.
+    await expect(spaces).toHaveAttribute('draggable', 'true')
+  })
+
+  test('honors a persisted custom order on boot', async () => {
+    const launched = await launchApp({
+      settings: {
+        activityBarOrder: ['projects', 'spaces', 'sessions', 'explorer', 'git', 'search']
+      }
+    })
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+
+    await expect(window.getByTestId('activity-bar-projects')).toBeVisible()
+    // Custom order flips Projects above Spaces.
+    expect(await topOf(window, 'projects')).toBeLessThan(await topOf(window, 'spaces'))
+  })
+
+  test('a reordered rail persists across reloads', async () => {
+    const launched = await launchApp()
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+
+    await expect(window.getByTestId('activity-bar-spaces')).toBeVisible()
+    // Spaces starts on top.
+    expect(await topOf(window, 'spaces')).toBeLessThan(await topOf(window, 'search'))
+
+    // Persist a new order (what a drop of Spaces to the bottom writes), then
+    // reload to prove it is read back from disk on boot.
+    await window.evaluate(async () => {
+      // @ts-expect-error: dplex is defined on the renderer window via preload
+      await window.dplex.settings.merge({
+        activityBarOrder: ['projects', 'sessions', 'explorer', 'git', 'search', 'spaces']
+      })
+    })
+    await window.reload()
+    await window.waitForLoadState('domcontentloaded')
+    await expect(window.getByTestId('activity-bar-spaces')).toBeVisible()
+
+    // Spaces is now last — below Search.
+    expect(await topOf(window, 'spaces')).toBeGreaterThan(await topOf(window, 'search'))
+  })
+
+  test('context menu Move up reorders and persists', async () => {
+    const launched = await launchApp()
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+
+    await expect(window.getByTestId('activity-bar-spaces')).toBeVisible()
+    // Default: Spaces above Projects.
+    expect(await topOf(window, 'spaces')).toBeLessThan(await topOf(window, 'projects'))
+
+    // Right-click Projects → Move up (an accessible alternative to drag).
+    await window.getByTestId('activity-bar-projects').click({ button: 'right' })
+    await window.getByRole('button', { name: 'Move up' }).click()
+
+    // Projects now leads the rail.
+    expect(await topOf(window, 'projects')).toBeLessThan(await topOf(window, 'spaces'))
+
+    // ...and the new order survives a reload.
+    await window.reload()
+    await window.waitForLoadState('domcontentloaded')
+    await expect(window.getByTestId('activity-bar-projects')).toBeVisible()
+    expect(await topOf(window, 'projects')).toBeLessThan(await topOf(window, 'spaces'))
+  })
+
+  test('Move up is disabled for the item already on top', async () => {
+    const launched = await launchApp()
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+
+    await expect(window.getByTestId('activity-bar-spaces')).toBeVisible()
+    // Spaces leads by default → its Move up is disabled.
+    await window.getByTestId('activity-bar-spaces').click({ button: 'right' })
+    await expect(window.getByRole('button', { name: 'Move up' })).toBeDisabled()
+    await expect(window.getByRole('button', { name: 'Move down' })).toBeEnabled()
+  })
+})

--- a/tests/e2e/global-search.e2e.spec.ts
+++ b/tests/e2e/global-search.e2e.spec.ts
@@ -147,4 +147,46 @@ test.describe('DPlex global search', () => {
     const fontRow = modal.locator('[data-setting-id="font-size"]')
     await expect(fontRow).toBeVisible()
   })
+
+  test('Spaces are searchable as their own category in the palette', async () => {
+    if (!window || !app) throw new Error('App not available')
+
+    await window.getByTestId('activity-bar-search').waitFor({ state: 'visible' })
+    // Fresh boot seeds a single "My Work" space — it must be findable in search.
+    await app.evaluate(({ BrowserWindow: BW }) => {
+      const win = BW.getAllWindows()[0]
+      win?.webContents.send('dplex:shortcut', 'palette.all')
+    })
+    const palette = window.getByTestId('command-palette')
+    await expect(palette).toBeVisible()
+
+    await window.getByTestId('command-palette-input').fill('My Work')
+    const results = window.getByTestId('search-result')
+    await expect(results.first()).toContainText('My Work')
+    // The dedicated Spaces group header confirms the source is wired in.
+    await expect(palette).toContainText('Spaces')
+
+    // Activating a space dismisses the palette (switch runs, never restarts).
+    await window.keyboard.press('Enter')
+    await expect(palette).not.toBeVisible()
+  })
+
+  test('New Space command opens the create-space modal', async () => {
+    if (!window) throw new Error('Window not available')
+
+    await window.getByTestId('activity-bar-search').waitFor({ state: 'visible' })
+    await window.keyboard.press('ControlOrMeta+Shift+p')
+
+    const palette = window.getByTestId('command-palette')
+    await expect(palette).toBeVisible()
+
+    await window.getByTestId('command-palette-input').fill('New Space')
+    const results = window.getByTestId('search-result')
+    await expect(results.first()).toContainText('New Space')
+
+    await results.first().click()
+    await expect(palette).not.toBeVisible()
+    // The create/rename modal is now open.
+    await expect(window.getByTestId('space-modal-save')).toBeVisible({ timeout: 5_000 })
+  })
 })

--- a/tests/e2e/spaces-overview.e2e.spec.ts
+++ b/tests/e2e/spaces-overview.e2e.spec.ts
@@ -1,0 +1,208 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
+import { closeApp, launchApp } from './support/electronApp'
+
+/**
+ * E2E coverage for the Spaces Overview grid layout.
+ *
+ * Regression guard for the card layout bugs seen on smaller screens:
+ *   1. Cards overlapped each other — the grid doubled as a fixed-height scroll
+ *      container, so `align-content: start` collapsed the auto row tracks to a
+ *      sliver (each card's `overflow: hidden` zeroes its grid min-size) and the
+ *      full-height cards spilled over one another.
+ *   2. Cards in the same row rendered at different heights.
+ *   3. The footer action buttons (Rename / Delete / Resume) were clipped by the
+ *      card's `overflow: hidden` on narrow cards.
+ *
+ * The fix moves scrolling to a wrapper (the grid is now natural-height, so rows
+ * size to content), restores per-row equal heights via the default stretch, and
+ * renders the hover actions as a right-pinned overlay that never overflows.
+ *
+ * These tests assert, against the real rendered app, that no two cards overlap,
+ * that every card's Resume button stays within the card bounds, and that cards
+ * sharing a row have equal heights.
+ */
+
+type Tab = {
+  id: string
+  title: string
+  kind: 'terminal'
+  command: string
+  sessionId: string
+  providerId: string
+}
+
+function workspace(tabCount: number): Record<string, unknown> {
+  if (tabCount === 0) {
+    return { layout: { type: 'group' }, groups: [], activeGroupId: null }
+  }
+  const tabs: Tab[] = Array.from({ length: tabCount }, (_, i) => ({
+    id: `t${i}`,
+    title: `Session ${i}`,
+    kind: 'terminal',
+    command: 'copilot',
+    sessionId: `sess-${i}`,
+    providerId: 'copilot-cli'
+  }))
+  return {
+    layout: { type: 'group', groupId: 'g1' },
+    groups: [{ id: 'g1', tabs, activeTabId: 't0' }],
+    activeGroupId: 'g1'
+  }
+}
+
+function space(id: string, name: string, color: string, tabCount: number): Record<string, unknown> {
+  const now = Date.now()
+  return {
+    id,
+    name,
+    color,
+    projectIds: [],
+    workspace: workspace(tabCount),
+    createdAt: now,
+    updatedAt: now,
+    lastActiveAt: now
+  }
+}
+
+// Six background spaces with very different content volumes so the grid spans
+// multiple rows and mixes tall/short cards — the exact conditions that produced
+// the overlap + unequal-height + clipped-button bugs. No active space, so the
+// app boots straight into the Overview.
+const SEED_SPACES = {
+  version: 1,
+  activeSpaceId: null,
+  spaces: [
+    space('a', 'Refactor auth', '#8b5cf6', 3),
+    space('b', 'Flaky CI', '#22d3ee', 0),
+    space('c', 'Reading notes', '#f59e0b', 1),
+    space('d', 'Release 2.0', '#3b82f6', 0),
+    space('e', 'Perf pass', '#10b981', 0),
+    space('f', 'Docs sweep', '#a855f7', 2)
+  ]
+}
+
+type CardMetric = {
+  id: string | null
+  top: number
+  bottom: number
+  left: number
+  right: number
+  height: number
+  resumeCut: boolean
+}
+
+type LayoutReport = {
+  cards: CardMetric[]
+  overlaps: string[]
+  unequalRows: { top: number; heights: number[] }[]
+}
+
+async function measureLayout(window: Page): Promise<LayoutReport> {
+  return window.evaluate(() => {
+    const els = Array.from(
+      document.querySelectorAll('[data-testid^="space-card-"]')
+    ) as HTMLElement[]
+    const cards = els.map((el) => {
+      const r = el.getBoundingClientRect()
+      const resume = el.querySelector('[data-testid^="card-resume-"]') as HTMLElement | null
+      const rr = resume?.getBoundingClientRect()
+      return {
+        id: el.getAttribute('data-testid'),
+        top: Math.round(r.top),
+        bottom: Math.round(r.bottom),
+        left: Math.round(r.left),
+        right: Math.round(r.right),
+        height: Math.round(r.height),
+        // The Resume button must stay within the card's box on every screen.
+        resumeCut: rr ? rr.right > r.right + 0.5 || rr.left < r.left - 0.5 : false
+      }
+    })
+
+    // True 2-D overlap: two cards overlap only if their boxes intersect on both
+    // axes (same-row cards share a vertical band but are horizontally apart).
+    const overlaps: string[] = []
+    for (let i = 0; i < cards.length; i++) {
+      for (let j = i + 1; j < cards.length; j++) {
+        const a = cards[i]
+        const b = cards[j]
+        const v = a.top < b.bottom - 0.5 && b.top < a.bottom - 0.5
+        const h = a.left < b.right - 0.5 && b.left < a.right - 0.5
+        if (v && h) overlaps.push(`${a.id} <> ${b.id}`)
+      }
+    }
+
+    // Group cards by row (shared top) and flag rows whose cards differ in height.
+    const rows = new Map<number, number[]>()
+    for (const c of cards) {
+      const key = Math.round(c.top / 6) * 6
+      const arr = rows.get(key) ?? []
+      arr.push(c.height)
+      rows.set(key, arr)
+    }
+    const unequalRows: { top: number; heights: number[] }[] = []
+    for (const [top, heights] of rows) {
+      if (heights.length > 1 && Math.max(...heights) - Math.min(...heights) > 1) {
+        unequalRows.push({ top, heights })
+      }
+    }
+
+    return { cards, overlaps, unequalRows }
+  })
+}
+
+async function resize(app: ElectronApplication, width: number, height: number): Promise<void> {
+  await app.evaluate(
+    async ({ BrowserWindow }, size) => {
+      BrowserWindow.getAllWindows()[0]?.setSize(size.width, size.height)
+    },
+    { width, height }
+  )
+}
+
+test.describe('Spaces Overview layout', () => {
+  let app: ElectronApplication | undefined
+  let window: Page | undefined
+  let userDataDir: string | undefined
+
+  test.beforeEach(async () => {
+    const launched = await launchApp({ spaces: SEED_SPACES })
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+  })
+
+  test.afterEach(async () => {
+    await closeApp(app, userDataDir)
+  })
+
+  test('single-column: no overlap, no clipped buttons', async () => {
+    if (!window || !app) throw new Error('Window not available')
+    await expect(window.getByRole('heading', { name: 'Spaces' })).toBeVisible()
+
+    await resize(app, 650, 720)
+    await window.waitForTimeout(400)
+
+    const { cards, overlaps } = await measureLayout(window)
+    expect(cards.length).toBeGreaterThanOrEqual(6)
+    expect(overlaps, `overlapping cards: ${overlaps.join(', ')}`).toEqual([])
+    expect(cards.filter((c) => c.resumeCut).map((c) => c.id)).toEqual([])
+    // Content-rich cards actually expand (the collapse bug rendered ~37px).
+    expect(Math.max(...cards.map((c) => c.height))).toBeGreaterThan(150)
+  })
+
+  test('multi-column: no overlap, equal heights per row, no clipped buttons', async () => {
+    if (!window || !app) throw new Error('Window not available')
+    await expect(window.getByRole('heading', { name: 'Spaces' })).toBeVisible()
+
+    await resize(app, 1000, 640)
+    await window.waitForTimeout(400)
+
+    const { cards, overlaps, unequalRows } = await measureLayout(window)
+    expect(cards.length).toBeGreaterThanOrEqual(6)
+    expect(overlaps, `overlapping cards: ${overlaps.join(', ')}`).toEqual([])
+    expect(cards.filter((c) => c.resumeCut).map((c) => c.id)).toEqual([])
+    expect(unequalRows, `rows with unequal card heights: ${JSON.stringify(unequalRows)}`).toEqual(
+      []
+    )
+  })
+})

--- a/tests/e2e/support/electronApp.ts
+++ b/tests/e2e/support/electronApp.ts
@@ -26,7 +26,10 @@ function createTestEnv(userDataDir: string): NodeJS.ProcessEnv {
   return env
 }
 
-export async function launchApp(opts?: { settings?: Record<string, unknown> }): Promise<{
+export async function launchApp(opts?: {
+  settings?: Record<string, unknown>
+  spaces?: Record<string, unknown>
+}): Promise<{
   app: ElectronApplication
   window: Page
   userDataDir: string
@@ -54,6 +57,17 @@ export async function launchApp(opts?: { settings?: Record<string, unknown> }): 
     await fs.writeFile(path.join(userDataDir, 'settings.json'), JSON.stringify(seedSettings))
   } catch {
     // Best-effort; continue even if seeding fails.
+  }
+
+  // Optionally seed spaces.json so the app boots straight into a known Spaces
+  // state (e.g. the Overview with a set of background spaces). Written to the
+  // same userData location as settings.json above.
+  if (opts?.spaces) {
+    try {
+      await fs.writeFile(path.join(userDataDir, 'spaces.json'), JSON.stringify(opts.spaces))
+    } catch {
+      // Best-effort; continue even if seeding fails.
+    }
   }
 
   const app = await electron.launch({

--- a/tests/unit/activity-bar-order.test.ts
+++ b/tests/unit/activity-bar-order.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from 'vitest'
+import {
+  DEFAULT_ACTIVITY_BAR_ORDER,
+  reconcileActivityBarOrder,
+  reorderActivityBar
+} from '../../src/renderer/src/utils/activityBarOrder'
+import type { ActivityBarId } from '../../src/renderer/src/types'
+
+const FULL: ActivityBarId[] = ['spaces', 'projects', 'sessions', 'explorer', 'git', 'search']
+
+describe('DEFAULT_ACTIVITY_BAR_ORDER', () => {
+  it('leads with Spaces and contains each view exactly once', () => {
+    expect(DEFAULT_ACTIVITY_BAR_ORDER[0]).toBe('spaces')
+    expect([...DEFAULT_ACTIVITY_BAR_ORDER].sort()).toEqual([...FULL].sort())
+  })
+})
+
+describe('reconcileActivityBarOrder', () => {
+  it('falls back to the canonical order when nothing is saved', () => {
+    expect(reconcileActivityBarOrder(undefined)).toEqual([...DEFAULT_ACTIVITY_BAR_ORDER])
+    expect(reconcileActivityBarOrder(null)).toEqual([...DEFAULT_ACTIVITY_BAR_ORDER])
+    expect(reconcileActivityBarOrder([])).toEqual([...DEFAULT_ACTIVITY_BAR_ORDER])
+  })
+
+  it('preserves a complete, valid custom order verbatim', () => {
+    const custom: ActivityBarId[] = ['git', 'search', 'spaces', 'projects', 'sessions', 'explorer']
+    expect(reconcileActivityBarOrder(custom)).toEqual(custom)
+  })
+
+  it('drops unknown ids', () => {
+    const saved = ['spaces', 'bogus', 'projects'] as unknown as ActivityBarId[]
+    expect(reconcileActivityBarOrder(saved)).toEqual([
+      'spaces',
+      'projects',
+      // remaining canonical ids appended in canonical order
+      'sessions',
+      'explorer',
+      'git',
+      'search'
+    ])
+  })
+
+  it('de-duplicates repeated ids', () => {
+    const saved: ActivityBarId[] = ['spaces', 'spaces', 'projects', 'projects']
+    const result = reconcileActivityBarOrder(saved)
+    expect(result.slice(0, 2)).toEqual(['spaces', 'projects'])
+    expect([...result].sort()).toEqual([...FULL].sort())
+    expect(result).toHaveLength(FULL.length)
+  })
+
+  it('appends canonical ids missing from a partial saved order', () => {
+    expect(reconcileActivityBarOrder(['git'])).toEqual([
+      'git',
+      'spaces',
+      'projects',
+      'sessions',
+      'explorer',
+      'search'
+    ])
+  })
+})
+
+describe('reorderActivityBar', () => {
+  it('moves an item before the target', () => {
+    // projects (idx 1) before spaces (idx 0) → projects leads
+    expect(reorderActivityBar(FULL, 'projects', 'spaces', 'before')).toEqual([
+      'projects',
+      'spaces',
+      'sessions',
+      'explorer',
+      'git',
+      'search'
+    ])
+  })
+
+  it('moves an item after the target', () => {
+    // spaces after projects → projects leads, spaces second
+    expect(reorderActivityBar(FULL, 'spaces', 'projects', 'after')).toEqual([
+      'projects',
+      'spaces',
+      'sessions',
+      'explorer',
+      'git',
+      'search'
+    ])
+  })
+
+  it('can move an item to the very end via after on the last item', () => {
+    expect(reorderActivityBar(FULL, 'spaces', 'search', 'after')).toEqual([
+      'projects',
+      'sessions',
+      'explorer',
+      'git',
+      'search',
+      'spaces'
+    ])
+  })
+
+  it('keeps every id exactly once regardless of direction', () => {
+    const result = reorderActivityBar(FULL, 'search', 'spaces', 'before')
+    expect([...result].sort()).toEqual([...FULL].sort())
+    expect(result[0]).toBe('search')
+  })
+
+  it('no-ops (returns a copy) when dropping onto itself', () => {
+    const result = reorderActivityBar(FULL, 'git', 'git', 'before')
+    expect(result).toEqual([...FULL])
+    expect(result).not.toBe(FULL)
+  })
+
+  it('no-ops when an id is not present', () => {
+    const result = reorderActivityBar(FULL, 'bogus' as ActivityBarId, 'spaces')
+    expect(result).toEqual([...FULL])
+  })
+})

--- a/tests/unit/close-confirm-store.test.ts
+++ b/tests/unit/close-confirm-store.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useCloseConfirmStore } from '../../src/renderer/src/stores/closeConfirmStore'
+import { useTerminalStore } from '../../src/renderer/src/stores/terminalStore'
+import { registerFileEditor } from '../../src/renderer/src/services/fileEditorRegistry'
+import {
+  stashParkedEditorBuffer,
+  clearParkedEditorBuffer
+} from '../../src/renderer/src/services/parkedEditorBuffers'
+import type { EditorGroup, FileEditorTab, TerminalTab } from '../../src/renderer/src/types'
+
+const closeTerminal = vi.fn()
+
+function fileEditorTab(id: string, dirty = false): FileEditorTab {
+  return {
+    id,
+    title: id,
+    kind: 'fileEditor',
+    rootFs: '/r',
+    rootLabel: 'r',
+    relPath: 'a.ts',
+    preview: false,
+    dirty
+  }
+}
+
+function terminalTab(id: string): TerminalTab {
+  return { id, title: id, cwd: '/r', command: 'copilot', sessionId: id, providerId: 'copilot-cli' }
+}
+
+function setTabs(tabs: EditorGroup['tabs']): void {
+  useTerminalStore.setState({
+    groups: [{ id: 'g', tabs, activeTabId: tabs[0]?.id ?? '' }],
+    layout: { type: 'group', groupId: 'g' },
+    activeGroupId: 'g',
+    // Override the real teardown so tests observe intent without running IPC.
+    closeTerminal
+  } as never)
+}
+
+beforeEach(() => {
+  closeTerminal.mockReset()
+  useCloseConfirmStore.setState({ pendingTabId: null, pendingTitle: '' })
+})
+
+afterEach(() => {
+  clearParkedEditorBuffer('f1')
+  vi.restoreAllMocks()
+})
+
+describe('closeConfirmStore.request', () => {
+  it('closes a clean, unmounted file editor immediately (no prompt)', () => {
+    setTabs([fileEditorTab('f1', false)])
+    useCloseConfirmStore.getState().request('f1')
+    expect(closeTerminal).toHaveBeenCalledWith('f1')
+    expect(useCloseConfirmStore.getState().pendingTabId).toBeNull()
+  })
+
+  it('prompts for a mounted dirty editor (live handle reports dirty)', () => {
+    setTabs([fileEditorTab('f1', false)])
+    // A live handle overrides the persisted flag.
+    const unregister = registerFileEditor('f1', {
+      save: async () => {},
+      isDirty: () => true,
+      getDirtyBuffer: () => null
+    })
+    useCloseConfirmStore.getState().request('f1')
+    expect(closeTerminal).not.toHaveBeenCalled()
+    expect(useCloseConfirmStore.getState().pendingTabId).toBe('f1')
+    unregister()
+  })
+
+  it('prompts for an UNMOUNTED editor that still holds a parked unsaved buffer', () => {
+    // No live handle (the tab was unmounted when its Space was backgrounded) and
+    // the persisted dirty flag is false — but a stashed buffer means unsaved
+    // edits exist, so closing must prompt instead of silently discarding them.
+    setTabs([fileEditorTab('f1', false)])
+    stashParkedEditorBuffer('f1', {
+      content: 'edited',
+      eol: '\n',
+      baseContent: 'x',
+      baseMtimeMs: 1
+    })
+    useCloseConfirmStore.getState().request('f1')
+    expect(closeTerminal).not.toHaveBeenCalled()
+    expect(useCloseConfirmStore.getState().pendingTabId).toBe('f1')
+  })
+
+  it('prompts for a MOUNTED editor reporting clean that still holds a parked buffer', () => {
+    // Regression: a mounted handle can report clean while a stash survives — e.g.
+    // the file turned binary/too-large while parked (loads read-only, can't host
+    // the edits) or is still loading. A false handle.isDirty() must NOT mask the
+    // stash, or the backgrounded edits would close without a prompt.
+    setTabs([fileEditorTab('f1', false)])
+    const unregister = registerFileEditor('f1', {
+      save: async () => {},
+      isDirty: () => false,
+      getDirtyBuffer: () => null
+    })
+    stashParkedEditorBuffer('f1', {
+      content: 'edited',
+      eol: '\n',
+      baseContent: 'x',
+      baseMtimeMs: 1
+    })
+    useCloseConfirmStore.getState().request('f1')
+    expect(closeTerminal).not.toHaveBeenCalled()
+    expect(useCloseConfirmStore.getState().pendingTabId).toBe('f1')
+    unregister()
+  })
+
+  it('closes a non-editor tab immediately regardless of parked buffers', () => {
+    setTabs([terminalTab('f1')])
+    // Even a stray stash for this id must not gate a non-editor close.
+    stashParkedEditorBuffer('f1', { content: 'x', eol: '\n', baseContent: '', baseMtimeMs: 1 })
+    useCloseConfirmStore.getState().request('f1')
+    expect(closeTerminal).toHaveBeenCalledWith('f1')
+    expect(useCloseConfirmStore.getState().pendingTabId).toBeNull()
+  })
+})

--- a/tests/unit/close-terminal-aftercreate.test.ts
+++ b/tests/unit/close-terminal-aftercreate.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Regression: `closeTerminal` must re-read store state AFTER `destroyTerminal`.
+ *
+ * `destroyTerminal` fires any pending exit handler *synchronously*. The worktree
+ * `afterCreate: 'terminal'` flow registers such a handler on the setup PTY and,
+ * when it exits, creates a brand-new terminal tab. If `closeTerminal` computed
+ * its group/layout mutation from the PRE-destroy snapshot, that just-created tab
+ * would be clobbered by the trailing `set(...)`. This test drives exactly that
+ * race and asserts the new tab survives.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTerminalStore } from '../../src/renderer/src/stores/terminalStore'
+import { registerExitHandler } from '../../src/renderer/src/services/terminalRegistry'
+
+function setupWindow(): void {
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: {
+      sessions: {
+        saveWorkspace: vi.fn().mockResolvedValue(undefined),
+        saveWorkspaceSync: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined)
+      },
+      pty: { destroy: vi.fn() }
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}
+
+function tabExists(id: string): boolean {
+  return useTerminalStore.getState().groups.some((g) => g.tabs.some((t) => t.id === id))
+}
+
+beforeEach(() => {
+  setupWindow()
+  useTerminalStore.setState({
+    groups: [],
+    layout: { type: 'group', groupId: '' },
+    activeGroupId: null,
+    restored: false
+  } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('closeTerminal + synchronous afterCreate exit handler', () => {
+  it('preserves a tab created by the exit handler fired during destroy', () => {
+    const setupId = useTerminalStore.getState().createTerminal()
+
+    // Simulate worktree afterCreate: 'terminal' — on the setup PTY's exit, spawn
+    // the follow-up terminal. destroyTerminal (below) fires this synchronously.
+    let spawnedId = ''
+    registerExitHandler(setupId, () => {
+      spawnedId = useTerminalStore.getState().createTerminal()
+    })
+
+    useTerminalStore.getState().closeTerminal(setupId)
+
+    expect(spawnedId).not.toBe('')
+    // The follow-up tab created mid-destroy must still be present…
+    expect(tabExists(spawnedId)).toBe(true)
+    // …and the closed setup tab must be gone.
+    expect(tabExists(setupId)).toBe(false)
+    // The store must still expose an active group (not collapsed to empty).
+    expect(useTerminalStore.getState().activeGroupId).not.toBeNull()
+  })
+
+  it('still removes the tab cleanly when the handler creates nothing', () => {
+    const a = useTerminalStore.getState().createTerminal()
+    const b = useTerminalStore.getState().createTerminal()
+    useTerminalStore.getState().closeTerminal(a)
+    expect(tabExists(a)).toBe(false)
+    expect(tabExists(b)).toBe(true)
+  })
+})

--- a/tests/unit/file-explorer-delete-tabs.test.ts
+++ b/tests/unit/file-explorer-delete-tabs.test.ts
@@ -1,0 +1,99 @@
+/**
+ * Regression coverage for `fileExplorerStore.deletePath` → `syncTabsOnDelete`.
+ *
+ * Deleting a file auto-closes its CLEAN editor tab, but must NOT close a tab
+ * that still holds unsaved work — either a live dirty buffer OR a parked buffer
+ * stashed when the editor's Space was backgrounded. Closing the latter would
+ * silently drop edits the user never saw a prompt for.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTerminalStore } from '../../src/renderer/src/stores/terminalStore'
+import { useFileExplorerStore } from '../../src/renderer/src/stores/fileExplorerStore'
+import {
+  stashParkedEditorBuffer,
+  clearParkedEditorBuffer
+} from '../../src/renderer/src/services/parkedEditorBuffers'
+
+const ROOT = '/proj'
+
+function setupWindow(): void {
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: {
+      sessions: {
+        saveWorkspace: vi.fn().mockResolvedValue(undefined),
+        saveWorkspaceSync: vi.fn(),
+        close: vi.fn().mockResolvedValue(undefined)
+      },
+      pty: { destroy: vi.fn() },
+      files: {
+        delete: vi.fn().mockResolvedValue({ ok: true }),
+        listDir: vi.fn().mockResolvedValue({ ok: true, entries: [] })
+      }
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}
+
+function openCleanEditorTab(relPath: string): string {
+  return useTerminalStore
+    .getState()
+    .openOrFocusFileTab({ rootFs: ROOT, rootLabel: 'proj', relPath, preview: false })
+}
+
+function tabExists(id: string): boolean {
+  return useTerminalStore.getState().groups.some((g) => g.tabs.some((t) => t.id === id))
+}
+
+beforeEach(() => {
+  setupWindow()
+  useTerminalStore.setState({
+    groups: [],
+    layout: { type: 'group', groupId: '' },
+    activeGroupId: null,
+    restored: false
+  } as never)
+  useTerminalStore.getState().createTerminal()
+  useFileExplorerStore.setState({ activeRootFs: ROOT } as never)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+describe('deletePath → syncTabsOnDelete', () => {
+  it('closes a clean editor tab for the deleted file', async () => {
+    const id = openCleanEditorTab('src/a.ts')
+    expect(tabExists(id)).toBe(true)
+    await useFileExplorerStore.getState().deletePath('src/a.ts')
+    expect(tabExists(id)).toBe(false)
+  })
+
+  it('keeps a tab holding a parked (backgrounded) buffer open', async () => {
+    const id = openCleanEditorTab('src/b.ts')
+    // The tab is clean on THIS Space, but its edits live in a parked stash from
+    // a backgrounded Space — deleting the file must not drop them.
+    stashParkedEditorBuffer(id, {
+      content: 'edited',
+      eol: '\n',
+      baseContent: 'orig',
+      baseMtimeMs: 1
+    })
+    try {
+      await useFileExplorerStore.getState().deletePath('src/b.ts')
+      expect(tabExists(id)).toBe(true)
+    } finally {
+      clearParkedEditorBuffer(id)
+    }
+  })
+
+  it('closes clean descendant tabs when a folder is deleted', async () => {
+    const inside = openCleanEditorTab('src/deep/c.ts')
+    const outside = openCleanEditorTab('other/d.ts')
+    await useFileExplorerStore.getState().deletePath('src')
+    expect(tabExists(inside)).toBe(false)
+    expect(tabExists(outside)).toBe(true)
+  })
+})

--- a/tests/unit/parked-editor-buffers.test.ts
+++ b/tests/unit/parked-editor-buffers.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  stashParkedEditorBuffer,
+  takeParkedEditorBuffer,
+  hasParkedEditorBuffer,
+  clearParkedEditorBuffer
+} from '../../src/renderer/src/services/parkedEditorBuffers'
+import {
+  registerFileEditor,
+  stashAllDirtyFileEditors,
+  type FileEditorHandle
+} from '../../src/renderer/src/services/fileEditorRegistry'
+
+function fakeHandle(
+  dirty: { content: string; eol: '\n' | '\r\n'; baseContent: string; baseMtimeMs: number } | null,
+  onFlush?: () => void
+): FileEditorHandle {
+  return {
+    save: async () => {},
+    isDirty: () => dirty !== null,
+    getDirtyBuffer: () => dirty,
+    flushIfAutoSave: () => onFlush?.()
+  }
+}
+
+describe('parkedEditorBuffers', () => {
+  afterEach(() => {
+    // Guard against cross-test leakage of the module-level map.
+    clearParkedEditorBuffer('t1')
+    clearParkedEditorBuffer('t2')
+  })
+
+  it('take consumes a stashed buffer exactly once', () => {
+    const buf = { content: 'hello', eol: '\n' as const, baseContent: 'hell', baseMtimeMs: 10 }
+    stashParkedEditorBuffer('t1', buf)
+    expect(takeParkedEditorBuffer('t1')).toEqual(buf)
+    // Consumed on first take — a second take returns null.
+    expect(takeParkedEditorBuffer('t1')).toBeNull()
+  })
+
+  it('take returns null when nothing is stashed', () => {
+    expect(takeParkedEditorBuffer('missing')).toBeNull()
+  })
+
+  it('clear drops a stashed buffer without returning it (no leak)', () => {
+    stashParkedEditorBuffer('t2', { content: 'x', eol: '\r\n', baseContent: '', baseMtimeMs: 1 })
+    clearParkedEditorBuffer('t2')
+    expect(takeParkedEditorBuffer('t2')).toBeNull()
+  })
+
+  it('hasParkedEditorBuffer reports presence without consuming the stash', () => {
+    expect(hasParkedEditorBuffer('t1')).toBe(false)
+    stashParkedEditorBuffer('t1', { content: 'x', eol: '\n', baseContent: '', baseMtimeMs: 1 })
+    expect(hasParkedEditorBuffer('t1')).toBe(true)
+    // Non-consuming — repeated checks stay true until an explicit take/clear.
+    expect(hasParkedEditorBuffer('t1')).toBe(true)
+    expect(takeParkedEditorBuffer('t1')).not.toBeNull()
+    expect(hasParkedEditorBuffer('t1')).toBe(false)
+  })
+})
+
+describe('stashAllDirtyFileEditors', () => {
+  it('stashes only dirty editors, restorable on take', () => {
+    const dirtyBuf = { content: 'edited', eol: '\n' as const, baseContent: 'orig', baseMtimeMs: 5 }
+    const offDirty = registerFileEditor('t1', fakeHandle(dirtyBuf))
+    const offClean = registerFileEditor('t2', fakeHandle(null))
+    try {
+      stashAllDirtyFileEditors()
+      // The dirty editor's buffer is preserved for restore-on-remount…
+      expect(takeParkedEditorBuffer('t1')).toEqual(dirtyBuf)
+      // …while a clean editor stashes nothing.
+      expect(takeParkedEditorBuffer('t2')).toBeNull()
+    } finally {
+      offDirty()
+      offClean()
+    }
+  })
+
+  it('flushes every registered editor on park (onChange autosave lands before quit)', () => {
+    const dirtyBuf = { content: 'edited', eol: '\n' as const, baseContent: 'orig', baseMtimeMs: 5 }
+    let dirtyFlushes = 0
+    let cleanFlushes = 0
+    const offDirty = registerFileEditor(
+      't1',
+      fakeHandle(dirtyBuf, () => (dirtyFlushes += 1))
+    )
+    const offClean = registerFileEditor(
+      't2',
+      fakeHandle(null, () => (cleanFlushes += 1))
+    )
+    try {
+      stashAllDirtyFileEditors()
+      // Both editors are asked to flush; the handle itself decides whether an
+      // onChange save is actually due (dirty + ready + no conflict). Parking must
+      // never skip the flush, or a within-debounce edit could be lost on quit.
+      expect(dirtyFlushes).toBe(1)
+      expect(cleanFlushes).toBe(1)
+    } finally {
+      offDirty()
+      offClean()
+    }
+  })
+})

--- a/tests/unit/search-registry.test.ts
+++ b/tests/unit/search-registry.test.ts
@@ -11,6 +11,8 @@ import type {
 
 const EMPTY_CTX: SearchContext = {
   projects: [],
+  spaces: [],
+  activeSpaceId: null,
   sessions: [],
   groups: [],
   activeGroupId: null

--- a/tests/unit/session-id-validation.test.ts
+++ b/tests/unit/session-id-validation.test.ts
@@ -3,6 +3,8 @@ import {
   BaseSessionProvider,
   type SessionEntry
 } from '../../src/main/services/providers/baseProvider'
+import { CopilotProvider } from '../../src/main/services/providers/copilotProvider'
+import { ClaudeCodeProvider } from '../../src/main/services/providers/claudeCodeProvider'
 import type {
   DiscoveredSession,
   ParsedSessionData,
@@ -87,5 +89,22 @@ describe('SessionEntry shape', () => {
   it('includes the four required fields', () => {
     const e: SessionEntry = { id: 'x', path: '/tmp/x', mtimeMs: 0, birthtimeMs: 0 }
     expect(e).toBeDefined()
+  })
+})
+
+describe('getResumeCommand refuses unsafe session ids', () => {
+  const copilot = new CopilotProvider()
+  const claude = new ClaudeCodeProvider()
+
+  it('builds the resume command for a safe id', () => {
+    expect(copilot.getResumeCommand('safe-123')).toBe('copilot --resume=safe-123')
+    expect(claude.getResumeCommand('safe-123')).toBe('claude --resume safe-123')
+  })
+
+  it('returns null for ids with shell metacharacters or traversal (no injection)', () => {
+    for (const bad of ['a;rm -rf /', 'a$(whoami)', 'a`whoami`', '../../x', 'a b', 'a|b', '']) {
+      expect(copilot.getResumeCommand(bad)).toBeNull()
+      expect(claude.getResumeCommand(bad)).toBeNull()
+    }
   })
 })

--- a/tests/unit/session-tabs.test.ts
+++ b/tests/unit/session-tabs.test.ts
@@ -14,6 +14,23 @@ vi.mock('../../src/renderer/src/stores/terminalStore', () => ({
   }
 }))
 
+// sessionTabs also reaches into spaceStore for cross-space (background) tabs.
+// Mock it so these unit tests stay isolated from the real store graph.
+const spaceStoreState = {
+  switchSpace: vi.fn()
+}
+const bgFns = {
+  findBackgroundSessionTab: vi.fn(),
+  closeBackgroundSessionTabs: vi.fn()
+}
+vi.mock('../../src/renderer/src/stores/spaceStore', () => ({
+  useSpaceStore: { getState: () => spaceStoreState },
+  findBackgroundSessionTab: (...a: [string, string, (string | undefined)?]) =>
+    bgFns.findBackgroundSessionTab(...a),
+  closeBackgroundSessionTabs: (...a: [string, string, (string | undefined)?]) =>
+    bgFns.closeBackgroundSessionTabs(...a)
+}))
+
 import {
   findTabsForSession,
   findFirstTabForSession,
@@ -33,6 +50,14 @@ const group = (id: string, tabs: TerminalTab[]): EditorGroup => ({
   id,
   tabs,
   activeTabId: tabs[0]?.id ?? ''
+})
+
+// Reset the cross-space mocks to their "no background match" defaults before
+// every test so the existing active-space cases behave exactly as before.
+beforeEach(() => {
+  bgFns.findBackgroundSessionTab.mockReset().mockReturnValue(null)
+  bgFns.closeBackgroundSessionTabs.mockReset().mockReturnValue(false)
+  spaceStoreState.switchSpace.mockReset()
 })
 
 describe('findTabsForSession', () => {
@@ -176,6 +201,25 @@ describe('focusSessionTab', () => {
     expect(storeState.setActiveGroup).toHaveBeenCalledWith('g1')
     expect(storeState.setActiveTerminalInGroup).toHaveBeenCalledTimes(1)
   })
+
+  it('switches to a background space and focuses the parked tab when the active space has no match', () => {
+    storeState.groups = []
+    bgFns.findBackgroundSessionTab.mockReturnValue({ spaceId: 'sp2', groupId: 'g9', tabId: 't9' })
+    expect(focusSessionTab('s1', 'copilot-cli')).toBe(true)
+    expect(spaceStoreState.switchSpace).toHaveBeenCalledWith('sp2')
+    expect(storeState.setActiveGroup).toHaveBeenCalledWith('g9')
+    expect(storeState.setActiveTerminalInGroup).toHaveBeenCalledWith('g9', 't9')
+  })
+
+  it('prefers an active-space match over a background match (no space switch)', () => {
+    storeState.groups = [
+      group('g1', [tab({ id: 't1', sessionId: 's1', providerId: 'copilot-cli' })])
+    ]
+    bgFns.findBackgroundSessionTab.mockReturnValue({ spaceId: 'sp2', groupId: 'g9', tabId: 't9' })
+    expect(focusSessionTab('s1', 'copilot-cli')).toBe(true)
+    expect(spaceStoreState.switchSpace).not.toHaveBeenCalled()
+    expect(storeState.setActiveGroup).toHaveBeenCalledWith('g1')
+  })
 })
 
 describe('closeOpenTabsForSession', () => {
@@ -239,6 +283,24 @@ describe('closeOpenTabsForSession', () => {
     expect(storeState.closeTerminal).toHaveBeenCalledTimes(1)
     expect(storeState.closeTerminal).toHaveBeenCalledWith('t1')
   })
+
+  it('returns true when only a background space had a matching tab', () => {
+    storeState.groups = []
+    bgFns.closeBackgroundSessionTabs.mockReturnValue(true)
+    expect(closeOpenTabsForSession('s1', 'copilot-cli')).toBe(true)
+    expect(storeState.closeTerminal).not.toHaveBeenCalled()
+    expect(bgFns.closeBackgroundSessionTabs).toHaveBeenCalledWith('s1', 'copilot-cli', undefined)
+  })
+
+  it('closes matching tabs in both the active and background spaces', () => {
+    storeState.groups = [
+      group('g1', [tab({ id: 't1', sessionId: 's1', providerId: 'copilot-cli' })])
+    ]
+    bgFns.closeBackgroundSessionTabs.mockReturnValue(true)
+    expect(closeOpenTabsForSession('s1', 'copilot-cli')).toBe(true)
+    expect(storeState.closeTerminal).toHaveBeenCalledWith('t1')
+    expect(bgFns.closeBackgroundSessionTabs).toHaveBeenCalled()
+  })
 })
 
 describe('hasOpenTab', () => {
@@ -276,5 +338,11 @@ describe('hasOpenTab', () => {
     ]
     expect(hasOpenTab('s1', 'copilot-cli')).toBe(false)
     expect(hasOpenTab('s1', 'claude-code')).toBe(true)
+  })
+
+  it('returns true when the session is parked in a background space', () => {
+    storeState.groups = []
+    bgFns.findBackgroundSessionTab.mockReturnValue({ spaceId: 'sp2', groupId: 'g9', tabId: 't9' })
+    expect(hasOpenTab('s1', 'copilot-cli')).toBe(true)
   })
 })

--- a/tests/unit/space-attention.test.ts
+++ b/tests/unit/space-attention.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  aggregateActiveAwareAttention,
+  aggregateAttention,
+  aggregateSpaceAttention,
+  attentionKindLabel,
+  collectSessionCompositeIds,
+  EMPTY_SPACE_ATTENTION,
+  pickTopKind
+} from '../../src/renderer/src/utils/spaceAttention'
+import { makeCompositeId, type AttentionEvent } from '../../src/preload/attentionTypes'
+import type {
+  EditorGroup,
+  Space,
+  TerminalTab,
+  WorkspaceSnapshot
+} from '../../src/renderer/src/types'
+
+function aiTab(id: string, sessionId: string, providerId = 'copilot-cli'): TerminalTab {
+  return { id, title: id, cwd: '/r', command: 'copilot', sessionId, providerId }
+}
+
+function group(id: string, tabs: TerminalTab[]): EditorGroup {
+  return { id, tabs, activeTabId: tabs[0]?.id ?? '' }
+}
+
+function snapshot(groups: EditorGroup[]): WorkspaceSnapshot {
+  return {
+    layout: { type: 'group', groupId: groups[0]?.id ?? 'g' },
+    groups,
+    activeGroupId: groups[0]?.id ?? null
+  }
+}
+
+function space(id: string, groups: EditorGroup[]): Space {
+  const now = Date.now()
+  return {
+    id,
+    name: id,
+    color: '#fff',
+    projectIds: [],
+    workspace: snapshot(groups),
+    createdAt: now,
+    updatedAt: now,
+    lastActiveAt: now
+  }
+}
+
+function event(
+  providerId: string,
+  sessionId: string,
+  kind: AttentionEvent['kind'],
+  overrides: Partial<AttentionEvent> = {}
+): AttentionEvent {
+  return {
+    compositeId: makeCompositeId(providerId, sessionId),
+    providerId,
+    sessionId,
+    displayName: sessionId,
+    kind,
+    createdAt: Date.now(),
+    escalated: false,
+    suppressed: false,
+    seeded: false,
+    ...overrides
+  }
+}
+
+describe('collectSessionCompositeIds', () => {
+  it('collects composite ids for every AI session tab, skipping non-session tabs', () => {
+    const snap = snapshot([
+      group('g1', [aiTab('t1', 's1'), aiTab('t2', 's2', 'claude-code')]),
+      group('g2', [
+        aiTab('t3', 's3'),
+        { id: 't4', title: 'plain shell', cwd: '/r' } as TerminalTab // no session/provider
+      ])
+    ])
+    const ids = collectSessionCompositeIds(snap)
+    expect(ids).toEqual(new Set(['copilot-cli:s1', 'claude-code:s2', 'copilot-cli:s3']))
+  })
+
+  it('accepts a bare { groups } object (live terminal-store groups)', () => {
+    const ids = collectSessionCompositeIds({ groups: [group('g1', [aiTab('t1', 's1')])] })
+    expect(ids).toEqual(new Set(['copilot-cli:s1']))
+  })
+})
+
+describe('aggregateAttention', () => {
+  it('returns EMPTY for an empty id set', () => {
+    expect(aggregateAttention([event('copilot-cli', 's1', 'finished')], new Set())).toBe(
+      EMPTY_SPACE_ATTENTION
+    )
+  })
+
+  it('counts only events whose composite id is in the set', () => {
+    const events = [
+      event('copilot-cli', 's1', 'waitingForApproval'),
+      event('copilot-cli', 's2', 'waitingForInput'),
+      event('copilot-cli', 'other', 'finished') // not in set
+    ]
+    const ids = new Set(['copilot-cli:s1', 'copilot-cli:s2'])
+    const a = aggregateAttention(events, ids)
+    expect(a.waitingForApproval).toBe(1)
+    expect(a.waitingForInput).toBe(1)
+    expect(a.finished).toBe(0)
+    expect(a.total).toBe(2)
+  })
+
+  it('ignores suppressed (dismissed) events', () => {
+    const events = [event('copilot-cli', 's1', 'waitingForApproval', { suppressed: true })]
+    const a = aggregateAttention(events, new Set(['copilot-cli:s1']))
+    expect(a.total).toBe(0)
+    expect(a.topKind).toBeNull()
+  })
+
+  it('prioritizes topKind approval > input > finished', () => {
+    const ids = new Set(['copilot-cli:s1', 'copilot-cli:s2', 'copilot-cli:s3'])
+    const all = aggregateAttention(
+      [
+        event('copilot-cli', 's1', 'finished'),
+        event('copilot-cli', 's2', 'waitingForInput'),
+        event('copilot-cli', 's3', 'waitingForApproval')
+      ],
+      ids
+    )
+    expect(all.topKind).toBe('waitingForApproval')
+
+    const noApproval = aggregateAttention(
+      [event('copilot-cli', 's1', 'finished'), event('copilot-cli', 's2', 'waitingForInput')],
+      ids
+    )
+    expect(noApproval.topKind).toBe('waitingForInput')
+
+    const onlyFinished = aggregateAttention([event('copilot-cli', 's1', 'finished')], ids)
+    expect(onlyFinished.topKind).toBe('finished')
+  })
+})
+
+describe('aggregateSpaceAttention', () => {
+  it('rolls up attention over a space own sessions only — including a backgrounded space', () => {
+    const bg = space('bg', [group('g1', [aiTab('t1', 's1'), aiTab('t2', 's2')])])
+    const events = [
+      event('copilot-cli', 's1', 'waitingForApproval'),
+      event('copilot-cli', 's2', 'finished'),
+      event('copilot-cli', 'foreign', 'waitingForApproval') // belongs to another space
+    ]
+    const a = aggregateSpaceAttention(bg, events)
+    expect(a.waitingForApproval).toBe(1)
+    expect(a.finished).toBe(1)
+    expect(a.total).toBe(2)
+    expect(a.topKind).toBe('waitingForApproval')
+  })
+
+  it('returns EMPTY when a space has no sessions', () => {
+    const empty = space('empty', [])
+    expect(aggregateSpaceAttention(empty, [event('copilot-cli', 's1', 'finished')])).toBe(
+      EMPTY_SPACE_ATTENTION
+    )
+  })
+})
+
+describe('aggregateActiveAwareAttention', () => {
+  it('uses live groups (not the stale snapshot) for the active space', () => {
+    // The stashed snapshot is empty/stale, but a session is live in the terminal
+    // store — the active space must count it immediately.
+    const s = space('active', [])
+    const events = [event('copilot-cli', 'live1', 'waitingForApproval')]
+    const liveGroups = { groups: [group('g1', [aiTab('t1', 'live1')])] }
+    const a = aggregateActiveAwareAttention(s, events, liveGroups)
+    expect(a.waitingForApproval).toBe(1)
+    expect(a.total).toBe(1)
+  })
+
+  it('falls back to the stashed snapshot for a background space (null live groups)', () => {
+    const s = space('bg', [group('g1', [aiTab('t1', 's1')])])
+    const events = [
+      event('copilot-cli', 's1', 'finished'),
+      event('copilot-cli', 'live1', 'waitingForApproval') // live only, not in the snapshot
+    ]
+    const a = aggregateActiveAwareAttention(s, events, null)
+    expect(a.finished).toBe(1)
+    expect(a.waitingForApproval).toBe(0)
+    expect(a.total).toBe(1)
+  })
+})
+
+describe('pickTopKind', () => {
+  it('orders approval > input > finished, null when nothing pending', () => {
+    expect(pickTopKind(1, 1, 1)).toBe('waitingForApproval')
+    expect(pickTopKind(0, 2, 3)).toBe('waitingForInput')
+    expect(pickTopKind(0, 0, 5)).toBe('finished')
+    expect(pickTopKind(0, 0, 0)).toBeNull()
+  })
+})
+
+describe('attentionKindLabel', () => {
+  it('returns Title-case labels by default and lower-case on request', () => {
+    expect(attentionKindLabel('waitingForApproval')).toBe('Needs approval')
+    expect(attentionKindLabel('waitingForInput')).toBe('Waiting for you')
+    expect(attentionKindLabel('finished')).toBe('Finished')
+    expect(attentionKindLabel('waitingForApproval', true)).toBe('needs approval')
+    expect(attentionKindLabel('finished', true)).toBe('finished')
+  })
+})

--- a/tests/unit/space-store.test.ts
+++ b/tests/unit/space-store.test.ts
@@ -1,0 +1,1209 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Spy on terminal teardown so we can assert switching NEVER destroys a
+// terminal (the whole point: backgrounded sessions keep running).
+const destroyTerminal = vi.fn()
+const cancelExitHandler = vi.fn()
+vi.mock('../../src/renderer/src/services/terminalRegistry', () => ({
+  destroyTerminal: (...args: unknown[]) => destroyTerminal(...args),
+  cancelExitHandler: (...args: unknown[]) => cancelExitHandler(...args)
+}))
+
+import { useSpaceStore } from '../../src/renderer/src/stores/spaceStore'
+import {
+  patchBackgroundTab,
+  findBackgroundSessionTab,
+  closeBackgroundSessionTabs,
+  syncBackgroundEditorTabsOnRename,
+  spaceHasUnsavedEditors
+} from '../../src/renderer/src/stores/spaceStore'
+import { useTerminalStore } from '../../src/renderer/src/stores/terminalStore'
+import { useProjectStore, type ResolvedAISession } from '../../src/renderer/src/stores/projectStore'
+import { startProjectSession, openProjectTerminal } from '../../src/renderer/src/utils/spaceStart'
+import {
+  stashParkedEditorBuffer,
+  clearParkedEditorBuffer
+} from '../../src/renderer/src/services/parkedEditorBuffers'
+import { registerFileEditor } from '../../src/renderer/src/services/fileEditorRegistry'
+import type {
+  EditorGroup,
+  FileEditorTab,
+  Space,
+  TerminalTab,
+  WorkspaceSnapshot
+} from '../../src/renderer/src/types'
+
+const saveSpaces = vi.fn().mockResolvedValue(undefined)
+const saveSpacesSync = vi.fn()
+const closeSession = vi.fn().mockResolvedValue(undefined)
+const mergeSettings = vi.fn().mockResolvedValue(undefined)
+let loadSpacesResult: unknown = null
+
+function installWindow(): void {
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: {
+      spaces: {
+        load: vi.fn().mockImplementation(() => Promise.resolve(loadSpacesResult)),
+        save: (...a: unknown[]) => saveSpaces(...a),
+        saveSync: (...a: unknown[]) => saveSpacesSync(...a)
+      },
+      sessions: {
+        close: (...a: unknown[]) => closeSession(...a),
+        getResumeCommand: vi.fn().mockResolvedValue('copilot --resume')
+      },
+      settings: {
+        getAll: vi.fn().mockResolvedValue({}),
+        merge: (...a: unknown[]) => mergeSettings(...a)
+      }
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+  // projectStore schedules a DOM scroll-into-view via rAF on active-project
+  // changes; a no-op stub keeps that off the node test path.
+  ;(globalThis as { requestAnimationFrame?: unknown }).requestAnimationFrame = () => 0
+}
+
+function aiTab(id: string, sessionId: string, cwd: string): TerminalTab {
+  return { id, title: id, cwd, command: 'copilot', sessionId, providerId: 'copilot-cli' }
+}
+
+function group(id: string, tabs: TerminalTab[]): EditorGroup {
+  return { id, tabs, activeTabId: tabs[0]?.id ?? '' }
+}
+
+function fileTab(
+  id: string,
+  rootFs: string,
+  relPath: string,
+  opts: { dirty?: boolean } = {}
+): FileEditorTab {
+  return {
+    id,
+    title: relPath.split('/').pop() ?? relPath,
+    kind: 'fileEditor',
+    rootFs,
+    rootLabel: 'proj',
+    relPath,
+    dirty: opts.dirty
+  }
+}
+
+/** A group holding arbitrary editor tabs (terminal and/or fileEditor). */
+function mixedGroup(id: string, tabs: (TerminalTab | FileEditorTab)[]): EditorGroup {
+  return { id, tabs, activeTabId: tabs[0]?.id ?? '' }
+}
+
+function snapshot(groups: EditorGroup[]): WorkspaceSnapshot {
+  return {
+    layout: { type: 'group', groupId: groups[0]?.id ?? 'g' },
+    groups,
+    activeGroupId: groups[0]?.id ?? null
+  }
+}
+
+/** A standalone Space fixture (for tests that set store state directly rather
+ *  than through `seed`, e.g. Overview → background-space transitions). */
+function bgSpace(id: string, workspace: WorkspaceSnapshot, projectIds: string[] = []): Space {
+  const now = Date.now()
+  return {
+    id,
+    name: id,
+    color: '#6E8BFF',
+    projectIds,
+    workspace,
+    createdAt: now,
+    updatedAt: now,
+    lastActiveAt: now
+  }
+}
+
+function resetTerminal(groups: EditorGroup[] = []): void {
+  useTerminalStore.setState({
+    groups,
+    layout: { type: 'group', groupId: groups[0]?.id ?? '' },
+    activeGroupId: groups[0]?.id ?? null,
+    restored: false
+  } as never)
+}
+
+beforeEach(() => {
+  installWindow()
+  loadSpacesResult = null
+  destroyTerminal.mockReset()
+  cancelExitHandler.mockReset()
+  saveSpaces.mockClear()
+  saveSpacesSync.mockClear()
+  closeSession.mockClear()
+  mergeSettings.mockClear()
+  resetTerminal([])
+  useProjectStore.setState({ projects: [], activeProjectId: null } as never)
+  useSpaceStore.setState({ spaces: [], activeSpaceId: null, loaded: false })
+})
+
+afterEach(() => vi.restoreAllMocks())
+
+/** Seed an active space A (its tabs live in the terminal store) plus any
+ *  background spaces. Sets space state BEFORE the terminal store so the
+ *  orphan-adoption subscription (which only fires while activeSpaceId===null)
+ *  never misfires during setup. */
+function seed(
+  active: { id: string; groups: EditorGroup[]; projectIds?: string[] },
+  background: {
+    id: string
+    workspace: WorkspaceSnapshot
+    projectIds?: string[]
+  }[]
+): void {
+  const now = Date.now()
+  const mk = (
+    id: string,
+    workspace: WorkspaceSnapshot,
+    projectIds: string[] = []
+  ): import('../../src/renderer/src/types').Space => ({
+    id,
+    name: id,
+    color: '#6E8BFF',
+    projectIds,
+    workspace,
+    createdAt: now,
+    updatedAt: now,
+    lastActiveAt: now
+  })
+  useSpaceStore.setState({
+    spaces: [
+      mk(active.id, snapshot(active.groups), active.projectIds),
+      ...background.map((b) => mk(b.id, b.workspace, b.projectIds))
+    ],
+    activeSpaceId: active.id,
+    loaded: true
+  })
+  resetTerminal(active.groups)
+}
+
+describe('spaceStore.hydrate', () => {
+  it('seeds a single active "My Work" space on a fresh install', async () => {
+    loadSpacesResult = null
+    await useSpaceStore.getState().hydrate()
+    const st = useSpaceStore.getState()
+    expect(st.spaces).toHaveLength(1)
+    expect(st.spaces[0].name).toBe('My Work')
+    expect(st.activeSpaceId).toBe(st.spaces[0].id)
+    expect(st.loaded).toBe(true)
+  })
+
+  it('restores the active space workspace into the terminal store', async () => {
+    loadSpacesResult = {
+      version: 1,
+      activeSpaceId: 's1',
+      spaces: [
+        {
+          id: 's1',
+          name: 'Ship OAuth',
+          color: '#6E8BFF',
+          projectIds: ['p1'],
+          workspace: {
+            layout: { type: 'group', groupId: 'g1' },
+            groups: [{ id: 'g1', tabs: [aiTab('t1', 'sess1', '/repo-a')], activeTabId: 't1' }],
+            activeGroupId: 'g1',
+            savedAt: new Date().toISOString()
+          },
+          createdAt: 1,
+          updatedAt: 1,
+          lastActiveAt: 1
+        }
+      ]
+    }
+    await useSpaceStore.getState().hydrate()
+    expect(useSpaceStore.getState().activeSpaceId).toBe('s1')
+    const groups = useTerminalStore.getState().groups
+    expect(groups).toHaveLength(1)
+    expect(groups[0].tabs[0].id).toBe('t1')
+  })
+
+  it('preserves work started during the async boot window instead of clobbering it', async () => {
+    // A valid on-disk file exists…
+    loadSpacesResult = {
+      version: 1,
+      activeSpaceId: 's1',
+      spaces: [
+        {
+          id: 's1',
+          name: 'Ship OAuth',
+          color: '#6E8BFF',
+          projectIds: [],
+          workspace: {
+            layout: { type: 'group', groupId: 'g1' },
+            groups: [{ id: 'g1', tabs: [aiTab('t1', 'sess1', '/repo-a')], activeTabId: 't1' }],
+            activeGroupId: 'g1'
+          },
+          createdAt: 1,
+          updatedAt: 1,
+          lastActiveAt: 1
+        }
+      ]
+    }
+    // …but the user already started a session before load resolved (loaded is
+    // still false, so the orphan-adoption net stays dormant during setup).
+    resetTerminal([group('gEarly', [aiTab('early1', 'sessEarly', '/repo-x')])])
+
+    await useSpaceStore.getState().hydrate()
+
+    const st = useSpaceStore.getState()
+    // The early work became the active space — not discarded by the loaded file.
+    const active = st.spaces.find((s) => s.id === st.activeSpaceId)!
+    expect(active.workspace.groups[0].tabs[0].id).toBe('early1')
+    expect(st.activeSpaceId).not.toBe('s1')
+    // The loaded space is kept alive in the background.
+    expect(st.spaces.some((s) => s.id === 's1')).toBe(true)
+    // The live workspace was never swapped away (early PTYs stay mounted).
+    expect(useTerminalStore.getState().groups[0].tabs[0].id).toBe('early1')
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('lands on the Overview for a valid but empty spaces file (no reseed)', async () => {
+    // The user deleted all their spaces last session — a valid, empty file must
+    // be honoured as the Overview, not mistaken for a fresh install.
+    loadSpacesResult = { version: 1, activeSpaceId: null, spaces: [] }
+    await useSpaceStore.getState().hydrate()
+    const st = useSpaceStore.getState()
+    expect(st.spaces).toHaveLength(0)
+    expect(st.activeSpaceId).toBeNull()
+    expect(st.loaded).toBe(true)
+  })
+
+  it('ignores a non-string persisted glyph without crashing', async () => {
+    loadSpacesResult = {
+      version: 1,
+      activeSpaceId: 's1',
+      spaces: [
+        {
+          id: 's1',
+          name: 'Weird',
+          color: '#6E8BFF',
+          glyph: 42,
+          projectIds: [],
+          workspace: { layout: { type: 'group', groupId: 'g1' }, groups: [], activeGroupId: null },
+          createdAt: 1,
+          updatedAt: 1,
+          lastActiveAt: 1
+        }
+      ]
+    }
+    await useSpaceStore.getState().hydrate()
+    const s = useSpaceStore.getState().spaces.find((x) => x.id === 's1')!
+    expect(s.glyph).toBeUndefined()
+  })
+
+  it('preserves a space created during the async load window', async () => {
+    loadSpacesResult = {
+      version: 1,
+      activeSpaceId: 's1',
+      spaces: [
+        {
+          id: 's1',
+          name: 'Ship OAuth',
+          color: '#6E8BFF',
+          projectIds: [],
+          workspace: {
+            layout: { type: 'group', groupId: 'g1' },
+            groups: [{ id: 'g1', tabs: [aiTab('t1', 'sess1', '/repo-a')], activeTabId: 't1' }],
+            activeGroupId: 'g1'
+          },
+          createdAt: 1,
+          updatedAt: 1,
+          lastActiveAt: 1
+        }
+      ]
+    }
+    // Kick off hydrate but don't await; create a space while it is still loading
+    // (the sidebar stays interactive during boot). createSpace runs
+    // synchronously before the pending load() resolves.
+    const pending = useSpaceStore.getState().hydrate()
+    const newId = useSpaceStore.getState().createSpace({ name: 'Hotfix' })
+    await pending
+
+    const st = useSpaceStore.getState()
+    // Both the loaded space and the one created mid-load survive the final set.
+    expect(st.spaces.some((s) => s.id === 's1')).toBe(true)
+    expect(st.spaces.some((s) => s.id === newId)).toBe(true)
+    // The user's in-window creation wins as the active space over the stale
+    // persisted pointer.
+    expect(st.activeSpaceId).toBe(newId)
+  })
+
+  it('drops a malformed array entry instead of resurrecting it as a bogus space', async () => {
+    loadSpacesResult = {
+      version: 1,
+      activeSpaceId: 's1',
+      spaces: [
+        [],
+        {
+          id: 's1',
+          name: 'Real',
+          color: '#6E8BFF',
+          projectIds: [],
+          workspace: { layout: { type: 'group', groupId: 'g1' }, groups: [], activeGroupId: null },
+          createdAt: 1,
+          updatedAt: 1,
+          lastActiveAt: 1
+        }
+      ]
+    }
+    await useSpaceStore.getState().hydrate()
+    const st = useSpaceStore.getState()
+    // The `[]` element (typeof 'object') is dropped; only the real space remains.
+    expect(st.spaces).toHaveLength(1)
+    expect(st.spaces[0].id).toBe('s1')
+  })
+
+  it('keeps a space created during the load window on a fresh install (no My Work clobber)', async () => {
+    loadSpacesResult = null // fresh install: no file and no legacy workspace
+    const pending = useSpaceStore.getState().hydrate()
+    const newId = useSpaceStore.getState().createSpace({ name: 'Hotfix' })
+    await pending
+
+    const st = useSpaceStore.getState()
+    // The created space survives; we did NOT seed "My Work" over it.
+    expect(st.spaces.some((s) => s.id === newId)).toBe(true)
+    expect(st.spaces.every((s) => s.name !== 'My Work')).toBe(true)
+    expect(st.activeSpaceId).toBe(newId)
+    expect(st.loaded).toBe(true)
+  })
+
+  it('attaches mid-boot early work to the space the user created for it (no throwaway space)', async () => {
+    // A valid on-disk file with one space…
+    loadSpacesResult = {
+      version: 1,
+      activeSpaceId: 's1',
+      spaces: [
+        {
+          id: 's1',
+          name: 'Ship OAuth',
+          color: '#6E8BFF',
+          projectIds: [],
+          workspace: {
+            layout: { type: 'group', groupId: 'g1' },
+            groups: [{ id: 'g1', tabs: [aiTab('t1', 'sess1', '/repo-a')], activeTabId: 't1' }],
+            activeGroupId: 'g1'
+          },
+          createdAt: 1,
+          updatedAt: 1,
+          lastActiveAt: 1
+        }
+      ]
+    }
+    // Mid-boot the user creates a space (activating it) AND starts terminal work
+    // in it — the created space is now in the store while early work sits live
+    // in the terminal store when the load resolves.
+    const pending = useSpaceStore.getState().hydrate()
+    const hotfixId = useSpaceStore.getState().createSpace({ name: 'Hotfix' })
+    resetTerminal([group('gEarly', [aiTab('early1', 'sessEarly', '/repo-x')])])
+    await pending
+
+    const st = useSpaceStore.getState()
+    // Both survive — the loaded space stays in the background, the created one
+    // is active. No throwaway third space is spun up.
+    expect(st.spaces.some((s) => s.id === 's1')).toBe(true)
+    expect(st.spaces.some((s) => s.id === hotfixId)).toBe(true)
+    expect(st.spaces).toHaveLength(2)
+    // The user's live work attaches to the space they created for it (Hotfix),
+    // NOT an auto-named adopted space, and stays intact.
+    expect(st.activeSpaceId).toBe(hotfixId)
+    const active = st.spaces.find((s) => s.id === st.activeSpaceId)!
+    expect(active.id).toBe(hotfixId)
+    expect(active.workspace.groups[0].tabs[0].id).toBe('early1')
+    expect(useTerminalStore.getState().groups[0].tabs[0].id).toBe('early1')
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+})
+
+describe('spaceStore.persist', () => {
+  it('does not write during the async boot window (no clobber before hydrate commits)', () => {
+    // Not loaded yet: a sync save must be suppressed so the on-disk file stays
+    // the source of truth until reconstruction lands.
+    useSpaceStore.setState({
+      spaces: [bgSpace('s1', snapshot([]))],
+      activeSpaceId: 's1',
+      loaded: false
+    })
+    useSpaceStore.getState().persistNow()
+    expect(saveSpacesSync).not.toHaveBeenCalled()
+    // Once loaded, a sync save goes through.
+    useSpaceStore.setState({ loaded: true })
+    useSpaceStore.getState().persistNow()
+    expect(saveSpacesSync).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('spaceStore.switchSpace', () => {
+  it('preserves running terminals (never destroys) and swaps in the target workspace', () => {
+    const bgWorkspace = snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])])
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: bgWorkspace }
+    ])
+
+    useSpaceStore.getState().switchSpace('B')
+
+    // The linchpin: switching must not tear down any terminal.
+    expect(destroyTerminal).not.toHaveBeenCalled()
+    // Target workspace is now live.
+    const groups = useTerminalStore.getState().groups
+    expect(groups).toHaveLength(1)
+    expect(groups[0].tabs[0].id).toBe('b1')
+    expect(useSpaceStore.getState().activeSpaceId).toBe('B')
+  })
+
+  it('auto-backgrounds the previous space, stashing its live arrangement', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+
+    useSpaceStore.getState().switchSpace('B')
+
+    const A = useSpaceStore.getState().spaces.find((s) => s.id === 'A')!
+    expect(A.workspace.groups[0].tabs[0].id).toBe('a1') // stashed, still there
+  })
+
+  it('is a no-op when switching to the already-active space', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [])
+    useSpaceStore.getState().switchSpace('A')
+    expect(useSpaceStore.getState().activeSpaceId).toBe('A')
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('switching in from the Overview does not misfire orphan adoption', () => {
+    // On the Overview (nothing in focus) with one background space that has tabs.
+    const B = bgSpace('B', snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]))
+    useSpaceStore.setState({ spaces: [B], activeSpaceId: null, loaded: true })
+    resetTerminal([]) // Overview: empty workspace
+    mergeSettings.mockClear() // ignore any setup writes
+
+    useSpaceStore.getState().switchSpace('B')
+
+    // No spurious adopted space leaked from the 0→>0 swap.
+    expect(useSpaceStore.getState().spaces).toHaveLength(1)
+    expect(useSpaceStore.getState().activeSpaceId).toBe('B')
+    // Active-project sync (which persists via settings.merge) runs exactly once,
+    // from switchSpace — the orphan net didn't also fire during the swap.
+    expect(mergeSettings).toHaveBeenCalledTimes(1)
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('adopts orphaned live work into a background space before swapping (boot-race guard)', () => {
+    // Boot-window race: while hydrate ran (loaded=false) the orphan-adoption net
+    // was dormant, so early terminal work that appeared went unclaimed. Now
+    // loaded, with nothing in focus, switching to B must NOT swap that work away
+    // — it adopts it into a background space first so its PTYs are preserved.
+    const B = bgSpace('B', snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]))
+    useSpaceStore.setState({ spaces: [B], activeSpaceId: null, loaded: false })
+    resetTerminal([group('gEarly', [aiTab('early1', 'sEarly', '/repo-early')])])
+    // Hydrate finishes; the net never fired for the already-present early work.
+    useSpaceStore.setState({ loaded: true })
+
+    useSpaceStore.getState().switchSpace('B')
+
+    const st = useSpaceStore.getState()
+    // The early work was adopted into a NEW background space (not discarded).
+    expect(st.spaces).toHaveLength(2)
+    const adopted = st.spaces.find((s) => s.id !== 'B')!
+    expect(adopted.workspace.groups[0].tabs[0].id).toBe('early1')
+    // Target B is now live; the early work's terminal was never destroyed.
+    expect(st.activeSpaceId).toBe('B')
+    expect(useTerminalStore.getState().groups[0].tabs[0].id).toBe('b1')
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+})
+
+describe('spaceStore.sendToBackground', () => {
+  it('clears focus to the Overview and empties the workspace, keeping the space alive', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [])
+
+    useSpaceStore.getState().sendToBackground()
+
+    expect(useSpaceStore.getState().activeSpaceId).toBeNull()
+    expect(useTerminalStore.getState().groups).toHaveLength(0)
+    // Its arrangement is stashed, so it can be resumed verbatim later.
+    const A = useSpaceStore.getState().spaces.find((s) => s.id === 'A')!
+    expect(A.workspace.groups[0].tabs[0].id).toBe('a1')
+    expect(destroyTerminal).not.toHaveBeenCalled()
+    // Active project is cleared on the Overview.
+    expect(useProjectStore.getState().activeProjectId).toBeNull()
+  })
+})
+
+describe('spaceStore.focusForDeferredWork', () => {
+  it('is a no-op when the origin is null (deferred work started from the Overview)', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa', '/a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb', '/b')])]) }
+    ])
+    useSpaceStore.getState().switchSpace('B')
+    useSpaceStore.getState().focusForDeferredWork(null)
+    // Focus is unchanged — no forced switch.
+    expect(useSpaceStore.getState().activeSpaceId).toBe('B')
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op when the origin space is already active', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa', '/a')])] }, [])
+    useSpaceStore.getState().focusForDeferredWork('A')
+    expect(useSpaceStore.getState().activeSpaceId).toBe('A')
+  })
+
+  it('is a no-op when the origin space was deleted during the async gap', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa', '/a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb', '/b')])]) }
+    ])
+    useSpaceStore.getState().switchSpace('B')
+    useSpaceStore.getState().focusForDeferredWork('gone')
+    expect(useSpaceStore.getState().activeSpaceId).toBe('B')
+  })
+
+  it('switches back to the origin space when focus moved away mid-resolve', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa', '/a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb', '/b')])]) }
+    ])
+    // Deferred work launched from A; the user switched to B during the gap.
+    useSpaceStore.getState().switchSpace('B')
+    expect(useSpaceStore.getState().activeSpaceId).toBe('B')
+    useSpaceStore.getState().focusForDeferredWork('A')
+    // Focus returns to the originating space so the tab lands there.
+    expect(useSpaceStore.getState().activeSpaceId).toBe('A')
+    // Never tears down B's terminals (it keeps running in the background).
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+})
+
+describe('spaceStore.patchBackgroundTab', () => {
+  it('updates a tab inside a background space snapshot and reports it found', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+    const before = useSpaceStore.getState().spaces
+    expect(patchBackgroundTab('b1', { title: 'renamed' })).toBe(true)
+    const after = useSpaceStore.getState().spaces
+    expect(after).not.toBe(before) // a real change → new state reference
+    expect(after.find((s) => s.id === 'B')!.workspace.groups[0].tabs[0].title).toBe('renamed')
+  })
+
+  it('is a no-op (no state churn, no disk write) when nothing actually changes', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+    const before = useSpaceStore.getState().spaces
+    saveSpaces.mockClear()
+    // aiTab titles default to the id, so patching with the same title is a no-op.
+    expect(patchBackgroundTab('b1', { title: 'b1' })).toBe(true)
+    expect(useSpaceStore.getState().spaces).toBe(before) // identical reference
+    expect(saveSpaces).not.toHaveBeenCalled()
+  })
+
+  it('ignores tabs that live in the active space (owned by the terminal store)', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [])
+    expect(patchBackgroundTab('a1', { title: 'renamed' })).toBe(false)
+  })
+
+  it('returns false for an unknown tab id', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+    expect(patchBackgroundTab('nope', { title: 'x' })).toBe(false)
+  })
+})
+
+describe('spaceStore cross-space session lookup/close', () => {
+  it('finds a session parked in a background space, skipping the active space', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+    expect(findBackgroundSessionTab('sb1', 'copilot-cli')).toEqual({
+      spaceId: 'B',
+      groupId: 'gB',
+      tabId: 'b1'
+    })
+  })
+
+  it('does not find a session that lives in the active space', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [])
+    expect(findBackgroundSessionTab('sa1', 'copilot-cli')).toBeNull()
+  })
+
+  it('returns null when no background space holds the session', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+    expect(findBackgroundSessionTab('ghost', 'copilot-cli')).toBeNull()
+  })
+
+  it('closes a parked session: destroys its terminal, closes it, prunes the snapshot', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      {
+        id: 'B',
+        workspace: snapshot([
+          group('gB', [aiTab('b1', 'sb1', '/repo-b'), aiTab('b2', 'sb2', '/repo-b')])
+        ])
+      }
+    ])
+    expect(closeBackgroundSessionTabs('sb1', 'copilot-cli')).toBe(true)
+    expect(destroyTerminal).toHaveBeenCalledWith('b1')
+    expect(closeSession).toHaveBeenCalledWith('sb1', 'copilot-cli')
+    const B = useSpaceStore.getState().spaces.find((s) => s.id === 'B')!
+    expect(B.workspace.groups[0].tabs.map((t) => t.id)).toEqual(['b2'])
+  })
+
+  it('empties a background space workspace when its last tab is closed', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+    expect(closeBackgroundSessionTabs('sb1', 'copilot-cli')).toBe(true)
+    expect(
+      useSpaceStore.getState().spaces.find((s) => s.id === 'B')!.workspace.groups
+    ).toHaveLength(0)
+  })
+
+  it('never touches the active space and returns false when the session is only active', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [])
+    expect(closeBackgroundSessionTabs('sa1', 'copilot-cli')).toBe(false)
+    expect(destroyTerminal).not.toHaveBeenCalled()
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+})
+
+describe('spaceStore.addProjectToSpace', () => {
+  it('appends a project after the primary (never displaces projectIds[0])', () => {
+    seed(
+      { id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])], projectIds: ['p1'] },
+      []
+    )
+
+    useSpaceStore.getState().addProjectToSpace('A', 'p2')
+
+    const space = useSpaceStore.getState().spaces.find((s) => s.id === 'A')
+    expect(space?.projectIds).toEqual(['p1', 'p2'])
+  })
+
+  it('is a no-op when the project is already bound (no duplicates)', () => {
+    seed(
+      { id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])], projectIds: ['p1', 'p2'] },
+      []
+    )
+    const before = useSpaceStore.getState().spaces.find((s) => s.id === 'A')?.updatedAt
+
+    useSpaceStore.getState().addProjectToSpace('A', 'p1')
+
+    const space = useSpaceStore.getState().spaces.find((s) => s.id === 'A')
+    expect(space?.projectIds).toEqual(['p1', 'p2'])
+    // Untouched: same object, updatedAt not bumped.
+    expect(space?.updatedAt).toBe(before)
+  })
+
+  it('is a no-op when the space no longer exists', () => {
+    seed(
+      { id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])], projectIds: ['p1'] },
+      []
+    )
+
+    expect(() => useSpaceStore.getState().addProjectToSpace('gone', 'p2')).not.toThrow()
+    expect(useSpaceStore.getState().spaces.find((s) => s.id === 'A')?.projectIds).toEqual(['p1'])
+  })
+
+  it('binds a project to a background space without touching the active one', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])], projectIds: ['p1'] }, [
+      {
+        id: 'B',
+        workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]),
+        projectIds: []
+      }
+    ])
+
+    useSpaceStore.getState().addProjectToSpace('B', 'p2')
+
+    expect(useSpaceStore.getState().spaces.find((s) => s.id === 'B')?.projectIds).toEqual(['p2'])
+    expect(useSpaceStore.getState().spaces.find((s) => s.id === 'A')?.projectIds).toEqual(['p1'])
+  })
+})
+
+describe('spaceStore multi-project binding', () => {
+  it('drives the active project from projectIds[0] and retains tabs from every project', () => {
+    useProjectStore.setState({
+      projects: [
+        { id: 'p1', name: 'repo-a', path: '/repo-a', addedAt: '' },
+        { id: 'p2', name: 'repo-b', path: '/repo-b', addedAt: '' }
+      ],
+      activeProjectId: null
+    } as never)
+
+    const multi = snapshot([
+      group('gA', [aiTab('a1', 'sa1', '/repo-a')]),
+      group('gB', [aiTab('b1', 'sb1', '/repo-b')])
+    ])
+    seed({ id: 'A', groups: [group('g0', [aiTab('x', 'sx', '/x')])] }, [
+      { id: 'multi', workspace: multi, projectIds: ['p1', 'p2'] }
+    ])
+
+    useSpaceStore.getState().switchSpace('multi')
+
+    expect(useProjectStore.getState().activeProjectId).toBe('p1') // primary = projectIds[0]
+    const groups = useTerminalStore.getState().groups
+    expect(groups).toHaveLength(2)
+    const cwds = groups.flatMap((g) => g.tabs.map((t) => (t as TerminalTab).cwd)).sort()
+    expect(cwds).toEqual(['/repo-a', '/repo-b'])
+  })
+})
+
+describe('spaceStore.deleteSpace', () => {
+  it('tears down a background space terminals (closes session + destroys pty)', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+
+    useSpaceStore.getState().deleteSpace('B')
+
+    expect(useSpaceStore.getState().spaces.find((s) => s.id === 'B')).toBeUndefined()
+    expect(destroyTerminal).toHaveBeenCalledWith('b1')
+    expect(closeSession).toHaveBeenCalledWith('sb1', 'copilot-cli')
+    // The active space is untouched.
+    expect(useSpaceStore.getState().activeSpaceId).toBe('A')
+    expect(destroyTerminal).not.toHaveBeenCalledWith('a1')
+  })
+
+  it('deleting the active space lands on the Overview and empties the workspace', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [])
+
+    useSpaceStore.getState().deleteSpace('A')
+
+    expect(useSpaceStore.getState().activeSpaceId).toBeNull()
+    expect(useTerminalStore.getState().groups).toHaveLength(0)
+    expect(destroyTerminal).toHaveBeenCalledWith('a1')
+  })
+
+  it('cancels each terminal pending exit handler before destroying it', () => {
+    // Regression: destroyTerminal fires pending exit handlers. A worktree setup
+    // script's handler re-focuses its origin Space and spawns its afterCreate
+    // tab — which, mid-delete, would re-enter the Space being removed (dangling
+    // activeSpaceId + orphan tab). deleteSpace must cancel handlers first.
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+
+    useSpaceStore.getState().deleteSpace('B')
+
+    expect(cancelExitHandler).toHaveBeenCalledWith('b1')
+    // Order matters: cancel must precede destroy (which fires exit handlers).
+    expect(cancelExitHandler.mock.invocationCallOrder[0]).toBeLessThan(
+      destroyTerminal.mock.invocationCallOrder[0]
+    )
+    // The active space is untouched — no re-entrant switch.
+    expect(useSpaceStore.getState().activeSpaceId).toBe('A')
+  })
+})
+
+describe('spaceStore orphan adoption (start work from the Overview)', () => {
+  it('gives the adopted space a neutral name but binds the triggering tab’s project', () => {
+    useProjectStore.setState({
+      projects: [{ id: 'p1', name: 'DPlex', path: '/repo-a', addedAt: '' }],
+      activeProjectId: null
+    } as never)
+    // On the Overview: nothing in focus, but spaces have loaded.
+    useSpaceStore.setState({ spaces: [], activeSpaceId: null, loaded: true })
+    resetTerminal([])
+
+    // Work starts from the Overview: groups go 0 → >0 while activeSpaceId=null.
+    resetTerminal([group('gA', [aiTab('a1', 'sa1', '/repo-a')])])
+
+    const st = useSpaceStore.getState()
+    expect(st.spaces).toHaveLength(1)
+    expect(st.spaces[0].name).toBe('Untitled Space 1') // neutral, not the project name
+    expect(st.spaces[0].projectIds).toEqual(['p1']) // …but still bound to the project
+    expect(st.activeSpaceId).toBe(st.spaces[0].id)
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('gives a neutral name when no project matches (no binding)', () => {
+    useProjectStore.setState({ projects: [], activeProjectId: null } as never)
+    useSpaceStore.setState({ spaces: [], activeSpaceId: null, loaded: true })
+    resetTerminal([])
+
+    resetTerminal([group('gA', [aiTab('a1', 'sa1', '/Users/me/experiments/scratch')])])
+
+    const st = useSpaceStore.getState()
+    expect(st.spaces).toHaveLength(1)
+    expect(st.spaces[0].name).toBe('Untitled Space 1')
+    expect(st.spaces[0].projectIds).toEqual([])
+  })
+
+  it('increments the Untitled Space number past existing ones', () => {
+    useProjectStore.setState({ projects: [], activeProjectId: null } as never)
+    // An earlier auto-created space already holds the number 1.
+    useSpaceStore.setState({
+      spaces: [bgSpace('Untitled Space 1', snapshot([]))],
+      activeSpaceId: null,
+      loaded: true
+    })
+    resetTerminal([])
+
+    resetTerminal([group('gA', [aiTab('a1', 'sa1', '/repo-a')])])
+
+    const st = useSpaceStore.getState()
+    expect(st.spaces).toHaveLength(2)
+    const adopted = st.spaces.find((s) => s.id === st.activeSpaceId)
+    expect(adopted?.name).toBe('Untitled Space 2')
+  })
+
+  it('does not adopt when a space is already in focus (populates it instead)', () => {
+    useProjectStore.setState({ projects: [], activeProjectId: null } as never)
+    // Focused space A with no tabs (the empty SpaceWelcome state).
+    seed({ id: 'A', groups: [] }, [])
+    expect(useTerminalStore.getState().groups).toHaveLength(0)
+
+    // Start work — groups go 0 → >0 while A is in focus.
+    resetTerminal([group('gA', [aiTab('a1', 'sa1', '/repo-a')])])
+
+    // No new space is created; A stays in focus.
+    expect(useSpaceStore.getState().spaces).toHaveLength(1)
+    expect(useSpaceStore.getState().activeSpaceId).toBe('A')
+  })
+
+  it('does not adopt while spaces are still loading', () => {
+    useProjectStore.setState({ projects: [], activeProjectId: null } as never)
+    useSpaceStore.setState({ spaces: [], activeSpaceId: null, loaded: false })
+    resetTerminal([])
+
+    resetTerminal([group('gA', [aiTab('a1', 'sa1', '/repo-a')])])
+
+    expect(useSpaceStore.getState().spaces).toHaveLength(0)
+  })
+})
+
+describe('startProjectSession space targeting', () => {
+  const project = { id: 'p', name: 'repo-a', path: '/repo-a', addedAt: '' }
+  const resolved: ResolvedAISession = {
+    command: 'copilot',
+    title: 'Copilot · repo-a',
+    providerId: 'copilot-cli',
+    cwd: '/repo-a'
+  }
+
+  it('creates the session in the space it was launched from even if focus moves mid-resolve', async () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+
+    // Hold provider resolution open so we can switch spaces before it settles.
+    let settle!: (v: ResolvedAISession | null) => void
+    const pending = new Promise<ResolvedAISession | null>((r) => {
+      settle = r
+    })
+    const createTab = vi.fn().mockReturnValue('new-tab')
+    useProjectStore.setState({
+      resolveAISession: vi.fn().mockReturnValue(pending),
+      createAISessionTab: createTab
+    } as never)
+
+    // Launch from A, then the user jumps to B while resolution is in-flight.
+    startProjectSession(project, 'copilot-cli')
+    useSpaceStore.getState().switchSpace('B')
+    expect(useSpaceStore.getState().activeSpaceId).toBe('B')
+
+    // Provider resolves — the session must land back in its origin space A.
+    settle(resolved)
+    await pending
+    await Promise.resolve()
+
+    expect(useSpaceStore.getState().activeSpaceId).toBe('A')
+    expect(createTab).toHaveBeenCalledTimes(1)
+    // Re-focusing to honor the origin space must never tear a terminal down.
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('does not force focus when launched from the Overview (lands where work now goes)', async () => {
+    // Overview → user opens space B during resolution; the session should not
+    // yank them back to the Overview.
+    const B = bgSpace('B', snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]))
+    useSpaceStore.setState({ spaces: [B], activeSpaceId: null, loaded: true })
+    resetTerminal([])
+
+    let settle!: (v: ResolvedAISession | null) => void
+    const pending = new Promise<ResolvedAISession | null>((r) => {
+      settle = r
+    })
+    const createTab = vi.fn().mockReturnValue('new-tab')
+    useProjectStore.setState({
+      resolveAISession: vi.fn().mockReturnValue(pending),
+      createAISessionTab: createTab
+    } as never)
+
+    startProjectSession(project, 'copilot-cli')
+    useSpaceStore.getState().switchSpace('B')
+
+    settle(resolved)
+    await pending
+    await Promise.resolve()
+
+    // Origin was the Overview (no space), so focus stays on B.
+    expect(useSpaceStore.getState().activeSpaceId).toBe('B')
+    expect(createTab).toHaveBeenCalledTimes(1)
+  })
+
+  it('binds the project to the origin space when it was not already a member', async () => {
+    seed(
+      { id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])], projectIds: ['other'] },
+      []
+    )
+
+    const settled = Promise.resolve<ResolvedAISession | null>(resolved)
+    useProjectStore.setState({
+      resolveAISession: vi.fn().mockReturnValue(settled),
+      createAISessionTab: vi.fn().mockReturnValue('new-tab')
+    } as never)
+
+    startProjectSession(project, 'copilot-cli')
+    await settled
+    await Promise.resolve()
+
+    // Appended after the existing primary, which is left in place.
+    expect(useSpaceStore.getState().spaces.find((s) => s.id === 'A')?.projectIds).toEqual([
+      'other',
+      'p'
+    ])
+  })
+
+  it('does not bind the project when launched from the Overview (orphan adoption handles it)', async () => {
+    const B = bgSpace('B', snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]))
+    useSpaceStore.setState({ spaces: [B], activeSpaceId: null, loaded: true })
+    resetTerminal([])
+
+    const settled = Promise.resolve<ResolvedAISession | null>(resolved)
+    useProjectStore.setState({
+      resolveAISession: vi.fn().mockReturnValue(settled),
+      createAISessionTab: vi.fn().mockReturnValue('new-tab')
+    } as never)
+
+    startProjectSession(project, 'copilot-cli')
+    await settled
+    await Promise.resolve()
+
+    // No origin space → the background space B is left untouched.
+    expect(useSpaceStore.getState().spaces.find((s) => s.id === 'B')?.projectIds).toEqual([])
+  })
+})
+
+describe('openProjectTerminal space binding', () => {
+  it('binds the project to the active space when opening its terminal', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])], projectIds: [] }, [])
+
+    openProjectTerminal({ id: 'p', name: 'repo-a', path: '/repo-a', addedAt: '' })
+
+    expect(useSpaceStore.getState().spaces.find((s) => s.id === 'A')?.projectIds).toEqual(['p'])
+  })
+
+  it('leaves binding to orphan adoption when opened from the Overview (no double bind)', () => {
+    useProjectStore.setState({
+      projects: [{ id: 'p', name: 'repo-a', path: '/repo-a', addedAt: '' }],
+      activeProjectId: null
+    } as never)
+    useSpaceStore.setState({ spaces: [], activeSpaceId: null, loaded: true })
+    resetTerminal([])
+
+    openProjectTerminal({ id: 'p', name: 'repo-a', path: '/repo-a', addedAt: '' })
+
+    // Orphan adoption creates one space bound to the project; the active-space
+    // guard must not add a second (duplicate) binding on top of it.
+    const spaces = useSpaceStore.getState().spaces
+    expect(spaces).toHaveLength(1)
+    expect(spaces[0].projectIds).toEqual(['p'])
+  })
+})
+
+describe('spaceStore.pruneProject (project-removal cleanup)', () => {
+  it('removes a project id from every space and reselects the active primary', () => {
+    seed({ id: 'A', groups: [], projectIds: ['p1', 'p2'] }, [
+      { id: 'B', workspace: snapshot([]), projectIds: ['p2', 'p3'] }
+    ])
+
+    useSpaceStore.getState().pruneProject('p1')
+
+    const st = useSpaceStore.getState()
+    expect(st.spaces.find((s) => s.id === 'A')!.projectIds).toEqual(['p2'])
+    expect(st.spaces.find((s) => s.id === 'B')!.projectIds).toEqual(['p2', 'p3'])
+    // A is active and its primary changed p1→p2, so the Projects panel retargets.
+    expect(useProjectStore.getState().activeProjectId).toBe('p2')
+  })
+
+  it('leaves spaces untouched when none reference the removed project', () => {
+    seed({ id: 'A', groups: [], projectIds: ['p1'] }, [])
+    useSpaceStore.getState().pruneProject('pX')
+    expect(useSpaceStore.getState().spaces[0].projectIds).toEqual(['p1'])
+  })
+
+  it('does not retarget the active project when the pruned project is not the active primary', () => {
+    // Active space A's primary is p1; a background space B holds p2.
+    seed({ id: 'A', groups: [], projectIds: ['p1'] }, [
+      { id: 'B', workspace: snapshot([]), projectIds: ['p2'] }
+    ])
+    // The Projects panel is focused on a specific project.
+    useProjectStore.setState({ activeProjectId: 'pFocused' } as never)
+
+    // Remove p2 — bound only to the background space B.
+    useSpaceStore.getState().pruneProject('p2')
+
+    const st = useSpaceStore.getState()
+    expect(st.spaces.find((s) => s.id === 'B')!.projectIds).toEqual([])
+    // A's primary is unchanged, so the active-project focus must NOT be yanked.
+    expect(useProjectStore.getState().activeProjectId).toBe('pFocused')
+  })
+
+  it('does not retarget when a non-primary member of the active space is pruned', () => {
+    seed({ id: 'A', groups: [], projectIds: ['p1', 'p2'] }, [])
+    useProjectStore.setState({ activeProjectId: 'pFocused' } as never)
+
+    // Remove p2 — present in the active space but NOT its primary (p1).
+    useSpaceStore.getState().pruneProject('p2')
+
+    const st = useSpaceStore.getState()
+    expect(st.spaces.find((s) => s.id === 'A')!.projectIds).toEqual(['p1'])
+    expect(useProjectStore.getState().activeProjectId).toBe('pFocused')
+  })
+
+  it('prunes automatically when a project is removed from projectStore', () => {
+    useProjectStore.setState({
+      projects: [
+        { id: 'p1', name: 'a', path: '/a', addedAt: '' },
+        { id: 'p2', name: 'b', path: '/b', addedAt: '' }
+      ]
+    } as never)
+    seed({ id: 'A', groups: [], projectIds: ['p1', 'p2'] }, [])
+
+    // Genuine removal (p1 present before, gone now) → the subscription prunes it.
+    useProjectStore.setState({
+      projects: [{ id: 'p2', name: 'b', path: '/b', addedAt: '' }]
+    } as never)
+
+    expect(useSpaceStore.getState().spaces[0].projectIds).toEqual(['p2'])
+  })
+
+  it('does not prune on a project add (only genuine removals)', () => {
+    seed({ id: 'A', groups: [], projectIds: ['p1'] }, [])
+    useProjectStore.setState({
+      projects: [
+        { id: 'p1', name: 'a', path: '/a', addedAt: '' },
+        { id: 'p2', name: 'b', path: '/b', addedAt: '' }
+      ]
+    } as never)
+    expect(useSpaceStore.getState().spaces[0].projectIds).toEqual(['p1'])
+  })
+})
+
+describe('spaceStore.syncBackgroundEditorTabsOnRename', () => {
+  it('rewrites a renamed file in a background space, leaving the active space to the terminal store', () => {
+    const activeGroups = [mixedGroup('gA', [fileTab('fa', '/repo', 'src/old.ts')])]
+    const bgWs = snapshot([mixedGroup('gB', [fileTab('fb', '/repo', 'src/old.ts')])])
+    useSpaceStore.setState({
+      spaces: [bgSpace('A', snapshot(activeGroups)), bgSpace('B', bgWs)],
+      activeSpaceId: 'A',
+      loaded: true
+    })
+    resetTerminal(activeGroups)
+
+    syncBackgroundEditorTabsOnRename('/repo', 'src/old.ts', 'src/new.ts')
+
+    const st = useSpaceStore.getState()
+    const bTab = st.spaces.find((s) => s.id === 'B')!.workspace.groups[0].tabs[0] as FileEditorTab
+    expect(bTab.relPath).toBe('src/new.ts')
+    expect(bTab.title).toBe('new.ts')
+    // The ACTIVE space snapshot is deliberately not touched (the terminal store
+    // owns it; fileExplorerStore.syncTabsOnRename updates the live tab).
+    const aTab = st.spaces.find((s) => s.id === 'A')!.workspace.groups[0].tabs[0] as FileEditorTab
+    expect(aTab.relPath).toBe('src/old.ts')
+  })
+
+  it('rewrites descendants on a folder rename', () => {
+    const bgWs = snapshot([
+      mixedGroup('gB', [
+        fileTab('fb', '/repo', 'src/util/a.ts'),
+        fileTab('fc', '/repo', 'src/util/b.ts')
+      ])
+    ])
+    useSpaceStore.setState({
+      spaces: [bgSpace('A', snapshot([])), bgSpace('B', bgWs)],
+      activeSpaceId: 'A',
+      loaded: true
+    })
+    resetTerminal([])
+
+    syncBackgroundEditorTabsOnRename('/repo', 'src/util', 'src/helpers')
+
+    const tabs = useSpaceStore.getState().spaces.find((s) => s.id === 'B')!.workspace.groups[0]
+      .tabs as FileEditorTab[]
+    expect(tabs.map((t) => t.relPath)).toEqual(['src/helpers/a.ts', 'src/helpers/b.ts'])
+  })
+
+  it('ignores editor tabs bound to a different project root', () => {
+    const bgWs = snapshot([mixedGroup('gB', [fileTab('fb', '/other', 'src/old.ts')])])
+    useSpaceStore.setState({
+      spaces: [bgSpace('A', snapshot([])), bgSpace('B', bgWs)],
+      activeSpaceId: 'A',
+      loaded: true
+    })
+    resetTerminal([])
+
+    syncBackgroundEditorTabsOnRename('/repo', 'src/old.ts', 'src/new.ts')
+
+    const bTab = useSpaceStore.getState().spaces.find((s) => s.id === 'B')!.workspace.groups[0]
+      .tabs[0] as FileEditorTab
+    expect(bTab.relPath).toBe('src/old.ts')
+  })
+})
+
+describe('spaceStore.spaceHasUnsavedEditors', () => {
+  afterEach(() => {
+    clearParkedEditorBuffer('fb')
+    clearParkedEditorBuffer('fa')
+  })
+
+  it('is true for a background space holding a stashed unsaved (parked) buffer', () => {
+    const bgWs = snapshot([mixedGroup('gB', [fileTab('fb', '/repo', 'src/x.ts')])])
+    useSpaceStore.setState({
+      spaces: [bgSpace('A', snapshot([])), bgSpace('B', bgWs)],
+      activeSpaceId: 'A',
+      loaded: true
+    })
+    stashParkedEditorBuffer('fb', {
+      content: 'edited',
+      eol: '\n',
+      baseContent: 'orig',
+      baseMtimeMs: 0
+    })
+
+    expect(spaceHasUnsavedEditors('B')).toBe(true)
+  })
+
+  it('is false for a background space whose editor tabs are all clean', () => {
+    const bgWs = snapshot([mixedGroup('gB', [fileTab('fb', '/repo', 'src/x.ts')])])
+    useSpaceStore.setState({
+      spaces: [bgSpace('A', snapshot([])), bgSpace('B', bgWs)],
+      activeSpaceId: 'A',
+      loaded: true
+    })
+    expect(spaceHasUnsavedEditors('B')).toBe(false)
+  })
+
+  it('is true for the active space with a mounted dirty editor', () => {
+    const activeGroups = [mixedGroup('gA', [fileTab('fa', '/repo', 'src/y.ts')])]
+    useSpaceStore.setState({
+      spaces: [bgSpace('A', snapshot(activeGroups))],
+      activeSpaceId: 'A',
+      loaded: true
+    })
+    resetTerminal(activeGroups)
+    const unregister = registerFileEditor('fa', {
+      save: async () => {},
+      isDirty: () => true,
+      getDirtyBuffer: () => null,
+      flushIfAutoSave: () => {}
+    })
+
+    expect(spaceHasUnsavedEditors('A')).toBe(true)
+    unregister()
+  })
+})

--- a/tests/unit/space-visuals.test.ts
+++ b/tests/unit/space-visuals.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { glyphFor, spaceInitials } from '../../src/renderer/src/components/spaces/spaceVisuals'
+import type { Space } from '../../src/renderer/src/types'
+
+describe('spaceInitials', () => {
+  it('derives up to two uppercase initials', () => {
+    expect(spaceInitials('Ship OAuth')).toBe('SO')
+    expect(spaceInitials('perf')).toBe('P')
+    expect(spaceInitials('fix flaky ci tests')).toBe('FF')
+  })
+
+  it('falls back to "S" for an empty/whitespace name', () => {
+    expect(spaceInitials('   ')).toBe('S')
+    expect(spaceInitials('')).toBe('S')
+  })
+})
+
+describe('glyphFor', () => {
+  it('uses an explicit glyph when present', () => {
+    expect(glyphFor({ name: 'Ship OAuth', glyph: '★' })).toBe('★')
+  })
+
+  it('falls back to initials for a missing or blank glyph', () => {
+    expect(glyphFor({ name: 'Ship OAuth', glyph: undefined })).toBe('SO')
+    expect(glyphFor({ name: 'Ship OAuth', glyph: '   ' })).toBe('SO')
+  })
+
+  it('does not crash on a non-string glyph from a hand-edited/corrupt file', () => {
+    // glyph is typed as string | undefined, but a malformed on-disk file could
+    // carry a number; glyphFor must guard rather than call .trim() on it.
+    const space = { name: 'Weird', glyph: 42 } as unknown as Pick<Space, 'name' | 'glyph'>
+    expect(glyphFor(space)).toBe('W')
+  })
+})

--- a/tests/unit/spaces-persistence.test.ts
+++ b/tests/unit/spaces-persistence.test.ts
@@ -1,0 +1,282 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import * as fs from 'fs'
+import * as os from 'os'
+import * as path from 'path'
+
+let tmpDir: string
+
+// Toggle to simulate a rename-aside failure (e.g. EXDEV across filesystems) so
+// the copy-fallback in preserveUnusableSpacesFile can be exercised. fs is
+// otherwise the real module (spread below), so every other call is unaffected.
+const fsState = vi.hoisted(() => ({ failRename: false }))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => tmpDir
+  }
+}))
+
+vi.mock('fs', async (importActual) => {
+  const actual = await importActual<typeof import('fs')>()
+  return {
+    ...actual,
+    default: actual,
+    renameSync: (...args: Parameters<typeof actual.renameSync>) => {
+      if (fsState.failRename) throw new Error('EXDEV: simulated cross-device rename')
+      return actual.renameSync(...args)
+    }
+  }
+})
+
+const loadWorkspace = vi.fn()
+vi.mock('../../src/main/services/sessionPersistence', () => ({
+  loadWorkspace: () => loadWorkspace()
+}))
+
+import {
+  loadOrMigrateSpaces,
+  loadSpaces,
+  migrateLegacyWorkspace,
+  saveSpaces,
+  type PersistedSpacesFile
+} from '../../src/main/services/spacesPersistence'
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dplex-spaces-'))
+  loadWorkspace.mockReset()
+  fsState.failRename = false
+})
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+function sampleFile(): PersistedSpacesFile {
+  return {
+    version: 1,
+    activeSpaceId: 'space-1',
+    spaces: [
+      {
+        id: 'space-1',
+        name: 'Ship OAuth',
+        color: '#6E8BFF',
+        projectIds: ['p1', 'p2'],
+        workspace: { layout: { type: 'group', groupId: 'g1' }, groups: [], activeGroupId: null },
+        createdAt: 1,
+        updatedAt: 2,
+        lastActiveAt: 3
+      }
+    ]
+  }
+}
+
+describe('spacesPersistence round-trip', () => {
+  it('save then load returns the same file', () => {
+    const file = sampleFile()
+    saveSpaces(file)
+    expect(fs.existsSync(path.join(tmpDir, 'spaces.json'))).toBe(true)
+    const loaded = loadSpaces()
+    expect(loaded).toEqual(file)
+  })
+
+  it('load returns null when no file exists', () => {
+    expect(loadSpaces()).toBeNull()
+  })
+
+  it('load returns null for a corrupted file', () => {
+    fs.writeFileSync(path.join(tmpDir, 'spaces.json'), '{ not valid json')
+    expect(loadSpaces()).toBeNull()
+  })
+
+  it('load rejects a structurally invalid file (bad activeSpaceId type)', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'spaces.json'),
+      JSON.stringify({ version: 1, spaces: [], activeSpaceId: 42 })
+    )
+    expect(loadSpaces()).toBeNull()
+  })
+
+  it('load rejects a file whose version is not a number', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'spaces.json'),
+      JSON.stringify({ version: 'one', spaces: [], activeSpaceId: null })
+    )
+    expect(loadSpaces()).toBeNull()
+  })
+
+  it('load rejects a file written by a newer schema version', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'spaces.json'),
+      JSON.stringify({ version: 999, spaces: [], activeSpaceId: null })
+    )
+    expect(loadSpaces()).toBeNull()
+  })
+
+  it('load rejects a bogus version (0, negative, or fractional)', () => {
+    for (const version of [0, -1, 1.5]) {
+      fs.writeFileSync(
+        path.join(tmpDir, 'spaces.json'),
+        JSON.stringify({ version, spaces: [], activeSpaceId: null })
+      )
+      expect(loadSpaces()).toBeNull()
+    }
+  })
+
+  it('load rejects a file with a malformed (null) space entry', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'spaces.json'),
+      JSON.stringify({ version: 1, spaces: [null], activeSpaceId: null })
+    )
+    expect(loadSpaces()).toBeNull()
+  })
+
+  it('load accepts a valid empty file with a null activeSpaceId', () => {
+    const file = { version: 1, spaces: [], activeSpaceId: null }
+    fs.writeFileSync(path.join(tmpDir, 'spaces.json'), JSON.stringify(file))
+    expect(loadSpaces()).toEqual(file)
+  })
+
+  it('save writes atomically (no leftover .tmp file)', () => {
+    saveSpaces(sampleFile())
+    expect(fs.existsSync(path.join(tmpDir, 'spaces.json.tmp'))).toBe(false)
+  })
+})
+
+describe('migrateLegacyWorkspace', () => {
+  it('wraps a legacy sessions.json workspace into a single active "My Work" space', () => {
+    const legacy = {
+      layout: { type: 'group', groupId: 'g1' },
+      groups: [{ id: 'g1' }],
+      activeGroupId: 'g1'
+    }
+    loadWorkspace.mockReturnValue(legacy)
+
+    const migrated = migrateLegacyWorkspace()
+    expect(migrated).not.toBeNull()
+    expect(migrated!.spaces).toHaveLength(1)
+    const s = migrated!.spaces[0]
+    expect(s.name).toBe('My Work')
+    expect(s.id).toBe('space-my-work')
+    expect(s.workspace).toEqual(legacy)
+    expect(migrated!.activeSpaceId).toBe('space-my-work')
+  })
+
+  it('returns null when there is no legacy workspace to migrate', () => {
+    loadWorkspace.mockReturnValue(null)
+    expect(migrateLegacyWorkspace()).toBeNull()
+  })
+})
+
+describe('loadOrMigrateSpaces precedence', () => {
+  it('prefers an existing spaces.json over legacy migration', () => {
+    const file = sampleFile()
+    saveSpaces(file)
+    loadWorkspace.mockReturnValue({ layout: { type: 'group' }, groups: [], activeGroupId: null })
+
+    const result = loadOrMigrateSpaces()
+    expect(result).toEqual(file)
+    // Existing file wins → migration path not consulted.
+    expect(loadWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('falls back to migration when no spaces.json exists', () => {
+    const legacy = { layout: { type: 'group', groupId: 'g1' }, groups: [], activeGroupId: null }
+    loadWorkspace.mockReturnValue(legacy)
+
+    const result = loadOrMigrateSpaces()
+    expect(result!.spaces[0].name).toBe('My Work')
+  })
+
+  it('persists the migrated file immediately so the migration is durable', () => {
+    const legacy = { layout: { type: 'group', groupId: 'g1' }, groups: [], activeGroupId: null }
+    loadWorkspace.mockReturnValue(legacy)
+
+    const migrated = loadOrMigrateSpaces()
+    // spaces.json must exist on disk right after migration — otherwise a
+    // mid-boot workspace autosave could clobber the legacy source first.
+    expect(fs.existsSync(path.join(tmpDir, 'spaces.json'))).toBe(true)
+
+    // And a fresh load returns the same migrated data without re-migrating.
+    loadWorkspace.mockClear()
+    const reloaded = loadOrMigrateSpaces()
+    expect(reloaded).toEqual(migrated)
+    expect(loadWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('returns null when there is neither a spaces file nor a legacy workspace', () => {
+    loadWorkspace.mockReturnValue(null)
+    expect(loadOrMigrateSpaces()).toBeNull()
+  })
+})
+
+describe('loadOrMigrateSpaces preserves unusable files', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  function backups(suffix: string): string[] {
+    return fs.readdirSync(tmpDir).filter((f) => f.startsWith(`spaces.json.${suffix}-`))
+  }
+
+  it('moves a corrupt file aside and does NOT migrate over it', () => {
+    fs.writeFileSync(path.join(tmpDir, 'spaces.json'), '{ not valid json')
+    loadWorkspace.mockReturnValue({ layout: { type: 'group' }, groups: [], activeGroupId: null })
+
+    const result = loadOrMigrateSpaces()
+
+    expect(result).toBeNull()
+    // Never wraps the legacy workspace over an existing (if unreadable) file.
+    expect(loadWorkspace).not.toHaveBeenCalled()
+    // The bad file is preserved as a timestamped backup, and no fresh
+    // spaces.json is written in its place (the renderer seeds in memory).
+    expect(backups('corrupt')).toHaveLength(1)
+    expect(fs.existsSync(path.join(tmpDir, 'spaces.json'))).toBe(false)
+  })
+
+  it('moves a newer-schema file aside as an .unsupported backup', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'spaces.json'),
+      JSON.stringify({ version: 999, spaces: [], activeSpaceId: null })
+    )
+    loadWorkspace.mockReturnValue({ layout: { type: 'group' }, groups: [], activeGroupId: null })
+
+    const result = loadOrMigrateSpaces()
+
+    expect(result).toBeNull()
+    expect(loadWorkspace).not.toHaveBeenCalled()
+    expect(backups('unsupported')).toHaveLength(1)
+    expect(fs.existsSync(path.join(tmpDir, 'spaces.json'))).toBe(false)
+  })
+
+  it('falls back to copying the backup when the rename-aside fails', () => {
+    fs.writeFileSync(path.join(tmpDir, 'spaces.json'), '{ not valid json')
+    loadWorkspace.mockReturnValue({ layout: { type: 'group' }, groups: [], activeGroupId: null })
+    fsState.failRename = true
+
+    const result = loadOrMigrateSpaces()
+
+    expect(result).toBeNull()
+    expect(loadWorkspace).not.toHaveBeenCalled()
+    const bak = backups('corrupt')
+    expect(bak).toHaveLength(1)
+    // Copy (not rename) fallback → the original file remains in place AND the
+    // backup holds its bytes, so the data survives the next save that overwrites
+    // spaces.json.
+    expect(fs.existsSync(path.join(tmpDir, 'spaces.json'))).toBe(true)
+    expect(fs.readFileSync(path.join(tmpDir, bak[0]), 'utf-8')).toBe('{ not valid json')
+  })
+
+  it('returns a valid empty file as-is without migrating or reseeding', () => {
+    const empty = { version: 1, spaces: [], activeSpaceId: null }
+    fs.writeFileSync(path.join(tmpDir, 'spaces.json'), JSON.stringify(empty))
+    loadWorkspace.mockReturnValue({ layout: { type: 'group' }, groups: [], activeGroupId: null })
+
+    const result = loadOrMigrateSpaces()
+
+    // An empty-but-valid file means the user deleted all spaces — honour it,
+    // don't treat it as a fresh install and re-migrate a legacy workspace.
+    expect(result).toEqual(empty)
+    expect(loadWorkspace).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/spaces-source.test.ts
+++ b/tests/unit/spaces-source.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SearchContext } from '../../src/renderer/src/services/search/types'
+import type {
+  EditorGroup,
+  Project,
+  Space,
+  TerminalTab,
+  WorkspaceSnapshot
+} from '../../src/renderer/src/types'
+
+// `run` reaches into these two stores; mock them so the source can be tested in
+// isolation (no terminal store / window.dplex setup needed).
+const { switchSpace, updateSettings } = vi.hoisted(() => ({
+  switchSpace: vi.fn(),
+  updateSettings: vi.fn()
+}))
+vi.mock('../../src/renderer/src/stores/spaceStore', () => ({
+  useSpaceStore: { getState: () => ({ switchSpace }) }
+}))
+vi.mock('../../src/renderer/src/stores/settingsStore', () => ({
+  useSettingsStore: { getState: () => ({ updateSettings }) }
+}))
+
+import { spacesSource } from '../../src/renderer/src/services/search/spacesSource'
+
+function tab(id: string): TerminalTab {
+  return {
+    id,
+    title: id,
+    cwd: '/x',
+    command: 'copilot',
+    sessionId: `s-${id}`,
+    providerId: 'copilot-cli'
+  }
+}
+
+function group(id: string, tabs: TerminalTab[]): EditorGroup {
+  return { id, tabs, activeTabId: tabs[0]?.id ?? '' }
+}
+
+function workspace(tabCount: number): WorkspaceSnapshot {
+  const tabs = Array.from({ length: tabCount }, (_, i) => tab(`t${i}`))
+  return { layout: { type: 'group', groupId: 'g' }, groups: [group('g', tabs)], activeGroupId: 'g' }
+}
+
+function space(id: string, name: string, projectIds: string[], ws: WorkspaceSnapshot): Space {
+  const now = Date.now()
+  return {
+    id,
+    name,
+    color: '#6E8BFF',
+    projectIds,
+    workspace: ws,
+    createdAt: now,
+    updatedAt: now,
+    lastActiveAt: now
+  }
+}
+
+const PROJECTS: Project[] = [
+  { id: 'p1', name: 'repo-a', path: '/repo-a', addedAt: '' },
+  { id: 'p2', name: 'repo-b', path: '/repo-b', addedAt: '' }
+]
+
+function ctx(
+  spaces: Space[],
+  activeSpaceId: string | null,
+  groups: EditorGroup[] = []
+): SearchContext {
+  return {
+    projects: PROJECTS,
+    spaces,
+    activeSpaceId,
+    sessions: [],
+    groups,
+    activeGroupId: groups[0]?.id ?? null
+  }
+}
+
+beforeEach(() => {
+  switchSpace.mockClear()
+  updateSettings.mockClear()
+})
+
+describe('spacesSource.getItems', () => {
+  it('labels a background space by name with its project and session counts', () => {
+    const s = space('s1', 'Ship OAuth', ['p1', 'p2'], workspace(2))
+    const [item] = spacesSource.getItems(ctx([s], null))
+    expect(item.id).toBe('space:s1')
+    expect(item.label).toBe('Ship OAuth')
+    expect(item.description).toBe('2 projects · 2 sessions')
+    expect(item.hint).toBeUndefined()
+  })
+
+  it('singularizes the counts for a one-project, one-session space', () => {
+    const s = space('s1', 'Solo', ['p1'], workspace(1))
+    const [item] = spacesSource.getItems(ctx([s], null))
+    expect(item.description).toBe('1 project · 1 session')
+  })
+
+  it('omits the project count when a space has no bound projects', () => {
+    const s = space('s1', 'Scratch', [], workspace(0))
+    const [item] = spacesSource.getItems(ctx([s], null))
+    expect(item.description).toBe('0 sessions')
+  })
+
+  it('counts the active space live sessions from the terminal groups, not its stale snapshot', () => {
+    // Snapshot says 0, but three tabs are live in the terminal store.
+    const active = space('s1', 'Focused', ['p1'], workspace(0))
+    const live = [group('gA', [tab('a'), tab('b')]), group('gB', [tab('c')])]
+    const [item] = spacesSource.getItems(ctx([active], 's1', live))
+    expect(item.description).toBe('1 project · 3 sessions')
+    expect(item.hint).toBe('In focus')
+  })
+
+  it('exposes bound project names as keywords so a space is findable by its repos', () => {
+    const s = space('s1', 'Ship OAuth', ['p1', 'p2'], workspace(1))
+    const [item] = spacesSource.getItems(ctx([s], null))
+    expect(item.keywords).toEqual(expect.arrayContaining(['space', 'repo-a', 'repo-b']))
+  })
+
+  it('drops project ids that no longer resolve to a project', () => {
+    const s = space('s1', 'Stale', ['p1', 'ghost'], workspace(0))
+    const [item] = spacesSource.getItems(ctx([s], null))
+    // Only the one resolvable project is counted / used as a keyword.
+    expect(item.description).toBe('1 project · 0 sessions')
+    expect(item.keywords).not.toContain('ghost')
+  })
+
+  it('run() reveals the Spaces panel and switches into the space (never restarts sessions)', () => {
+    const s = space('s1', 'Ship OAuth', ['p1'], workspace(1))
+    const [item] = spacesSource.getItems(ctx([s], null))
+    item.run()
+    expect(updateSettings).toHaveBeenCalledWith({
+      sidebarActiveTab: 'spaces',
+      sidebarPanelCollapsed: false,
+      sidebarVisible: true
+    })
+    expect(switchSpace).toHaveBeenCalledWith('s1')
+  })
+})

--- a/tests/unit/terminal-preview-tabs.test.ts
+++ b/tests/unit/terminal-preview-tabs.test.ts
@@ -56,8 +56,7 @@ function setupWindow(): void {
 
 beforeEach(() => {
   setupWindow()
-  // Hard-reset the store between tests. `restoreWorkspace` early-returns
-  // when there are existing groups, so we have to drop directly via setState.
+  // Hard-reset the store between tests directly via setState.
   useTerminalStore.setState({
     groups: [],
     layout: { type: 'group', groupId: '' },

--- a/tests/unit/terminal-ready.test.ts
+++ b/tests/unit/terminal-ready.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  subscribeTerminalReady,
+  markTerminalReady,
+  registerExitHandler,
+  fireExitHandler,
+  cancelExitHandler,
+  registerDestroyCleanup,
+  destroyTerminal
+} from '../../src/renderer/src/services/terminalRegistry'
+
+// These cover the readiness-subscription mechanism that replaced the single
+// bound onReady callback. The old design notified only the first mount, so a
+// terminal remounted mid-startup (a Space switch) could hang on
+// "Starting terminal…" forever. The subscription model must notify whatever
+// hook is currently mounted, keyed by the stable terminalId.
+describe('terminalRegistry ready subscriptions', () => {
+  it('notifies a subscriber when the terminal is marked ready', () => {
+    const cb = vi.fn()
+    const off = subscribeTerminalReady('ready-1', cb)
+    markTerminalReady('ready-1')
+    expect(cb).toHaveBeenCalledTimes(1)
+    off()
+  })
+
+  it('notifies the CURRENT subscriber after a prior one unsubscribed (remount)', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    // First mount subscribes, then unmounts (unsubscribes) before the first byte.
+    const offFirst = subscribeTerminalReady('ready-2', first)
+    offFirst()
+    // A remount subscribes; it must be the one notified — the core bug fix.
+    const offSecond = subscribeTerminalReady('ready-2', second)
+    markTerminalReady('ready-2')
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+    offSecond()
+  })
+
+  it('supports multiple concurrent subscribers for one terminal', () => {
+    const a = vi.fn()
+    const b = vi.fn()
+    const offA = subscribeTerminalReady('ready-3', a)
+    const offB = subscribeTerminalReady('ready-3', b)
+    markTerminalReady('ready-3')
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+    offA()
+    offB()
+  })
+
+  it('stops notifying a subscriber after it unsubscribes', () => {
+    const cb = vi.fn()
+    const off = subscribeTerminalReady('ready-4', cb)
+    off()
+    markTerminalReady('ready-4')
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent — repeated marks re-notify live subscribers', () => {
+    const cb = vi.fn()
+    const off = subscribeTerminalReady('ready-5', cb)
+    markTerminalReady('ready-5')
+    markTerminalReady('ready-5')
+    expect(cb).toHaveBeenCalledTimes(2)
+    off()
+  })
+
+  it('is safe to mark ready with no subscribers', () => {
+    expect(() => markTerminalReady('ready-none')).not.toThrow()
+  })
+
+  it('isolates a throwing subscriber so siblings still fire', () => {
+    const boom = vi.fn(() => {
+      throw new Error('boom')
+    })
+    const ok = vi.fn()
+    const offBoom = subscribeTerminalReady('ready-6', boom)
+    const offOk = subscribeTerminalReady('ready-6', ok)
+    expect(() => markTerminalReady('ready-6')).not.toThrow()
+    expect(ok).toHaveBeenCalledTimes(1)
+    offBoom()
+    offOk()
+  })
+})
+
+// Pending exit handlers let a caller (e.g. the worktree setup-script flow) react
+// to a terminal's PTY exit before a hook mounts. cancelExitHandler discards one
+// WITHOUT firing it — used on deliberate teardown (a Space is deleted) so a
+// setup script's afterCreate action never runs for a Space that no longer exists.
+describe('terminalRegistry exit handlers', () => {
+  it('fires a registered handler once, then clears it', () => {
+    const cb = vi.fn()
+    registerExitHandler('exit-1', cb)
+    fireExitHandler('exit-1', 0)
+    fireExitHandler('exit-1', 0)
+    expect(cb).toHaveBeenCalledTimes(1)
+    expect(cb).toHaveBeenCalledWith(0)
+  })
+
+  it('cancelExitHandler discards a pending handler WITHOUT firing it', () => {
+    const cb = vi.fn()
+    registerExitHandler('exit-2', cb)
+    cancelExitHandler('exit-2')
+    // A subsequent exit (e.g. destroyTerminal's synthetic fire) must be a no-op.
+    fireExitHandler('exit-2', -1)
+    expect(cb).not.toHaveBeenCalled()
+  })
+
+  it('cancelExitHandler is safe when no handler is registered', () => {
+    expect(() => cancelExitHandler('exit-none')).not.toThrow()
+  })
+})
+
+// Destroy cleanups ALWAYS run when a terminal is destroyed — even when the exit
+// handler was cancelled for deliberate teardown (e.g. a Space deleted mid-setup).
+// This is what stops a setup script's temp file leaking on the delete path,
+// which matters most on Windows where %TEMP% is not auto-reaped.
+describe('terminalRegistry destroy cleanups', () => {
+  it('fires a registered cleanup on destroy, exactly once', () => {
+    const cleanup = vi.fn()
+    registerDestroyCleanup('destroy-1', cleanup)
+    // No registry entry for this id → destroyTerminal takes the no-entry branch,
+    // which still fires the cleanup (no window/PTY access on that path).
+    destroyTerminal('destroy-1')
+    destroyTerminal('destroy-1')
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs the cleanup even after the exit handler was cancelled (no temp-file leak)', () => {
+    const cleanup = vi.fn()
+    const exit = vi.fn()
+    registerDestroyCleanup('destroy-2', cleanup)
+    registerExitHandler('destroy-2', exit)
+    // Deliberate teardown discards the deferred afterCreate work…
+    cancelExitHandler('destroy-2')
+    destroyTerminal('destroy-2')
+    // …but the resource-releasing cleanup must still run.
+    expect(exit).not.toHaveBeenCalled()
+    expect(cleanup).toHaveBeenCalledTimes(1)
+  })
+
+  it('unregister fn prevents a stale cleanup from firing', () => {
+    const cleanup = vi.fn()
+    const off = registerDestroyCleanup('destroy-3', cleanup)
+    off()
+    destroyTerminal('destroy-3')
+    expect(cleanup).not.toHaveBeenCalled()
+  })
+
+  it('isolates a throwing cleanup (destroy still completes)', () => {
+    const throwing = vi.fn(() => {
+      throw new Error('cleanup boom')
+    })
+    registerDestroyCleanup('destroy-4', throwing)
+    expect(() => destroyTerminal('destroy-4')).not.toThrow()
+    expect(throwing).toHaveBeenCalledTimes(1)
+  })
+})

--- a/tests/unit/workspace-snapshot.test.ts
+++ b/tests/unit/workspace-snapshot.test.ts
@@ -1,0 +1,247 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  EMPTY_WORKSPACE,
+  reconstructWorkspace,
+  serializeWorkspaceSnapshot
+} from '../../src/renderer/src/utils/workspaceSnapshot'
+import type {
+  EditorGroup,
+  FileEditorTab,
+  TerminalTab,
+  WorkspaceSnapshot
+} from '../../src/renderer/src/types'
+
+function aiTab(
+  id: string,
+  sessionId: string,
+  cwd: string,
+  providerId = 'copilot-cli'
+): TerminalTab {
+  return { id, title: id, cwd, command: 'copilot', sessionId, providerId }
+}
+
+function shellTab(id: string): TerminalTab {
+  return { id, title: id, cwd: '/r' } // no command → plain shell, not persisted
+}
+
+function fileEditorTab(id: string, preview: boolean): FileEditorTab {
+  return {
+    id,
+    title: id,
+    kind: 'fileEditor',
+    rootFs: '/r',
+    rootLabel: 'r',
+    relPath: 'src/x.ts',
+    preview
+  }
+}
+
+function group(id: string, tabs: EditorGroup['tabs']): EditorGroup {
+  return { id, tabs, activeTabId: tabs[0]?.id ?? '' }
+}
+
+function installWindow(resumeCommand: string | null): void {
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: {
+      sessions: {
+        getResumeCommand: vi.fn().mockResolvedValue(resumeCommand)
+      }
+    }
+  }
+}
+
+beforeEach(() => installWindow(null))
+afterEach(() => vi.restoreAllMocks())
+
+describe('serializeWorkspaceSnapshot', () => {
+  it('keeps AI session terminals + permanent file tabs, drops plain shells and previews', () => {
+    const snap: WorkspaceSnapshot = {
+      layout: { type: 'group', groupId: 'g1' },
+      groups: [
+        group('g1', [
+          aiTab('t1', 's1', '/repo-a'),
+          shellTab('t2'),
+          fileEditorTab('fe-keep', false),
+          fileEditorTab('fe-preview', true)
+        ])
+      ],
+      activeGroupId: 'g1'
+    }
+    const persisted = serializeWorkspaceSnapshot(snap)
+    const ids = persisted.groups[0].tabs.map((t) => (t as { id?: string }).id)
+    expect(ids).toContain('t1')
+    expect(ids).toContain('fe-keep')
+    expect(ids).not.toContain('t2') // plain shell dropped
+    expect(ids).not.toContain('fe-preview') // preview dropped
+    expect(persisted.savedAt).toBeTruthy()
+  })
+})
+
+describe('reconstructWorkspace', () => {
+  it('round-trips AI session tabs and refreshes their resume command', async () => {
+    installWindow('copilot --resume=s1')
+    const snap: WorkspaceSnapshot = {
+      layout: { type: 'group', groupId: 'g1' },
+      groups: [group('g1', [aiTab('t1', 's1', '/repo-a')])],
+      activeGroupId: 'g1'
+    }
+    const persisted = serializeWorkspaceSnapshot(snap)
+    const restored = await reconstructWorkspace(persisted)
+    expect(restored).not.toBeNull()
+    const tab = restored!.groups[0].tabs[0] as TerminalTab
+    expect(tab.id).toBe('t1')
+    expect(tab.sessionId).toBe('s1')
+    expect(tab.command).toBe('copilot --resume=s1')
+  })
+
+  it('appends a resume flag for a legacy tab (no providerId) with a safe id', async () => {
+    // No providerId → the renderer-side fallback builds the resume command.
+    const legacy: TerminalTab = {
+      id: 't1',
+      title: 't1',
+      cwd: '/r',
+      command: 'copilot',
+      sessionId: 'safe-123'
+    }
+    const snap: WorkspaceSnapshot = {
+      layout: { type: 'group', groupId: 'g1' },
+      groups: [group('g1', [legacy])],
+      activeGroupId: 'g1'
+    }
+    const restored = await reconstructWorkspace(serializeWorkspaceSnapshot(snap))
+    const tab = restored!.groups[0].tabs[0] as TerminalTab
+    expect(tab.command).toBe('copilot --resume=safe-123')
+  })
+
+  it('does NOT interpolate an unsafe session id into a legacy tab resume command', async () => {
+    const evil: TerminalTab = {
+      id: 't1',
+      title: 't1',
+      cwd: '/r',
+      command: 'copilot',
+      sessionId: 's1; rm -rf /'
+    }
+    const snap: WorkspaceSnapshot = {
+      layout: { type: 'group', groupId: 'g1' },
+      groups: [group('g1', [evil])],
+      activeGroupId: 'g1'
+    }
+    const restored = await reconstructWorkspace(serializeWorkspaceSnapshot(snap))
+    const tab = restored!.groups[0].tabs[0] as TerminalTab
+    // Command left untouched — no shell metacharacters interpolated.
+    expect(tab.command).toBe('copilot')
+    expect(tab.command).not.toContain('rm -rf')
+  })
+
+  it('retains tabs from MULTIPLE projects across a serialize→reconstruct round-trip', async () => {
+    const snap: WorkspaceSnapshot = {
+      layout: {
+        type: 'split',
+        direction: 'horizontal',
+        children: [
+          { type: 'group', groupId: 'gA' },
+          { type: 'group', groupId: 'gB' }
+        ]
+      },
+      groups: [
+        group('gA', [aiTab('a1', 'sa1', '/repo-a'), aiTab('a2', 'sa2', '/repo-a')]),
+        group('gB', [aiTab('b1', 'sb1', '/repo-b')])
+      ],
+      activeGroupId: 'gA'
+    }
+    const restored = await reconstructWorkspace(serializeWorkspaceSnapshot(snap))
+    expect(restored).not.toBeNull()
+    const cwds = restored!.groups.flatMap((g) => g.tabs.map((t) => (t as TerminalTab).cwd))
+    expect(cwds.sort()).toEqual(['/repo-a', '/repo-a', '/repo-b'])
+    expect(restored!.groups.map((g) => g.id).sort()).toEqual(['gA', 'gB'])
+  })
+
+  it('returns null when nothing restorable remains (all plain shells)', async () => {
+    const snap: WorkspaceSnapshot = {
+      layout: { type: 'group', groupId: 'g1' },
+      groups: [group('g1', [shellTab('t1'), shellTab('t2')])],
+      activeGroupId: 'g1'
+    }
+    const restored = await reconstructWorkspace(serializeWorkspaceSnapshot(snap))
+    expect(restored).toBeNull()
+  })
+
+  it('isolates a malformed group — good groups survive instead of nulling all', async () => {
+    const good = serializeWorkspaceSnapshot({
+      layout: { type: 'group', groupId: 'gGood' },
+      groups: [group('gGood', [aiTab('a1', 'sa1', '/repo-a')])],
+      activeGroupId: 'gGood'
+    })
+    const data = {
+      layout: {
+        type: 'split',
+        direction: 'horizontal',
+        children: [
+          { type: 'group', groupId: 'gGood' },
+          { type: 'group', groupId: 'gBad' }
+        ]
+      },
+      groups: [
+        good.groups[0],
+        // A null group and a group with a non-array `tabs` — either would throw
+        // in the old single try/catch and null the ENTIRE workspace.
+        null,
+        { id: 'gBad', tabs: null, activeTabId: '' }
+      ],
+      activeGroupId: 'gGood'
+    } as unknown as Parameters<typeof reconstructWorkspace>[0]
+    const restored = await reconstructWorkspace(data)
+    expect(restored).not.toBeNull()
+    expect(restored!.groups.map((g) => g.id)).toEqual(['gGood'])
+    expect(restored!.groups[0].tabs.map((t) => t.id)).toEqual(['a1'])
+  })
+
+  it('isolates a malformed tab — good tabs in the same group survive', async () => {
+    const good = serializeWorkspaceSnapshot({
+      layout: { type: 'group', groupId: 'gGood' },
+      groups: [group('gGood', [aiTab('a1', 'sa1', '/repo-a')])],
+      activeGroupId: 'gGood'
+    })
+    const goodTab = good.groups[0].tabs[0]
+    // A tab whose property access throws while being prepared (passes the keeper
+    // filter via its command, then throws on sessionId read).
+    const throwingTab: Record<string, unknown> = { id: 'bad', title: 'bad', command: 'copilot' }
+    Object.defineProperty(throwingTab, 'sessionId', {
+      enumerable: true,
+      get() {
+        throw new Error('boom')
+      }
+    })
+    const data = {
+      layout: { type: 'group', groupId: 'gGood' },
+      groups: [
+        {
+          id: 'gGood',
+          // null / undefined tabs and a throwing tab alongside a valid one.
+          tabs: [null, throwingTab, goodTab, undefined],
+          activeTabId: goodTab.id
+        }
+      ],
+      activeGroupId: 'gGood'
+    } as unknown as Parameters<typeof reconstructWorkspace>[0]
+    const restored = await reconstructWorkspace(data)
+    expect(restored).not.toBeNull()
+    expect(restored!.groups[0].tabs.map((t) => t.id)).toEqual(['a1'])
+  })
+
+  it('returns null when EVERY group is malformed (nothing salvageable)', async () => {
+    const data = {
+      layout: { type: 'group', groupId: 'g1' },
+      groups: [null, { id: 'g2', tabs: null, activeTabId: '' }, undefined],
+      activeGroupId: 'g1'
+    } as unknown as Parameters<typeof reconstructWorkspace>[0]
+    const restored = await reconstructWorkspace(data)
+    expect(restored).toBeNull()
+  })
+
+  it('EMPTY_WORKSPACE has no groups', () => {
+    expect(EMPTY_WORKSPACE.groups).toHaveLength(0)
+    expect(EMPTY_WORKSPACE.activeGroupId).toBeNull()
+  })
+})


### PR DESCRIPTION
## Context Spaces

Introduces **Spaces** — a management layer that lets a developer group an entire piece of work (its projects/worktrees, AI + terminal sessions, and the exact tab/split layout) into a named, color-coded Space they can leave and return to without reconstructing their workspace.

Switching Spaces **never restarts or interrupts a running session** — the Space you leave keeps working in the background and still surfaces attention updates.

> DPlex remains **only the management layer**: it never reads, summarizes, modifies, or intercepts session content, prompts, responses, or approvals.

### What's included

- **Spaces sidebar** — create, rename, recolor, reorder, switch, minimize (park), resume, and delete Spaces. Current Space sits in a dedicated **Focused** section; the rest under **All spaces** (MRU), each row showing its projects and live session count. Jump to a Space with `Cmd/Ctrl+Shift+1–9`.
- **Overview** — a home base showing every Space at a glance: live state, projects held, and which need attention. Resume any Space exactly as you left it.
- **Multi-project Spaces** — a single Space can span multiple repositories.
- **Global search + command palette** (`⌘/Ctrl+P`) — find/switch to a Space by name or a project it contains; create a Space or open the Overview from the palette.
- **Reorderable activity bar** — drag or right-click to reorder icons; Spaces leads by default; order persists across restarts.
- **Attention aggregation** — a parked Space aggregates the attention of its sessions and nudges you when one needs input.

### Coexistence & migration

Spaces sit alongside the existing **Projects** (repo organization) and **Sessions** (raw provider discovery) surfaces. On first launch after upgrading, existing sessions and layout **migrate automatically** into a starter **"My Work"** Space; unassigned/loose sessions remain fully usable. Work started without picking a Space is auto-wrapped in an **"Untitled Space N"** linked to its originating project.

### Architecture (follows existing patterns)

- New `spaceStore` (Zustand) owns Space lifecycle, parking, and workspace snapshot swap; persisted to `spaces.json` in userData via a main-process `spacesPersistence` service and a typed preload channel.
- Running terminals are preserved across switches via the existing out-of-React `terminalRegistry` (attach/detach, never destroy).
- Unsaved editor buffers are stashed on park (`parkedEditorBuffers`) and reconciled on resume.

### Testing

Unit + e2e coverage for persistence, switching, parking, attention aggregation, multi-project Spaces, workspace snapshotting, and activity-bar ordering. Full suite green (792 unit passing), `npm run build` green.

### Versioning

Ships the Spaces batch: `package.json` → **0.31.1**, with `CHANGELOG.md` sections `[0.30.0]` (Spaces core), `[0.31.0]` (session/palette/activity-bar follow-ups), and `[0.31.1]` (Untitled Space N auto-naming).
