### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,16 @@ A built-in picker reopens *one* session in *one* tool. DPlex orchestrates your w
 
 ### macOS
 
+**Homebrew (recommended)** — handles the quarantine flag for you and keeps DPlex up to date:
+
+```bash
+brew install --cask ron537/tap/dplex
+```
+
+Upgrade later with `brew upgrade --cask dplex`.
+
+**Manual DMG:**
+
 ```bash
 # Apple Silicon
 curl -L https://github.com/Ron537/DPlex/releases/latest/download/DPlex-arm64.dmg -o DPlex.dmg

--- a/site/index.html
+++ b/site/index.html
@@ -376,7 +376,11 @@
       <button class="install-tab" data-tab="src" type="button" aria-pressed="false">From source</button>
     </div>
     <div id="tab-mac" class="install-block active">
-<pre><code># Apple Silicon
+<pre><code># Homebrew (recommended) — auto-handles quarantine &amp; upgrades
+brew install --cask ron537/tap/dplex
+
+# — or download the DMG directly —
+# Apple Silicon
 curl -L https://github.com/Ron537/DPlex/releases/latest/download/DPlex-arm64.dmg -o DPlex.dmg
 # Intel
 curl -L https://github.com/Ron537/DPlex/releases/latest/download/DPlex-x64.dmg -o DPlex.dmg
@@ -384,7 +388,7 @@ curl -L https://github.com/Ron537/DPlex/releases/latest/download/DPlex-x64.dmg -
 # Drag DPlex to /Applications, then on first launch:
 xattr -dr com.apple.quarantine /Applications/DPlex.app
 open /Applications/DPlex.app</code></pre>
-      <p class="install-note">The <code>xattr</code> line removes the macOS quarantine flag — equivalent to right-click → Open, but cleaner from the terminal. Builds are <a href="https://github.com/Ron537/DPlex/blob/main/.github/workflows/release.yml" rel="noopener">ad-hoc signed</a> and carry <a href="https://docs.github.com/en/actions/security-guides/using-artifact-attestations" rel="noopener">Sigstore provenance</a>.</p>
+      <p class="install-note">Homebrew is the easiest path — it clears the quarantine flag for you and <code>brew upgrade --cask dplex</code> keeps you current. The <code>xattr</code> line does the same for a manual DMG install. Builds are <a href="https://github.com/Ron537/DPlex/blob/main/.github/workflows/release.yml" rel="noopener">ad-hoc signed</a> and carry <a href="https://docs.github.com/en/actions/security-guides/using-artifact-attestations" rel="noopener">Sigstore provenance</a>.</p>
     </div>
     <div id="tab-win" class="install-block" hidden>
 <pre><code># Download the latest installer


### PR DESCRIPTION
Now that the [Homebrew tap](https://github.com/Ron537/homebrew-tap) ships a DPlex cask, this documents the easiest install path.

### Changes
- **README** — macOS section now leads with Homebrew (`brew install --cask ron537/tap/dplex`), noting it auto-clears the quarantine flag and handles upgrades. Manual DMG steps kept as an alternative.
- **Marketing site** (`site/index.html`) — macOS install tab updated to match, with the Homebrew one-liner first.

Docs/site-only — no version bump or changelog entry per policy.
