### PR TITLE
feat: move a tab/session to another Space without restarting it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] — 2026-07-14
+
+### Features
+
+- Move a tab to another Space: right-click any session, terminal, editor, or diff tab and pick **Move to space** to send it to a different Space (or a brand-new one) without restarting it — the session keeps running and its scrollback is preserved.
+
 ## [0.31.1] — 2026-07-14
 
 ### Improvements
@@ -676,7 +682,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.31.1...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.32.0...HEAD
+[0.32.0]: https://github.com/Ron537/DPlex/compare/v0.31.1...v0.32.0
 [0.31.1]: https://github.com/Ron537/DPlex/compare/v0.31.0...v0.31.1
 [0.31.0]: https://github.com/Ron537/DPlex/compare/v0.30.0...v0.31.0
 [0.30.0]: https://github.com/Ron537/DPlex/compare/v0.29.0...v0.30.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.31.1",
+  "version": "0.32.0",
   "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/renderer/src/components/terminal/GroupTabBar.tsx
+++ b/src/renderer/src/components/terminal/GroupTabBar.tsx
@@ -12,9 +12,11 @@ import { useTerminalStore } from '../../stores/terminalStore'
 import { requestCloseTab } from '../../stores/closeConfirmStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useProjectStore } from '../../stores/projectStore'
+import { useSpaceStore } from '../../stores/spaceStore'
 import { useFocusFilter } from '../../hooks/useFocusFilter'
 import { StatusDot } from '../common/StatusDot'
 import { PopoverMenu } from '../common/PopoverMenu'
+import { SpaceAvatar } from '../spaces/SpaceAvatar'
 import { TAB_COLORS } from '../../utils/tabColors'
 import { labelForVisual } from '../../utils/sessionStatusVisual'
 import { effectiveSessionVisual } from '../../utils/sessionPairing'
@@ -57,6 +59,11 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
 
   const sessions = useSessionStore((s) => s.sessions)
   const projects = useProjectStore((s) => s.projects)
+  const spaces = useSpaceStore((s) => s.spaces)
+  const activeSpaceId = useSpaceStore((s) => s.activeSpaceId)
+  const moveTabToSpace = useSpaceStore((s) => s.moveTabToSpace)
+  const moveTabToNewSpace = useSpaceStore((s) => s.moveTabToNewSpace)
+  const otherSpaces = spaces.filter((s) => s.id !== activeSpaceId)
   const { isolate, dim, matches } = useFocusFilter()
   // Mirror EditorGroup's effective-active-tab derivation: in isolate mode a
   // group's stored activeTabId may point at a now-hidden tab, in which case the
