### PR TITLE
docs: reposition DPlex as mission control for AI coding agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 # DPlex
 
-**A desktop workspace for the AI CLI sessions you run every day.**
+**Mission control for your AI coding agents.**
 
-DPlex **discovers** every **Copilot CLI** / **Claude Code** session you've ever started, lets you **resume** any of them in one click, and **auto-restores every open session tab** the next time you open the app — splits, order, working directory, and resume command preserved. On top of that: the multiplexer essentials — split panes, tabs, projects, worktrees, and a built-in VSCode-style Source Control view.
+DPlex runs **Copilot CLI**, **Claude Code**, and any provider you add across **many repos in parallel** — in one window. Group everything a task needs into a named, multi-repo **Space**; watch a **dashboard** that tells you which of your running agents is blocked on *you* right now; resume any past session in a click; and reopen the app after a reboot with every tab, split, and working directory exactly where you left it. Underneath it's a full workspace too — split panes, tabs, worktrees, a file editor, and a VSCode-style Source Control view.
 
 [![Tests](https://github.com/Ron537/DPlex/actions/workflows/tests.yml/badge.svg)](https://github.com/Ron537/DPlex/actions/workflows/tests.yml)
 [![CodeQL](https://github.com/Ron537/DPlex/actions/workflows/codeql.yml/badge.svg)](https://github.com/Ron537/DPlex/actions/workflows/codeql.yml)
@@ -15,7 +15,7 @@ DPlex **discovers** every **Copilot CLI** / **Claude Code** session you've ever 
 [![Discussions](https://img.shields.io/github/discussions/Ron537/DPlex)](https://github.com/Ron537/DPlex/discussions)
 
 
-[Quick install](#quick-install) · [Features](#features) · [Screenshots](#screenshots) · [How DPlex compares](#how-dplex-compares) · [Architecture](./docs/architecture.md) · [Add a provider](./docs/providers.md) · [Privacy](./PRIVACY.md) · [Contributing](./CONTRIBUTING.md)
+[Quick install](#quick-install) · [Features](#features) · [Screenshots](#screenshots) · [Where DPlex fits](#where-dplex-fits) · [Architecture](./docs/architecture.md) · [Add a provider](./docs/providers.md) · [Privacy](./PRIVACY.md) · [Contributing](./CONTRIBUTING.md)
 
 </div>
 
@@ -38,18 +38,25 @@ DPlex **discovers** every **Copilot CLI** / **Claude Code** session you've ever 
 
 ## Why DPlex?
 
-When working with AI CLI tools across multiple projects, you end up with a mess of terminal windows — a Copilot session here, a Claude session there, plus regular shells scattered everywhere, and not a single one of them survives a reboot. DPlex gives you one home for all of it, with **AI session management as the headline feature**:
+When you're driving several AI coding agents across several repos, you end up with a mess of terminal windows — a Copilot session here, a Claude session there, regular shells scattered everywhere — no single view of which one is waiting on you, and not one of them survives a reboot. DPlex gives you one home for the whole fleet:
 
-- **🗂️ Discover every past session.** DPlex reads each provider's data directory and surfaces every Copilot CLI / Claude Code session you've ever started — searchable by name, ID, summary, or workspace.
-- **▶️ Resume in one click.** Click any past session and it opens in a new tab with the correct resume command and original CWD. No copy-pasting session IDs from `~/.copilot/...`.
-- **⏹️ Close active sessions from the sidebar.** Stop running AI sessions without hunting for their terminal — closing a tab fully terminates the underlying process.
-- **🗑️ Delete from disk.** Remove a session's stored data when you're done, with confirmation.
-- **♻️ Auto-restore session tabs across restarts.** Quit the app, reopen it tomorrow — every AI session tab snaps back exactly where it was, with the right resume command, CWD, splits, and tab order preserved.
-- **One window** for everything: split panes, tabs, and an activity bar (Projects · Sessions · Source Control).
-- **Project-aware workflow** — group sessions by project, start a new AI session in any folder with one click.
-- **Worktree-friendly** — first-class Git worktree support so concurrent feature work doesn't pollute your main checkout.
-- **Built-in Source Control** — VSCode-style changes view scoped to whichever project (or worktree) you pick.
-- **No telemetry. No analytics.** Read [PRIVACY.md](./PRIVACY.md) — it's a one-page promise, backed by `grep`-able source.
+- **🚀 Multi-repo Spaces.** Group everything a task needs — its projects, AI sessions, terminals, and exact split layout — into a named, color-coded Space, and switch between Spaces without restarting anything. The Space you leave keeps working in the background and still nudges you when one of its sessions needs you.
+- **⚡ Parallel agents, side by side.** Run many AI sessions at once in splits and tabs — resume a past one straight into a split next to the agent you already have open.
+- **🔔 Attention inbox across every session.** One aggregated bell tells you which sessions are *waiting for approval*, *waiting for input*, or *finished* — across every repo and provider — so you never babysit a terminal to catch the moment an agent needs you.
+- **📊 Insights dashboard.** A bird's-eye view of your fleet: what's running, what's blocked on you, the oldest request still waiting, stale and longest-running sessions, uncommitted changes across all your repos, activity trends, and your Copilot/Claude mix.
+- **🗂️ Every past session, unified.** Discover every Copilot CLI / Claude Code session you've ever started — from every repo, in one searchable sidebar — and resume any of it in one click, in a new tab with the right working directory.
+- **♻️ Comes back after a reboot.** Quit the app, reopen it tomorrow — every AI session tab snaps back exactly where it was, with the right resume command, CWD, splits, and tab order preserved.
+- **🧰 A full workspace too.** Split panes, tabs, first-class Git worktrees, a file explorer/editor, and a VSCode-style Source Control view with a commit graph — scoped to whichever project or worktree you pick.
+- **🧩 Provider-agnostic.** Copilot CLI and Claude Code out of the box, and any other AI CLI you add via one TypeScript interface.
+- **🔒 No telemetry. No analytics.** Read [PRIVACY.md](./PRIVACY.md) — it's a one-page promise, backed by `grep`-able source.
+
+### "My AI CLI already has a built-in resume picker, though"
+
+- **One list for everything.** Every session across every AI CLI you use — Copilot CLI, Claude Code, and any provider you add — from *every* repo, in one searchable sidebar. No launching a tool and paging through its own picker, project by project.
+- **One click, zero context-switch.** Click a session and it resumes in a new tab — or drop it into a split next to the agent you're already running. A built-in picker makes you stop what you're doing; DPlex doesn't.
+- **It's the front door, not the whole house.** Resuming is just the entry point to parallel agents in splits, multi-repo **Spaces**, a dashboard that shows which of your running sessions is blocked on *you*, and a workspace that comes back after a reboot with every tab in place.
+
+A built-in picker reopens *one* session in *one* tool. DPlex orchestrates your whole agent fleet — across every provider, every repo, in one window.
 
 ## Quick install
 
@@ -314,20 +321,14 @@ CI logs and SBOMs are attached to every release.
 
 (`⌘` = `Ctrl` on Linux/Windows.)
 
-## How DPlex compares
+## Where DPlex fits
 
-There are great tools in adjacent niches. DPlex isn't trying to replace any of them — it's optimizing for one specific workflow: **running multiple AI CLI sessions across multiple projects without losing your place.**
+DPlex isn't a terminal emulator, and it isn't an AI-native editor — it's the **orchestration layer above the AI CLIs you already use.** If you're happy driving a single agent in a single terminal, you may not need it. It earns its place the moment you're running **several agents, across several repos, at once** and need one surface to launch them, resume them, group them into Spaces, and see which one is waiting on you.
 
-| Tool                       | Niche                                  | Where it differs from DPlex                                                                            |
-| -------------------------- | -------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| **tmux** / **Zellij**      | Terminal multiplexer, server-side      | Powerful but generic; no AI-tool awareness, no project sidebar, no session discovery.                  |
-| **Warp**                   | AI-augmented terminal                  | Beautiful, but the AI is *theirs*, not the CLI tool you already use. Closed source.                    |
-| **iTerm2** / **WezTerm**   | Best-in-class terminal emulators       | More polished as terminals; no orchestration of external AI sessions.                                  |
-| **VS Code terminal panel** | Embedded terminals in the IDE          | Fine for ad-hoc shells; not designed for managing many concurrent AI sessions across many repos.       |
-| **Wave Terminal**          | AI-focused terminal                    | Adjacent vision; broader scope, more opinionated UI. DPlex is narrower and Electron-portable today.    |
-| **Zed / Cursor**           | AI-native editors                      | They embed the AI in the editor; DPlex orchestrates the AI you already use from the terminal.          |
+- **vs. a plain terminal or multiplexer** — those move characters around; DPlex understands *sessions*, *projects*, and *providers*, and remembers them across restarts.
+- **vs. an AI-native editor or terminal** — those embed *their* AI; DPlex orchestrates the CLI agents *you* choose, and stays out of their way.
 
-If your goal is "I want to start a Claude session in repo A today, a Copilot session in repo B tomorrow, find yesterday's sessions whenever I need them, resume any of them in one click, and reopen the app next week with every tab right where I left it" — that's DPlex.
+If your goal is "I want a Claude session in repo A and a Copilot session in repo B running side by side, grouped into a Space I can switch to instantly, with one glance telling me which agent is blocked on me — and the whole thing back exactly where I left it after a reboot" — that's DPlex.
 
 ## FAQ / Troubleshooting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dplex",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dplex",
-      "version": "0.32.0",
+      "version": "0.33.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -2800,6 +2800,16 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react/node_modules/react-refresh": {
+      "version": "0.18.0",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/react-refresh/-/react-refresh-0.18.0.tgz",
+      "integrity": "sha1-Lc6X9P6TKk2BQvoWMOR1wXKcgGI=",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -8352,16 +8362,6 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-refresh": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
-      "integrity": "sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/read-binary-file-arch": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dplex",
   "version": "0.33.0",
-  "description": "A terminal multiplexer built for AI-assisted development. Manage multiple AI CLI sessions (Copilot, Claude, and more) alongside regular terminals in one window.",
+  "description": "Mission control for your AI coding agents. Run Copilot CLI, Claude Code, and more across many repos in parallel — grouped into multi-repo Spaces, with a dashboard that shows which sessions need you, one-click resume, and every tab restored after a reboot.",
   "main": "./out/main/index.js",
   "author": {
     "name": "Ron Borysowski",

--- a/site/index.html
+++ b/site/index.html
@@ -6,8 +6,8 @@
 <meta name="theme-color" content="#0b0c0f" />
 <meta name="color-scheme" content="dark" />
 
-<title>DPlex — AI session management for Copilot CLI &amp; Claude Code</title>
-<meta name="description" content="DPlex is an open-source desktop app for AI session management: discover, resume, and auto-restore every GitHub Copilot CLI and Claude Code session you've ever started — across projects, in one window. MIT-licensed, no telemetry, macOS/Windows/Linux." />
+<title>DPlex — mission control for your AI coding agents (Copilot CLI &amp; Claude Code)</title>
+<meta name="description" content="DPlex is an open-source desktop control center for AI coding agents: run Copilot CLI, Claude Code, and more across many repos in parallel, grouped into multi-repo Spaces, with a dashboard that shows which sessions need you, one-click resume, and every tab restored after a reboot. MIT-licensed, no telemetry, macOS/Windows/Linux." />
 <meta name="keywords" content="DPlex, AI session management, Copilot CLI session manager, Claude Code session manager, AI coding agent multiplexer, resume Copilot CLI session, manage Claude Code sessions, Copilot CLI GUI, Claude Code GUI, terminal multiplexer AI, AI session tabs" />
 <meta name="author" content="Ron Borysowski" />
 <meta name="robots" content="index, follow, max-image-preview:large, max-snippet:-1" />
@@ -16,8 +16,8 @@
 <!-- Open Graph -->
 <meta property="og:type" content="website" />
 <meta property="og:site_name" content="DPlex" />
-<meta property="og:title" content="DPlex — AI session management for Copilot CLI &amp; Claude Code" />
-<meta property="og:description" content="Discover, resume, and auto-restore every Copilot CLI and Claude Code session you've ever started, in one window. Open source, MIT, no telemetry." />
+<meta property="og:title" content="DPlex — mission control for your AI coding agents" />
+<meta property="og:description" content="Run Copilot CLI, Claude Code, and more across many repos in parallel — grouped into multi-repo Spaces, with a dashboard that shows which sessions need you and every tab restored after a reboot. Open source, MIT, no telemetry." />
 <meta property="og:url" content="https://ron537.github.io/DPlex/" />
 <meta property="og:image" content="https://ron537.github.io/DPlex/assets/01-hero-projects.png" />
 <meta property="og:image:width" content="1600" />
@@ -27,8 +27,8 @@
 
 <!-- Twitter / X -->
 <meta name="twitter:card" content="summary_large_image" />
-<meta name="twitter:title" content="DPlex — AI session management for Copilot CLI &amp; Claude Code" />
-<meta name="twitter:description" content="Discover, resume, and auto-restore every Copilot CLI and Claude Code session you've ever started. Open source · MIT · No telemetry." />
+<meta name="twitter:title" content="DPlex — mission control for your AI coding agents" />
+<meta name="twitter:description" content="Run Copilot CLI, Claude Code &amp; more across many repos in parallel, grouped into Spaces, with a dashboard showing which sessions need you. Open source · MIT · No telemetry." />
 <meta name="twitter:image" content="https://ron537.github.io/DPlex/assets/01-hero-projects.png" />
 
 <!-- Performance hints -->
@@ -54,7 +54,7 @@
   "applicationCategory": "DeveloperApplication",
   "applicationSubCategory": "Terminal multiplexer for AI coding agents",
   "operatingSystem": "macOS, Windows, Linux",
-  "description": "DPlex is an open-source desktop app for AI session management. It discovers every GitHub Copilot CLI and Claude Code session you've ever started, lets you resume any of them in one click, and auto-restores every session tab across app restarts.",
+  "description": "DPlex is an open-source desktop control center for AI coding agents. It runs GitHub Copilot CLI, Claude Code, and other AI CLIs across many repos in parallel — grouped into multi-repo Spaces, with a dashboard that surfaces which sessions need you, one-click resume of any past session, and every tab restored across app restarts.",
   "url": "https://ron537.github.io/DPlex/",
   "downloadUrl": "https://github.com/Ron537/DPlex/releases/latest",
   "softwareVersion": "latest",
@@ -144,10 +144,10 @@
     },
     {
       "@type": "Question",
-      "name": "How is DPlex different from tmux, Zellij, or Warp?",
+      "name": "How is DPlex different from a terminal, multiplexer, or AI editor?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "tmux and Zellij are generic terminal multiplexers — they have no concept of AI sessions, projects, or session discovery. Warp embeds its own AI in a closed-source terminal. DPlex orchestrates the AI CLI tools you already use (Copilot CLI, Claude Code, …) and adds project sidebar, session history, resume in one click, and workspace persistence."
+        "text": "DPlex isn't a terminal emulator or an AI-native editor — it's the orchestration layer above the AI CLIs you already use. A plain terminal or multiplexer just moves characters around; DPlex understands sessions, projects, and providers, and remembers them across restarts. AI-native editors and terminals embed their own AI; DPlex orchestrates the CLI agents you choose (Copilot CLI, Claude Code, and any you add), runs many in parallel across repos, and shows which one is waiting on you."
       }
     },
     {
@@ -179,7 +179,7 @@
       <a href="#screenshots">Screenshots</a>
       <a href="#whats-new">What's new</a>
       <a href="#install">Install</a>
-      <a href="#compare">Compare</a>
+      <a href="#compare">Where it fits</a>
       <a href="#faq">FAQ</a>
       <a href="./changelog/">Changelog</a>
       <a href="https://github.com/Ron537/DPlex/blob/main/docs/architecture.md" rel="noopener">Docs</a>
@@ -196,9 +196,9 @@
       <svg width="11" height="11" viewBox="0 0 12 12" fill="currentColor" aria-hidden="true"><circle cx="6" cy="6" r="5"/></svg>
       Open source · MIT · <span id="version-badge">latest</span>
     </div>
-    <h1>AI session management for <span class="accent">Copilot CLI &amp; Claude Code</span>.</h1>
+    <h1>Mission control for your <span class="accent">AI coding agents</span>.</h1>
     <p class="lede">
-      DPlex is the desktop workspace that discovers every <strong>Copilot CLI</strong> and <strong>Claude Code</strong> session you've ever started, lets you <strong>resume any of them in one click</strong>, and <strong>auto-restores every session tab</strong> the next time you open the app — splits, order, working directory, and resume command preserved.
+      DPlex runs <strong>Copilot CLI</strong>, <strong>Claude Code</strong>, and any provider you add across <strong>many repos in parallel</strong> — grouped into multi-repo <strong>Spaces</strong>, with a <strong>dashboard</strong> that shows which of your running agents is blocked on you right now. Resume any past session in a click, and reopen the app after a reboot with every tab, split, and working directory exactly where you left it.
     </p>
     <div class="cta-row">
       <a href="#install" class="btn btn-primary">
@@ -216,8 +216,8 @@
 
 <section id="features" aria-labelledby="features-heading">
   <div class="container">
-    <h2 id="features-heading">Built around AI session management.</h2>
-    <p class="section-lede">DPlex's headline capability is full-lifecycle control over your AI coding sessions — discover them, resume them, close them, delete them, and never lose your place across restarts.</p>
+    <h2 id="features-heading">One home for your whole agent fleet.</h2>
+    <p class="section-lede">Group work into multi-repo Spaces, run many agents in parallel, and let one dashboard and attention inbox tell you which session needs you — then pick up exactly where you left off after every restart.</p>
     <div class="features">
       <div class="feature">
         <div class="feature-icon" aria-hidden="true">
@@ -414,20 +414,16 @@ npm run dev</code></pre>
 
 <section id="compare" aria-labelledby="compare-heading">
   <div class="container">
-    <h2 id="compare-heading">How DPlex compares.</h2>
-    <p class="section-lede">DPlex isn't trying to replace any of these — it's optimized for one specific workflow: managing AI coding sessions across many projects.</p>
+    <h2 id="compare-heading">Where DPlex fits.</h2>
+    <p class="section-lede">DPlex isn't a terminal emulator, and it isn't an AI-native editor — it's the orchestration layer above the AI CLIs you already use. If you're happy driving a single agent in a single terminal, you may not need it. It earns its place the moment you're running several agents, across several repos, at once.</p>
     <div class="compare">
       <table>
         <thead>
-          <tr><th scope="col">Tool</th><th scope="col">Where it differs from DPlex</th></tr>
+          <tr><th scope="col">Compared to…</th><th scope="col">How DPlex is different</th></tr>
         </thead>
         <tbody>
-          <tr><td>tmux / Zellij</td><td>Powerful but generic; no AI-tool awareness, no project sidebar, no session discovery.</td></tr>
-          <tr><td>Warp</td><td>Beautiful, but the AI is theirs, not the CLI tool you already use. Closed source.</td></tr>
-          <tr><td>iTerm2 / WezTerm</td><td>More polished as terminals; no orchestration of external AI sessions.</td></tr>
-          <tr><td>VS Code terminal panel</td><td>Fine for ad-hoc shells; not designed for managing many concurrent AI sessions across many repos.</td></tr>
-          <tr><td>Wave Terminal</td><td>Adjacent vision; broader scope, more opinionated UI. DPlex is narrower and Electron-portable today.</td></tr>
-          <tr><td>Zed / Cursor</td><td>They embed the AI in the editor; DPlex orchestrates the AI you already use from the terminal.</td></tr>
+          <tr><td>A plain terminal or multiplexer</td><td>Those move characters around. DPlex understands <em>sessions</em>, <em>projects</em>, and <em>providers</em> — and remembers them across restarts.</td></tr>
+          <tr><td>An AI-native editor or terminal</td><td>Those embed <em>their</em> AI. DPlex orchestrates the CLI agents <em>you</em> choose, in parallel, and stays out of their way.</td></tr>
         </tbody>
       </table>
     </div>
@@ -477,9 +473,9 @@ npm run dev</code></pre>
         </div>
       </details>
       <details>
-        <summary>How does DPlex compare to tmux, Warp, or Wave Terminal?</summary>
+        <summary>How is DPlex different from a terminal or AI editor?</summary>
         <div class="faq-body">
-          <p>tmux and Zellij are generic terminal multiplexers — they have no concept of AI sessions, projects, or session history. Warp ships a closed-source terminal with its own embedded AI, not the CLI tools you already use. Wave has an adjacent vision with broader scope and a more opinionated UI; DPlex stays narrow and Electron-portable today.</p>
+          <p>DPlex isn't a terminal emulator or an AI-native editor — it's the orchestration layer above the AI CLIs you already use. A plain terminal or multiplexer just moves characters around; DPlex understands sessions, projects, and providers, and remembers them across restarts. AI-native editors and terminals embed <em>their</em> AI; DPlex orchestrates the CLI agents <em>you</em> choose, runs many in parallel across repos, and shows which one is waiting on you.</p>
         </div>
       </details>
       <details>


### PR DESCRIPTION
## What & why

DPlex started as a session-restore tool, but it's now much more — Spaces, an insights dashboard, an attention inbox, a file editor, and Source Control. The README and marketing copy still led with "terminal multiplexer / AI session management," which lets a reader think "I already have an interactive resume picker" and bounce. This PR repositions the messaging around what's genuinely hard to copy: **orchestrating a fleet of AI coding agents across many repos in parallel, and always knowing which one needs you.**

No app behavior changes — docs/site/metadata only. Per the versioning policy this is a docs-only pass, so **no version bump and no CHANGELOG entry**.

## Changes

**README.md**
- New hero + lede: *"Mission control for your AI coding agents."*
- Reordered **Why DPlex?** to lead with differentiators (Spaces, parallel agents, attention inbox, dashboard), then discovery/resume/restore.
- Added a *"My AI CLI already has a built-in resume picker, though"* rebuttal block — provider-neutral, no flag name-dropping.
- Replaced the named-competitor comparison table with a provider-neutral **"Where DPlex fits"** section (category framing, no product names to date or shame).

**site/index.html**
- Matching hero, title, meta description, OG/Twitter tags, and JSON-LD.
- Features section heading + lede.
- Category-based compare section; de-named FAQ answer + its JSON-LD entry; nav label "Compare" -> "Where it fits."

**package.json**
- Updated description to match the new positioning.

**package-lock.json**
- Lockfile sync (was out of date; `npm ci` failed against it).

## Verification
- Rebuilt the static site (`npm run site:build`) and confirmed zero references to previously-named tools remain.
- Previewed locally at :8080.

Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>