@@ -470,6 +477,56 @@ export function GroupTabBar({ group, isActiveGroup }: GroupTabBarProps): React.J
                   </button>
                 </div>
                 <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+                {!isDashboardTab(menuTab) && (
+                  <>
+                    <div
+                      className="px-3 pt-1.5 pb-1 text-[10px] font-semibold uppercase"
+                      style={{ color: 'var(--dplex-text-faint)', letterSpacing: '0.08em' }}
+                    >
+                      Move to space
+                    </div>
+                    <div className="max-h-[188px] overflow-y-auto">
+                      {otherSpaces.map((sp) => (
+                        <button
+                          key={sp.id}
+                          type="button"
+                          title={`Move to ${sp.name}`}
+                          onClick={() => {
+                            moveTabToSpace(menu.tabId, sp.id)
+                            setMenu(null)
+                          }}
+                          className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+                          style={{ color: 'var(--dplex-text)' }}
+                        >
+                          <SpaceAvatar space={sp} size={16} radius={5} />
+                          <span className="truncate">{sp.name}</span>
+                        </button>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={() => {
+                          moveTabToNewSpace(menu.tabId)
+                          setMenu(null)
+                        }}
+                        className="flex items-center gap-2 w-full px-3 py-1.5 text-xs hover:bg-[var(--dplex-hover)]"
+                        style={{ color: 'var(--dplex-text-muted)' }}
+                      >
+                        <span
+                          className="grid place-items-center rounded"
+                          style={{
+                            width: 16,
+                            height: 16,
+                            border: '1px dashed var(--dplex-border-strong)'
+                          }}
+                        >
+                          <Plus size={10} />
+                        </span>
+                        New space
+                      </button>
+                    </div>
+                    <div className="my-1" style={{ borderTop: '1px solid var(--dplex-border)' }} />
+                  </>
+                )}
                 {isTerminalTab(menuTab) && (
                   <button
                     type="button"

--- a/src/renderer/src/services/fileEditorRegistry.ts
+++ b/src/renderer/src/services/fileEditorRegistry.ts
@@ -69,13 +69,25 @@ export function isFileEditorDirty(tabId: string): boolean {
  * store swaps the active workspace out.
  */
 export function stashAllDirtyFileEditors(): void {
-  for (const [tabId, reg] of registry) {
-    const buffer = reg.handle.getDirtyBuffer()
-    if (buffer) stashParkedEditorBuffer(tabId, buffer)
-    // onChange editors also flush their pending debounced save to disk at park
-    // time, so an edit within the debounce window survives a quit-while-parked.
-    // The stash above remains the in-session restore + conflict-detection
-    // baseline; the resume path reconciles the two (adopts disk when identical).
-    reg.handle.flushIfAutoSave()
-  }
+  for (const tabId of registry.keys()) stashDirtyFileEditor(tabId)
+}
+
+/**
+ * Stash a single mounted editor's unsaved buffer + flush its pending auto-save.
+ *
+ * Used both by {@link stashAllDirtyFileEditors} (park) and when a single tab is
+ * MOVED to another Space: the editor unmounts here and remounts there, consuming
+ * the stash. (Contrast closeTerminal, which CLEARS the stash because a closed tab
+ * never remounts.) No-op when no editor is mounted for the tab.
+ */
+export function stashDirtyFileEditor(tabId: string): void {
+  const reg = registry.get(tabId)
+  if (!reg) return
+  const buffer = reg.handle.getDirtyBuffer()
+  if (buffer) stashParkedEditorBuffer(tabId, buffer)
+  // onChange editors also flush their pending debounced save to disk here, so an
+  // edit within the debounce window survives a quit-while-parked. The stash above
+  // remains the in-session restore + conflict-detection baseline; the resume path
+  // reconciles the two (adopts disk when identical).
+  reg.handle.flushIfAutoSave()
 }

--- a/src/renderer/src/stores/spaceStore.ts
+++ b/src/renderer/src/stores/spaceStore.ts
@@ -3,6 +3,7 @@ import type { EditorTab, Space, WorkspaceSnapshot } from '../types'
 import { isTerminalTab } from '../types'
 import {
   EMPTY_WORKSPACE,
+  injectTabIntoSnapshot,
   reconstructWorkspace,
   serializeWorkspaceSnapshot,
   type PersistedWorkspaceSnapshot
@@ -14,7 +15,11 @@ import { useTerminalStore, setWorkspaceSink } from './terminalStore'
 import { useProjectStore } from './projectStore'
 import { useSessionStore } from './sessionStore'
 import { destroyTerminal, cancelExitHandler } from '../services/terminalRegistry'
-import { stashAllDirtyFileEditors, isFileEditorDirty } from '../services/fileEditorRegistry'
+import {
+  stashAllDirtyFileEditors,
+  stashDirtyFileEditor,
+  isFileEditorDirty
+} from '../services/fileEditorRegistry'
 import { clearParkedEditorBuffer, hasParkedEditorBuffer } from '../services/parkedEditorBuffers'
 
 const SPACES_VERSION = 1
@@ -65,6 +70,16 @@ export interface SpaceState {
    *  or already includes the project. Used when work for an unbound project is
    *  started from within a space. */
   addProjectToSpace: (id: string, projectId: string) => void
+  /** Move a single tab from the ACTIVE space's live workspace into a background
+   *  target space, without restarting it: its terminal/session keeps running in
+   *  the registry and re-attaches when the target space is opened. The tab's
+   *  project (if any) is bound to the target. No-op when the target is missing,
+   *  is the active space, or the tab isn't in the live workspace. */
+  moveTabToSpace: (tabId: string, targetSpaceId: string) => void
+  /** Create a fresh background space (neutral "Untitled Space N" name) and move
+   *  the tab into it, without restarting it. No-op when the tab isn't in the live
+   *  workspace (so an invalid id never leaves an empty orphan space behind). */
+  moveTabToNewSpace: (tabId: string) => void
   /** Remove a project id from every space that references it (called when the
    *  project is deleted from the Projects panel) so no space keeps a dangling
    *  binding. If the removed id was a space's primary (projectIds[0]), the next
@@ -510,6 +525,56 @@ export const useSpaceStore = create<SpaceState>((set, get) => ({
       )
     }))
     get().persist()
+  },
+
+  moveTabToSpace: (tabId, targetSpaceId) => {
+    const { activeSpaceId, spaces } = get()
+    const target = spaces.find((s) => s.id === targetSpaceId)
+    // Only the active space's tabs are live/mounted, so the source is always the
+    // active space; moving to the active space (or a missing one) is a no-op.
+    if (!target || targetSpaceId === activeSpaceId) return
+
+    // Preserve any unsaved edits of a moved file editor across its unmount here /
+    // remount in the target, then detach WITHOUT destroying the PTY or closing
+    // the session. detachTab returns null if the tab isn't in the live workspace.
+    stashDirtyFileEditor(tabId)
+    const tab = useTerminalStore.getState().detachTab(tabId)
+    if (!tab) return
+
+    const project = findProjectForTab(tab, useProjectStore.getState().projects)
+    const now = Date.now()
+    set((state) => ({
+      spaces: state.spaces.map((s) =>
+        s.id === targetSpaceId
+          ? {
+              ...s,
+              workspace: injectTabIntoSnapshot(s.workspace, tab),
+              projectIds:
+                project && !s.projectIds.includes(project.id)
+                  ? [...s.projectIds, project.id]
+                  : s.projectIds,
+              updatedAt: now
+            }
+          : s
+      )
+    }))
+    // buildPersistedFile serializes the active space from the LIVE terminal store
+    // (tab already gone) and the target from its stored workspace (tab present),
+    // so there's no duplication — the active space's own stored snapshot is left
+    // intentionally stale until it next backgrounds. Attention re-aggregates from
+    // the snapshots. A moved fileEditor/fileDiff may briefly coexist with an
+    // equivalent tab already in the target (two views of one file, VS Code-style,
+    // non-lossy); the dashboard singleton is excluded from the move menu instead.
+    get().persist()
+  },
+
+  moveTabToNewSpace: (tabId) => {
+    // Only spin up a destination when the tab is actually live/movable, so an
+    // invalid id can't leave an empty orphan space behind.
+    const live = useTerminalStore.getState().groups.some((g) => g.tabs.some((t) => t.id === tabId))
+    if (!live) return
+    const id = get().createSpace({ name: nextUntitledSpaceName(get().spaces), activate: false })
+    get().moveTabToSpace(tabId, id)
   },
 
   pruneProject: (projectId) => {

--- a/src/renderer/src/stores/terminalStore.ts
+++ b/src/renderer/src/stores/terminalStore.ts
@@ -132,6 +132,13 @@ interface TerminalState {
     providerId?: string
   ) => string
   closeTerminal: (terminalId: string) => void
+  /** Remove a tab from the live workspace WITHOUT destroying its terminal or
+   *  closing its session, returning the removed tab (promoted out of preview) so
+   *  it can be injected into another Space's snapshot. The PTY keeps running in
+   *  the registry and re-attaches when the tab mounts again; empty groups/layout
+   *  are pruned exactly like closeTerminal. Returns null when the tab isn't in
+   *  the live workspace. */
+  detachTab: (tabId: string) => EditorTab | null
   setActiveGroup: (groupId: string) => void
   setActiveTerminalInGroup: (groupId: string, terminalId: string) => void
   renameTerminal: (terminalId: string, title: string) => void
@@ -352,6 +359,57 @@ export const useTerminalStore = create<TerminalState>((set, get) => ({
       layout: aliveGroups.length > 0 ? newLayout : { type: 'group', groupId: 'group-0' },
       activeGroupId: newActiveGroupId
     })
+  },
+
+  detachTab: (tabId) => {
+    const state = get()
+    let removed: EditorTab | undefined
+    for (const g of state.groups) {
+      const found = g.tabs.find((t) => t.id === tabId)
+      if (found) {
+        removed = found
+        break
+      }
+    }
+    if (!removed) return null
+
+    // Same removal/prune logic as closeTerminal, minus every side effect: no
+    // destroyTerminal, no session close, no parked-buffer clear. The terminal
+    // survives in the registry so the tab can re-attach in its new Space. Nothing
+    // fires synchronously here, so a plain (non-re-read) state pass is safe.
+    const updatedGroups = state.groups.map((g) => {
+      const idx = g.tabs.findIndex((t) => t.id === tabId)
+      if (idx === -1) return g
+      const newTabs = g.tabs.filter((t) => t.id !== tabId)
+      const newActive =
+        g.activeTabId === tabId ? (newTabs[Math.max(0, idx - 1)]?.id ?? null) : g.activeTabId
+      return {
+        ...g,
+        tabs: newTabs,
+        activeTabId: newActive ?? '',
+        previewTabId: g.previewTabId === tabId ? undefined : g.previewTabId
+      }
+    })
+
+    const emptyGroupIds = updatedGroups.filter((g) => g.tabs.length === 0).map((g) => g.id)
+    const aliveGroups = updatedGroups.filter((g) => g.tabs.length > 0)
+
+    let newLayout = state.layout
+    for (const gid of emptyGroupIds) {
+      const pruned = removeGroupFromLayout(newLayout, gid)
+      if (pruned) newLayout = pruned
+    }
+
+    const newActiveGroupId =
+      aliveGroups.find((g) => g.id === state.activeGroupId)?.id ?? aliveGroups[0]?.id ?? null
+
+    set({
+      groups: aliveGroups,
+      layout: aliveGroups.length > 0 ? newLayout : { type: 'group', groupId: 'group-0' },
+      activeGroupId: newActiveGroupId
+    })
+
+    return promoteOnMove(removed)
   },
 
   setActiveGroup: (groupId) => {

--- a/src/renderer/src/utils/workspaceSnapshot.ts
+++ b/src/renderer/src/utils/workspaceSnapshot.ts
@@ -62,6 +62,44 @@ export const EMPTY_WORKSPACE: WorkspaceSnapshot = {
   activeGroupId: null
 }
 
+let movedGroupSeq = 0
+
+/**
+ * Inject a live tab into a (background) Space's workspace snapshot, focusing it.
+ * Used to move a tab from the active Space into another Space without touching
+ * its terminal: the PTY keeps running in the registry and re-attaches when the
+ * target Space is next opened. Pure — returns a new snapshot, never mutates the
+ * input; the caller owns removing the tab from its source (terminalStore
+ * .detachTab).
+ *
+ * - Empty target → a fresh single group holding the tab becomes the whole
+ *   workspace. The new group id is non-numeric (`group-moved-*`) so it can never
+ *   collide with the `group-<n>` ids syncGroupCounter tracks once the snapshot is
+ *   later swapped live.
+ * - Non-empty target → the tab is appended to the target's active group (or the
+ *   first group as a fallback) and focused there.
+ */
+export function injectTabIntoSnapshot(snap: WorkspaceSnapshot, tab: EditorTab): WorkspaceSnapshot {
+  if (snap.groups.length === 0) {
+    movedGroupSeq += 1
+    const groupId = `group-moved-${Date.now()}-${movedGroupSeq}`
+    return {
+      layout: { type: 'group', groupId },
+      groups: [{ id: groupId, tabs: [tab], activeTabId: tab.id }],
+      activeGroupId: groupId
+    }
+  }
+  const targetGroupId =
+    snap.groups.find((g) => g.id === snap.activeGroupId)?.id ?? snap.groups[0].id
+  return {
+    ...snap,
+    activeGroupId: targetGroupId,
+    groups: snap.groups.map((g) =>
+      g.id === targetGroupId ? { ...g, tabs: [...g.tabs, tab], activeTabId: tab.id } : g
+    )
+  }
+}
+
 /**
  * Serialize a live workspace snapshot to its persisted (lossy) form. Only AI
  * session terminal tabs (they carry a `command`) and PERMANENT

--- a/tests/unit/space-store.test.ts
+++ b/tests/unit/space-store.test.ts
@@ -22,7 +22,8 @@ import { useProjectStore, type ResolvedAISession } from '../../src/renderer/src/
 import { startProjectSession, openProjectTerminal } from '../../src/renderer/src/utils/spaceStart'
 import {
   stashParkedEditorBuffer,
-  clearParkedEditorBuffer
+  clearParkedEditorBuffer,
+  hasParkedEditorBuffer
 } from '../../src/renderer/src/services/parkedEditorBuffers'
 import { registerFileEditor } from '../../src/renderer/src/services/fileEditorRegistry'
 import type {
@@ -1205,5 +1206,146 @@ describe('spaceStore.spaceHasUnsavedEditors', () => {
 
     expect(spaceHasUnsavedEditors('A')).toBe(true)
     unregister()
+  })
+})
+
+describe('spaceStore.moveTabToSpace', () => {
+  it('moves a live tab into a background space, keeping the session running', () => {
+    useProjectStore.setState({
+      projects: [{ id: 'p1', name: 'repo-a', path: '/repo-a', addedAt: '' }],
+      activeProjectId: null
+    } as never)
+    seed(
+      {
+        id: 'A',
+        groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a'), aiTab('a2', 'sa2', '/repo-a')])]
+      },
+      [{ id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }]
+    )
+
+    useSpaceStore.getState().moveTabToSpace('a2', 'B')
+
+    // a2 left the live (active) workspace; a1 stays.
+    const live = useTerminalStore.getState().groups.flatMap((g) => g.tabs.map((t) => t.id))
+    expect(live).toEqual(['a1'])
+    // a2 landed in B's stored snapshot, focused, alongside b1.
+    const B = useSpaceStore.getState().spaces.find((s) => s.id === 'B')!
+    const bTabs = B.workspace.groups.flatMap((g) => g.tabs.map((t) => t.id))
+    expect(bTabs).toEqual(['b1', 'a2'])
+    const bGroup = B.workspace.groups.find((g) => g.tabs.some((t) => t.id === 'a2'))!
+    expect(bGroup.activeTabId).toBe('a2')
+    // Project of the moved tab (cwd /repo-a → p1) is bound to the target.
+    expect(B.projectIds).toContain('p1')
+    // The whole point: the terminal is NEVER destroyed and the session NEVER closed.
+    expect(destroyTerminal).not.toHaveBeenCalled()
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('injects into an empty background space as a new group and can empty the source', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([]) }
+    ])
+
+    useSpaceStore.getState().moveTabToSpace('a1', 'B')
+
+    const B = useSpaceStore.getState().spaces.find((s) => s.id === 'B')!
+    expect(B.workspace.groups).toHaveLength(1)
+    expect(B.workspace.groups[0].tabs.map((t) => t.id)).toEqual(['a1'])
+    expect(B.workspace.activeGroupId).toBe(B.workspace.groups[0].id)
+    // The active space is now empty (like closing its last tab) but still active.
+    expect(useTerminalStore.getState().groups).toHaveLength(0)
+    expect(useSpaceStore.getState().activeSpaceId).toBe('A')
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('serializes without duplicating the moved tab (active from live, target from snapshot)', () => {
+    seed(
+      {
+        id: 'A',
+        groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a'), aiTab('a2', 'sa2', '/repo-a')])]
+      },
+      [{ id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }]
+    )
+    useSpaceStore.getState().moveTabToSpace('a2', 'B')
+
+    saveSpacesSync.mockClear()
+    useSpaceStore.getState().persistNow()
+    const file = saveSpacesSync.mock.calls[0][0] as {
+      spaces: { id: string; workspace: { groups: { tabs: { id: string }[] }[] } }[]
+    }
+    const ids = (id: string): string[] =>
+      file.spaces.find((s) => s.id === id)!.workspace.groups.flatMap((g) => g.tabs.map((t) => t.id))
+    expect(ids('A')).toEqual(['a1']) // moved tab gone from the active space
+    expect(ids('B')).toContain('a2') // present in the target exactly once
+    expect(ids('B').filter((x) => x === 'a2')).toHaveLength(1)
+  })
+
+  it('is a no-op when the target is the active space, missing, or the tab is not live', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [
+      { id: 'B', workspace: snapshot([group('gB', [aiTab('b1', 'sb1', '/repo-b')])]) }
+    ])
+    const before = useSpaceStore.getState().spaces
+
+    useSpaceStore.getState().moveTabToSpace('a1', 'A') // target === active
+    useSpaceStore.getState().moveTabToSpace('a1', 'nope') // missing target
+    useSpaceStore.getState().moveTabToSpace('ghost', 'B') // tab not in live workspace
+
+    expect(useTerminalStore.getState().groups.flatMap((g) => g.tabs.map((t) => t.id))).toEqual([
+      'a1'
+    ])
+    expect(useSpaceStore.getState().spaces).toBe(before) // no state churn
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('preserves a moved file editor unsaved buffer via the parked stash', () => {
+    const fe = fileTab('fe1', '/repo-a', 'src/x.ts', { dirty: true })
+    seed({ id: 'A', groups: [mixedGroup('gA', [fe])] }, [{ id: 'B', workspace: snapshot([]) }])
+    // Register a mounted editor with a dirty buffer so the move stashes it.
+    const handle = {
+      isDirty: () => true,
+      getDirtyBuffer: () => ({ content: 'edited', baseline: 'orig', savedViewState: null }),
+      flushIfAutoSave: vi.fn()
+    }
+    const unregister = registerFileEditor('fe1', handle as never)
+
+    useSpaceStore.getState().moveTabToSpace('fe1', 'B')
+
+    // The editor's unsaved buffer was stashed (survives unmount→remount in B).
+    expect(hasParkedEditorBuffer('fe1')).toBe(true)
+    clearParkedEditorBuffer('fe1')
+    unregister()
+  })
+})
+
+describe('spaceStore.moveTabToNewSpace', () => {
+  it('creates a background untitled space and moves the tab into it', () => {
+    seed(
+      {
+        id: 'A',
+        groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a'), aiTab('a2', 'sa2', '/repo-a')])]
+      },
+      []
+    )
+
+    useSpaceStore.getState().moveTabToNewSpace('a2')
+
+    const st = useSpaceStore.getState()
+    expect(st.spaces).toHaveLength(2)
+    const created = st.spaces.find((s) => s.id !== 'A')!
+    expect(created.name).toMatch(/^Untitled Space \d+$/)
+    // The new space stays in the background; A remains active.
+    expect(st.activeSpaceId).toBe('A')
+    expect(created.workspace.groups.flatMap((g) => g.tabs.map((t) => t.id))).toEqual(['a2'])
+    // a2 left the live workspace; a1 stays.
+    expect(useTerminalStore.getState().groups.flatMap((g) => g.tabs.map((t) => t.id))).toEqual([
+      'a1'
+    ])
+    expect(destroyTerminal).not.toHaveBeenCalled()
+  })
+
+  it('is a no-op (creates no space) when the tab is not live', () => {
+    seed({ id: 'A', groups: [group('gA', [aiTab('a1', 'sa1', '/repo-a')])] }, [])
+    useSpaceStore.getState().moveTabToNewSpace('ghost')
+    expect(useSpaceStore.getState().spaces).toHaveLength(1)
   })
 })

--- a/tests/unit/terminal-detach-tab.test.ts
+++ b/tests/unit/terminal-detach-tab.test.ts
@@ -1,0 +1,162 @@
+/**
+ * Unit tests for `terminalStore.detachTab` — the removal half of the
+ * "move a tab to another Space" feature. detachTab must mirror closeTerminal's
+ * removal/prune invariants EXACTLY while never destroying the terminal or closing
+ * the session (the PTY keeps running in the registry so the tab can re-attach in
+ * its new Space). Runs in node env.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { useTerminalStore } from '../../src/renderer/src/stores/terminalStore'
+import type {
+  EditorGroup,
+  EditorTab,
+  FileEditorTab,
+  LayoutNode,
+  TerminalTab
+} from '../../src/renderer/src/types'
+
+const destroy = vi.fn()
+const closeSession = vi.fn().mockResolvedValue(undefined)
+
+function setupWindow(): void {
+  ;(globalThis as { window?: unknown }).window = {
+    dplex: {
+      sessions: {
+        saveWorkspace: vi.fn().mockResolvedValue(undefined),
+        saveWorkspaceSync: vi.fn(),
+        close: (...a: unknown[]) => closeSession(...a)
+      },
+      pty: { destroy: (...a: unknown[]) => destroy(...a) }
+    },
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }
+}
+
+function termTab(id: string): TerminalTab {
+  return {
+    id,
+    title: id,
+    cwd: '/r',
+    command: 'copilot',
+    sessionId: `s-${id}`,
+    providerId: 'copilot-cli'
+  }
+}
+
+function previewTab(id: string): FileEditorTab {
+  return {
+    id,
+    title: id,
+    kind: 'fileEditor',
+    rootFs: '/r',
+    rootLabel: 'r',
+    relPath: `src/${id}.ts`,
+    preview: true
+  }
+}
+
+function reset(groups: EditorGroup[], layout: LayoutNode, activeGroupId: string | null): void {
+  useTerminalStore.setState({ groups, layout, activeGroupId, restored: false } as never)
+}
+
+beforeEach(() => {
+  setupWindow()
+  destroy.mockReset()
+  closeSession.mockClear()
+})
+afterEach(() => vi.restoreAllMocks())
+
+describe('terminalStore.detachTab', () => {
+  it('returns null and leaves state untouched when the tab is not live', () => {
+    reset(
+      [{ id: 'g1', tabs: [termTab('a')], activeTabId: 'a' }],
+      { type: 'group', groupId: 'g1' },
+      'g1'
+    )
+    const before = useTerminalStore.getState().groups
+    const out = useTerminalStore.getState().detachTab('ghost')
+    expect(out).toBeNull()
+    expect(useTerminalStore.getState().groups).toBe(before)
+  })
+
+  it('never destroys the terminal or closes the session', () => {
+    reset(
+      [{ id: 'g1', tabs: [termTab('a'), termTab('b')], activeTabId: 'a' }],
+      { type: 'group', groupId: 'g1' },
+      'g1'
+    )
+    const out = useTerminalStore.getState().detachTab('a')
+    expect((out as TerminalTab).id).toBe('a')
+    expect(destroy).not.toHaveBeenCalled()
+    expect(closeSession).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the previous tab when the removed tab was active', () => {
+    reset(
+      [{ id: 'g1', tabs: [termTab('a'), termTab('b'), termTab('c')], activeTabId: 'b' }],
+      { type: 'group', groupId: 'g1' },
+      'g1'
+    )
+    useTerminalStore.getState().detachTab('b')
+    const g = useTerminalStore.getState().groups.find((x) => x.id === 'g1')!
+    expect(g.tabs.map((t) => t.id)).toEqual(['a', 'c'])
+    expect(g.activeTabId).toBe('a') // newTabs[max(0, idx-1)] = index 0
+  })
+
+  it('clears previewTabId and promotes the returned preview tab out of preview', () => {
+    const pv = previewTab('pv')
+    reset(
+      [{ id: 'g1', tabs: [termTab('a'), pv], activeTabId: 'pv', previewTabId: 'pv' }],
+      { type: 'group', groupId: 'g1' },
+      'g1'
+    )
+    const out = useTerminalStore.getState().detachTab('pv') as FileEditorTab
+    const g = useTerminalStore.getState().groups.find((x) => x.id === 'g1')!
+    expect(g.previewTabId).toBeUndefined()
+    expect(g.activeTabId).toBe('a')
+    expect(out.preview).toBe(false) // promoteOnMove clears the preview flag
+  })
+
+  it('prunes an emptied group and collapses the split layout, recomputing activeGroupId', () => {
+    const layout: LayoutNode = {
+      type: 'split',
+      direction: 'horizontal',
+      children: [
+        { type: 'group', groupId: 'g1' },
+        { type: 'group', groupId: 'g2' }
+      ]
+    }
+    reset(
+      [
+        { id: 'g1', tabs: [termTab('a')], activeTabId: 'a' },
+        { id: 'g2', tabs: [termTab('b')], activeTabId: 'b' }
+      ],
+      layout,
+      'g1'
+    )
+    useTerminalStore.getState().detachTab('a')
+    const st = useTerminalStore.getState()
+    expect(st.groups.map((g) => g.id)).toEqual(['g2'])
+    // The split collapses to the surviving group node.
+    expect(st.layout).toEqual({ type: 'group', groupId: 'g2' })
+    expect(st.activeGroupId).toBe('g2')
+  })
+
+  it('resets to an empty workspace when the last tab is detached', () => {
+    reset(
+      [{ id: 'g1', tabs: [termTab('a')], activeTabId: 'a' }],
+      { type: 'group', groupId: 'g1' },
+      'g1'
+    )
+    const out = useTerminalStore.getState().detachTab('a')
+    const st = useTerminalStore.getState()
+    expect((out as EditorTab).id).toBe('a')
+    expect(st.groups).toHaveLength(0)
+    expect(st.layout).toEqual({ type: 'group', groupId: 'group-0' })
+    expect(st.activeGroupId).toBeNull()
+    expect(destroy).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/workspace-snapshot.test.ts
+++ b/tests/unit/workspace-snapshot.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import {
   EMPTY_WORKSPACE,
+  injectTabIntoSnapshot,
   reconstructWorkspace,
   serializeWorkspaceSnapshot
 } from '../../src/renderer/src/utils/workspaceSnapshot'
@@ -243,5 +244,63 @@ describe('reconstructWorkspace', () => {
   it('EMPTY_WORKSPACE has no groups', () => {
     expect(EMPTY_WORKSPACE.groups).toHaveLength(0)
     expect(EMPTY_WORKSPACE.activeGroupId).toBeNull()
+  })
+})
+
+describe('injectTabIntoSnapshot', () => {
+  it('creates a fresh focused group when the target snapshot is empty', () => {
+    const tab = aiTab('t1', 's1', '/repo-a')
+    const out = injectTabIntoSnapshot(EMPTY_WORKSPACE, tab)
+    expect(out.groups).toHaveLength(1)
+    expect(out.groups[0].tabs.map((t) => t.id)).toEqual(['t1'])
+    expect(out.groups[0].activeTabId).toBe('t1')
+    expect(out.activeGroupId).toBe(out.groups[0].id)
+    // The layout points at the new group, whose id is non-numeric so it can
+    // never collide with the `group-<n>` ids syncGroupCounter tracks.
+    expect(out.layout).toEqual({ type: 'group', groupId: out.groups[0].id })
+    expect(out.groups[0].id.startsWith('group-moved-')).toBe(true)
+    // Pure: the shared EMPTY_WORKSPACE constant is never mutated.
+    expect(EMPTY_WORKSPACE.groups).toHaveLength(0)
+  })
+
+  it('generates a unique group id for each empty-target injection', () => {
+    const a = injectTabIntoSnapshot(EMPTY_WORKSPACE, aiTab('t1', 's1', '/r'))
+    const b = injectTabIntoSnapshot(EMPTY_WORKSPACE, aiTab('t2', 's2', '/r'))
+    expect(a.groups[0].id).not.toBe(b.groups[0].id)
+  })
+
+  it('appends the tab to the active group and focuses it when the target is non-empty', () => {
+    const snap: WorkspaceSnapshot = {
+      layout: {
+        type: 'split',
+        direction: 'horizontal',
+        children: [
+          { type: 'group', groupId: 'g1' },
+          { type: 'group', groupId: 'g2' }
+        ]
+      },
+      groups: [group('g1', [aiTab('a', 'sa', '/r')]), group('g2', [aiTab('b', 'sb', '/r')])],
+      activeGroupId: 'g2'
+    }
+    const out = injectTabIntoSnapshot(snap, aiTab('c', 'sc', '/r'))
+    // Landed in the active group g2, focused there; g1 untouched; layout intact.
+    expect(out.groups.find((g) => g.id === 'g2')!.tabs.map((t) => t.id)).toEqual(['b', 'c'])
+    expect(out.groups.find((g) => g.id === 'g2')!.activeTabId).toBe('c')
+    expect(out.groups.find((g) => g.id === 'g1')!.tabs.map((t) => t.id)).toEqual(['a'])
+    expect(out.activeGroupId).toBe('g2')
+    expect(out.layout).toEqual(snap.layout)
+    // Pure: input untouched.
+    expect(snap.groups.find((g) => g.id === 'g2')!.tabs).toHaveLength(1)
+  })
+
+  it('falls back to the first group when activeGroupId does not resolve', () => {
+    const snap: WorkspaceSnapshot = {
+      layout: { type: 'group', groupId: 'g1' },
+      groups: [group('g1', [aiTab('a', 'sa', '/r')])],
+      activeGroupId: null
+    }
+    const out = injectTabIntoSnapshot(snap, aiTab('c', 'sc', '/r'))
+    expect(out.groups[0].tabs.map((t) => t.id)).toEqual(['a', 'c'])
+    expect(out.activeGroupId).toBe('g1')
   })
 })


### PR DESCRIPTION
## Summary

Adds a **Move to space** action to the tab right-click menu. Right-click any session, terminal, editor, or diff tab → **Move to space** → pick an existing background Space or **New space…**. The tab moves **without restarting** — the PTY keeps running and its scrollback is preserved, exactly like switching Spaces today.

## How it stays safe (no restart, no duplication)

- **`detachTab`** (`terminalStore`) removes the tab from the live workspace with **no** `destroyTerminal`/`sessions.close`, so the registry PTY survives. It mirrors `closeTerminal`'s prune / active-tab-fallback / empty-layout-reset logic, but side-effect-free.
- **`injectTabIntoSnapshot`** (`workspaceSnapshot`, pure) inserts the tab into the target Space's stored snapshot. Moved-group ids are non-numeric (`group-moved-…`) so they can't collide with the live group counter. The tab re-attaches when the target Space is opened.
- **`moveTabToSpace` / `moveTabToNewSpace`** (`spaceStore`) stash any dirty editor buffer **before** detach and restore it on remount — no unsaved work lost. `moveTabToNewSpace` validates tab liveness before creating the Space, so an invalid id never leaves an empty orphan.
- No duplication on persist: the active Space serializes from the live `terminalStore`; background Spaces serialize from their stored snapshot — a moved tab lives in exactly one.
- **Dashboard** tabs are excluded from the menu (they're coded singletons; two would be invalid. Sessions / editors / diffs stay movable.

## Tests

 (4),  parity (6, new file), / (7). Full suite **809 pass**;  (web+node) 0,  0, 
> dplex@0.32.0 build
> npm run typecheck && electron-vite build


> dplex@0.32.0 typecheck
> npm run typecheck:node && npm run typecheck:web


> dplex@0.32.0 typecheck:node
> tsc --noEmit -p tsconfig.node.json --composite false


> dplex@0.32.0 typecheck:web
> tsc --noEmit -p tsconfig.web.json --composite false

vite v7.3.5 building ssr environment for production...
transforming...
✓ 41 modules transformed.
rendering chunks...
out/main/index.js  249.73 kB
✓ built in 300ms
vite v7.3.5 building ssr environment for production...
transforming...
✓ 1 modules transformed.
rendering chunks...
out/preload/index.js  11.82 kB
✓ built in 18ms
vite v7.3.5 building client environment for production...
transforming...
✓ 3173 modules transformed.
rendering chunks...
../../out/renderer/index.html                                   0.59 kB
../../out/renderer/assets/codicon-ngg6Pgfi.ttf                121.97 kB
../../out/renderer/assets/editor.worker-BKBmkYkj.js           540.94 kB
../../out/renderer/assets/json.worker-r5IVm0zS.js             840.03 kB
../../out/renderer/assets/html.worker-5fBvJVFp.js           1,241.56 kB
../../out/renderer/assets/css.worker-CsqbzYvt.js            1,865.96 kB
../../out/renderer/assets/ts.worker-CL8L56yC.js            13,264.04 kB
../../out/renderer/assets/index-DElSBbgn.css                   63.71 kB
../../out/renderer/assets/editor-B6UfNlAV.css                 206.31 kB
../../out/renderer/assets/azcli-BEAhqcuE.js                     1.30 kB
../../out/renderer/assets/javascript-NK41XoAj.js                1.34 kB
../../out/renderer/assets/ini-BcQysCTb.js                       1.67 kB
../../out/renderer/assets/csp-D_3BK2Wp.js                       1.70 kB
../../out/renderer/assets/scheme-D7PxodDG.js                    2.36 kB
../../out/renderer/assets/bat-Bqkp9Cfu.js                       2.66 kB
../../out/renderer/assets/flow9-ZSTChSMd.js                     2.76 kB
../../out/renderer/assets/xml-Bc6ivxWR.js                       2.79 kB
../../out/renderer/assets/sb-Chfc_wZF.js                        2.81 kB
../../out/renderer/assets/pla-DEV89yYj.js                       2.87 kB
../../out/renderer/assets/dockerfile--oxj0cAH.js                3.02 kB
../../out/renderer/assets/pascaligo-VA_LQ1oU.js                 3.25 kB
../../out/renderer/assets/lua-hNsuGJkO.js                       3.43 kB
../../out/renderer/assets/bicep-DIlfshcM.js                     3.44 kB
../../out/renderer/assets/objective-c-B1L1C5EC.js               3.48 kB
../../out/renderer/assets/cameligo-CLaaYNMV.js                  3.51 kB
../../out/renderer/assets/graphql-BeiGgjIU.js                   3.77 kB
../../out/renderer/assets/lexon-C1U0m2n9.js                     3.81 kB
../../out/renderer/assets/typespec-R77Ln7Jb.js                  3.90 kB
../../out/renderer/assets/sparql-DxuVdnRl.js                    3.94 kB
../../out/renderer/assets/mips-CJm71dS3.js                      4.14 kB
../../out/renderer/assets/m3-6ko6q9-_.js                        4.15 kB
../../out/renderer/assets/sophia-D7pU0Y1d.js                    4.27 kB
../../out/renderer/assets/shell-vZEubQ82.js                     4.48 kB
../../out/renderer/assets/go-brnMpFrj.js                        4.49 kB
../../out/renderer/assets/fsharp-D2uoxuLH.js                    4.51 kB
../../out/renderer/assets/pascal-DMQyD4Xk.js                    4.71 kB
../../out/renderer/assets/r-CtqYUQ6l.js                         4.80 kB
../../out/renderer/assets/less-B7Qaxw-O.js                      5.00 kB
../../out/renderer/assets/tcl-Bb4GCwBr.js                       5.05 kB
../../out/renderer/assets/liquid-B8XgBeM4.js                    5.12 kB
../../out/renderer/assets/qsharp-BWK6YLKm.js                    5.14 kB
../../out/renderer/assets/cypher-D0--_GAN.js                    5.15 kB
../../out/renderer/assets/java-Dt3iMn2o.js                      5.16 kB
../../out/renderer/assets/kotlin-Ddo1SjA5.js                    5.20 kB
../../out/renderer/assets/hcl-CrX1Es2W.js                       5.21 kB
../../out/renderer/assets/redis-O7gSt3oh.js                     5.25 kB
../../out/renderer/assets/restructuredtext-B-KQCVu_.js          5.33 kB
../../out/renderer/assets/powershell-BXiKvz7Z.js                5.39 kB
../../out/renderer/assets/coffee-CzJ5oEdj.js                    5.51 kB
../../out/renderer/assets/mdx-Cecne8cD.js                       5.80 kB
../../out/renderer/assets/yaml-D5FPtmAe.js                      5.85 kB
../../out/renderer/assets/css-i3rI3_64.js                       6.10 kB
../../out/renderer/assets/cssMode-B7Vhtqd2.js                   6.18 kB
../../out/renderer/assets/rust-B1c0VCeq.js                      6.27 kB
../../out/renderer/assets/apex-DVGUZ64i.js                      6.39 kB
../../out/renderer/assets/python-BiogkVWP.js                    6.47 kB
../../out/renderer/assets/dart-vLMHv35g.js                      6.48 kB
../../out/renderer/assets/markdown-B0YTnTxW.js                  6.65 kB
../../out/renderer/assets/swift-CbF6f74o.js                     6.92 kB
../../out/renderer/assets/htmlMode-AezzU2yJ.js                  6.92 kB
../../out/renderer/assets/msdax-BBeIktCY.js                     6.95 kB
../../out/renderer/assets/csharp-BJeIuvde.js                    6.98 kB
../../out/renderer/assets/html-BiyFUo0z.js                      7.59 kB
../../out/renderer/assets/typescript-Blo3z6fz.js                7.88 kB
../../out/renderer/assets/ecl-CeuUgzaZ.js                       7.94 kB
../../out/renderer/assets/cpp-CcN6f0ik.js                       8.22 kB
../../out/renderer/assets/pug-BxCXwerb.js                       8.26 kB
../../out/renderer/assets/vb-Bm6ESA0Q.js                        8.33 kB
../../out/renderer/assets/scss-B42qMyAu.js                      9.07 kB
../../out/renderer/assets/wgsl-_KPae5vw.js                      9.78 kB
../../out/renderer/assets/st-C-b0Dh53.js                       10.15 kB
../../out/renderer/assets/twig-DvgEGWAV.js                     10.26 kB
../../out/renderer/assets/handlebars-BDMlsH9N.js               10.37 kB
../../out/renderer/assets/julia-Cm3ItYL_.js                    10.54 kB
../../out/renderer/assets/scala-DbVzH-3O.js                    10.70 kB
../../out/renderer/assets/systemverilog-BOC0OOdC.js            11.63 kB
../../out/renderer/assets/php-Bkx1qpkQ.js                      12.48 kB
../../out/renderer/assets/protobuf-CndvAUGu.js                 12.68 kB
../../out/renderer/assets/perl-DC0Z0tlO.js                     12.82 kB
../../out/renderer/assets/razor-CvalZOxK.js                    13.30 kB
../../out/renderer/assets/clojure-fcgFaMHx.js                  13.94 kB
../../out/renderer/assets/ruby-DCd4DmAr.js                     15.31 kB
../../out/renderer/assets/sql-BAGepFCR.js                      15.56 kB
../../out/renderer/assets/mysql-BWiizXSn.js                    16.16 kB
../../out/renderer/assets/redshift-CvYMMYZY.js                 16.33 kB
../../out/renderer/assets/pgsql-DaSGFTLp.js                    18.25 kB
../../out/renderer/assets/elixir-eLfY1jWH.js                   18.74 kB
../../out/renderer/assets/postiats-CVVurEnu.js                 19.30 kB
../../out/renderer/assets/powerquery-BQ_t1ZiQ.js               21.65 kB
../../out/renderer/assets/abap-D5KwWAsZ.js                     22.97 kB
../../out/renderer/assets/solidity-yHOxYChb.js                 26.03 kB
../../out/renderer/assets/jsonMode-DCne4IbN.js                 29.15 kB
../../out/renderer/assets/tsMode-AfWabkze.js                   40.36 kB
../../out/renderer/assets/freemarker2-C558Rqdu.js              42.13 kB
../../out/renderer/assets/lspLanguageFeatures-BnzQHw0u.js      61.70 kB
../../out/renderer/assets/index-fedW5TL4.js                 1,970.55 kB
../../out/renderer/assets/editor.main-CrOn6ND8.js           7,297.32 kB
✓ built in 27.72s ✓.

## Review

Dual-model review (Claude Opus 4.8 + GPT-5.6 Sol): both **Approve with suggestions**. The one Minor finding (moving a dashboard singleton) was fixed by gating dashboards out of the menu.

## Versioning

MINOR bump **0.31.1 → 0.32.0** + customer-facing  changelog entry.

🤖 Generated with GitHub Copilot CLI
EOF
)