### PR TITLE
perf(terminal): GPU rendering and pause hidden sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.33.1] — 2026-07-27
+
+### Performance
+
+- Busy terminals now render on the GPU — a heavy AI session no longer freezes the rest of the app.
+- Background tabs stop rendering while hidden, so several heavy sessions at once stay smooth.
+- Faster switching back to a busy session tab.
+- Rapidly switching between sessions that are still starting up no longer stalls the UI.
+- Smoother pane and window resizing with large scrollback.
+
 ## [0.33.0] — 2026-07-23
 
 ### Features
@@ -688,7 +698,8 @@ AI-assisted development.
 - Eight built-in themes (dark and light variants).
 - Keyboard shortcuts for tabs, splits, sidebar, and settings.
 
-[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.33.0...HEAD
+[Unreleased]: https://github.com/Ron537/DPlex/compare/v0.33.1...HEAD
+[0.33.1]: https://github.com/Ron537/DPlex/compare/v0.33.0...v0.33.1
 [0.33.0]: https://github.com/Ron537/DPlex/compare/v0.32.0...v0.33.0
 [0.32.0]: https://github.com/Ron537/DPlex/compare/v0.31.1...v0.32.0
 [0.31.1]: https://github.com/Ron537/DPlex/compare/v0.31.0...v0.31.1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dplex",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "description": "Mission control for your AI coding agents. Run Copilot CLI, Claude Code, and more across many repos in parallel — grouped into multi-repo Spaces, with a dashboard that shows which sessions need you, one-click resume, and every tab restored after a reboot.",
   "main": "./out/main/index.js",
   "author": {

--- a/src/renderer/src/components/settings/SettingsModal.tsx
+++ b/src/renderer/src/components/settings/SettingsModal.tsx
@@ -14,7 +14,6 @@ import { useSettingsStore } from '../../stores/settingsStore'
 import { useSessionStore } from '../../stores/sessionStore'
 import { useUpdateStore } from '../../stores/updateStore'
 import { getThemesByVariant, getTheme } from '../../services/themes'
-import { applyThemeToAll } from '../../services/terminalRegistry'
 import { Switch } from '../common/Switch'
 import type { ShellInfo, AppSettings } from '../../types'
 import { MOD, SHIFT, isMac } from '../../utils/shortcuts'
@@ -322,7 +321,6 @@ export function SettingsModal({ isOpen, onClose }: SettingsModalProps): React.JS
 
   const applyNow = (partial: Partial<AppSettings>): void => {
     updateSettings(partial)
-    if (partial.theme) applyThemeToAll(partial.theme)
   }
 
   const applyDebounced = (partial: Partial<AppSettings>): void => {

--- a/src/renderer/src/components/terminal/EditorGroup.tsx
+++ b/src/renderer/src/components/terminal/EditorGroup.tsx
@@ -128,28 +128,48 @@ export function EditorGroup({ group }: EditorGroupProps): React.JSX.Element {
         onDrop={handleDrop}
         onDragLeave={handleDragLeave}
       >
-        {/* Render all tabs — active on top, inactive hidden but laid out */}
+        {/* Render all tabs; only the group's current tab is displayed.
+            `content-visibility: hidden` is deliberate. `visibility: hidden`
+            doesn't work: xterm pauses its render loop via an
+            IntersectionObserver, and a `visibility: hidden` element still
+            intersects — so every background AI session kept re-rendering and
+            starved the main thread. `display: none` does pause it, but throws
+            away the subtree's rendering state, so returning to a tab costs a
+            full repaint (measured ~34% slower tab switching).
+            `content-visibility: hidden` skips the content — which pauses xterm
+            just the same — while *preserving* that rendering state, so
+            switching back is cheap. Hidden tabs keep their layout box, hence
+            the explicit pointer-events guard below. */}
         {visibleTabs.map((tab) => {
-          const isActive = tab.id === effectiveActiveId
+          const isVisible = tab.id === effectiveActiveId
+          const isFocused = isActiveGroup && isVisible
           return (
             <div
               key={tab.id}
               className="absolute inset-0"
               style={{
-                visibility: isActive ? 'visible' : 'hidden',
-                zIndex: isActive ? 1 : 0
+                contentVisibility: isVisible ? 'visible' : 'hidden',
+                // A hidden tab still occupies its box, so without this a tab
+                // later in DOM order would swallow clicks meant for the
+                // visible one.
+                pointerEvents: isVisible ? undefined : 'none',
+                // Establishes a stacking context so content overlays inside a
+                // tab (e.g. Monaco's z-20 conflict banner) stay below this
+                // group's own overlays at z-index 5/10/20.
+                zIndex: 1
               }}
             >
               {isFileDiffTab(tab) ? (
                 <FileDiffTabView tab={tab} />
               ) : isFileEditorTab(tab) ? (
-                <FileEditorTabView tab={tab} isActive={isActiveGroup && isActive} />
+                <FileEditorTabView tab={tab} isActive={isVisible} />
               ) : isDashboardTab(tab) ? (
-                <DashboardTabView isActive={isActiveGroup && isActive} />
+                <DashboardTabView isActive={isVisible} />
               ) : (
                 <TerminalView
                   terminalId={tab.id}
-                  isActive={isActiveGroup && isActive}
+                  isVisible={isVisible}
+                  isFocused={isFocused}
                   onFocus={activateGroup}
                 />
               )}

--- a/src/renderer/src/components/terminal/TerminalView.tsx
+++ b/src/renderer/src/components/terminal/TerminalView.tsx
@@ -1,38 +1,56 @@
 import { useRef, useEffect } from 'react'
 import { useTerminal } from '../../hooks/useTerminal'
-import { fitTerminal, getTerminalEntry } from '../../services/terminalRegistry'
+import {
+  enableWebglRenderer,
+  fitTerminal,
+  getTerminalEntry,
+  setTerminalVisible
+} from '../../services/terminalRegistry'
 import { Loader2 } from 'lucide-react'
 
 interface TerminalViewProps {
   terminalId: string
-  isActive: boolean
+  /** True when this is the tab currently displayed by its group (regardless of
+   *  which group has focus). Drives fitting and GPU-context acquisition. */
+  isVisible: boolean
+  /** True when this tab is displayed AND its group is the focused one. */
+  isFocused: boolean
   onFocus: () => void
 }
 
 export function TerminalView({
   terminalId,
-  isActive,
+  isVisible,
+  isFocused,
   onFocus
 }: TerminalViewProps): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
   const { ready } = useTerminal({ terminalId, containerRef })
 
-  // Fit and focus when this terminal becomes active
+  // Becoming visible: claim a WebGL context (hidden terminals don't get one)
+  // and refit, since the pane may have been resized while this tab was hidden.
+  // Deferred a frame so the visibility flip has been laid out — measuring a
+  // still-hidden element yields no usable dimensions.
   useEffect(() => {
-    if (isActive) {
+    setTerminalVisible(terminalId, isVisible)
+    if (!isVisible) return
+    const raf = requestAnimationFrame(() => {
+      enableWebglRenderer(terminalId)
       fitTerminal(terminalId)
-      const entry = getTerminalEntry(terminalId)
-      if (entry) entry.term.focus()
+    })
+    return () => {
+      cancelAnimationFrame(raf)
+      setTerminalVisible(terminalId, false)
     }
-  }, [isActive, terminalId])
+  }, [isVisible, terminalId])
 
-  // Focus when terminal becomes ready (first data received)
+  // Focus the terminal once it's the focused tab and has started producing
+  // output (focusing a not-yet-started terminal is a no-op users can't see).
   useEffect(() => {
-    if (ready && isActive) {
-      const entry = getTerminalEntry(terminalId)
-      if (entry) entry.term.focus()
-    }
-  }, [ready, isActive, terminalId])
+    if (!isFocused || !isVisible) return
+    const entry = getTerminalEntry(terminalId)
+    if (entry) entry.term.focus()
+  }, [isFocused, isVisible, ready, terminalId])
 
   return (
     <div
@@ -44,7 +62,7 @@ export function TerminalView({
         // rows × cell-height) shows the same color, not the parent's
         // darker chrome.
         backgroundColor: 'var(--dplex-bg)',
-        ...(isActive
+        ...(isFocused
           ? {
               // Three-sided active ring — top edge is intentionally
               // omitted so the active tab and the terminal area read as

--- a/src/renderer/src/hooks/useTerminal.ts
+++ b/src/renderer/src/hooks/useTerminal.ts
@@ -8,8 +8,9 @@ import {
   getOrCreateTerminal,
   updateTerminalFont,
   updateTerminalMacOptionIsMeta,
-  applyThemeToAll,
+  fitTerminal,
   fireExitHandler,
+  recordTerminalRenderLoad,
   registerPtyDataHandler,
   subscribeTerminalReady,
   markTerminalReady,
@@ -168,11 +169,7 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
 
     // Fit after attaching (needs dimensions from container)
     requestAnimationFrame(() => {
-      try {
-        entry.fitAddon.fit()
-      } catch {
-        // ignore
-      }
+      fitTerminal(terminalId)
     })
 
     // Reflect terminal readiness even when this hook mounted AFTER the PTY was
@@ -254,6 +251,9 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
           for (const item of earlyBuffer) {
             if (item.id === ptyId) {
               entry.term.write(entry.truecolorNormalizer.write(item.data))
+              // Counts toward render load like any other output — an AI CLI's
+              // first full-screen paint usually arrives in this buffer.
+              recordTerminalRenderLoad(terminalId, item.data.length)
               hadData = true
             }
           }
@@ -328,19 +328,26 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
         })
     }
 
-    // ResizeObserver for container size changes
+    // ResizeObserver for container size changes. Coalesced to one fit per
+    // frame: a fit forces a synchronous layout read and, when cols/rows change,
+    // a buffer reflow across the 10k-line scrollback. Sidebar drags and window
+    // resizes fire the observer far faster than that work can complete.
+    // `fitTerminal` ignores hidden tabs — the observer also fires when a tab is
+    // hidden, and fitting then would resize the PTY to a garbage size.
+    let fitFrame: number | null = null
     const resizeObserver = new ResizeObserver(() => {
-      try {
-        entry.fitAddon.fit()
-      } catch {
-        // ignore
-      }
+      if (fitFrame !== null) return
+      fitFrame = requestAnimationFrame(() => {
+        fitFrame = null
+        fitTerminal(terminalId)
+      })
     })
     resizeObserver.observe(container)
 
     return () => {
       // Only detach the DOM element — do NOT destroy the terminal or PTY
       resizeObserver.disconnect()
+      if (fitFrame !== null) cancelAnimationFrame(fitFrame)
       unsubReady()
       if (container.contains(entry.wrapperEl)) {
         container.removeChild(entry.wrapperEl)
@@ -357,11 +364,6 @@ export function useTerminal({ terminalId, containerRef }: UseTerminalOptions): {
   useEffect(() => {
     updateTerminalMacOptionIsMeta(terminalId, settings.macOptionIsMeta)
   }, [terminalId, settings.macOptionIsMeta])
-
-  // Apply theme changes to this terminal
-  useEffect(() => {
-    applyThemeToAll(settings.theme)
-  }, [settings.theme])
 
   return { ready }
 }

--- a/src/renderer/src/services/terminalRegistry.ts
+++ b/src/renderer/src/services/terminalRegistry.ts
@@ -1,7 +1,11 @@
 import { Terminal } from '@xterm/xterm'
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
+import { WebglAddon } from '@xterm/addon-webgl'
 import { getTheme } from './themes'
+import { MAX_WEBGL_CONTEXTS, WebglRendererPool } from './webglRenderer'
+import { RenderLoadTracker } from './terminalRenderLoad'
+import { WebglAttachScheduler } from './webglAttachScheduler'
 import { FlowController } from './flowControl'
 import { isMac } from '../utils/shortcuts'
 import {
@@ -33,6 +37,129 @@ export interface TerminalEntry {
 
 // Global registry — lives outside React lifecycle
 const registry = new Map<string, TerminalEntry>()
+
+/**
+ * Whether a terminal currently has a layout box. Guards against measuring an
+ * entry that is mid-teardown or not yet in the document.
+ *
+ * Note this is deliberately *not* a visibility check: hidden tabs use
+ * `content-visibility: hidden` (see EditorGroup), which keeps their layout box
+ * and resolved dimensions intact. Visibility is tracked explicitly by
+ * TerminalView instead.
+ */
+function isTerminalRendered(entry: TerminalEntry): boolean {
+  return entry.wrapperEl.isConnected && entry.wrapperEl.getClientRects().length > 0
+}
+
+/**
+ * Fit a terminal to its container, but only while it's on screen with a box.
+ *
+ * The box check is not an optimization — it's required for correctness. FitAddon
+ * sizes the terminal from `getComputedStyle(parent)`, and for an element with
+ * no box Chromium returns the *computed* value rather than the used one: our
+ * wrapper's `height: 100%` comes back as the string `"100%"`, which parses to
+ * the number 100. Fitting then resizes the terminal to roughly 10×5 cells and
+ * forwards that to the PTY, wrecking the layout of the AI CLI running inside.
+ *
+ * Hidden tabs are skipped too. They still have a box, so they'd otherwise be
+ * refitted on every pane, window and sidebar resize — and each fit queues a
+ * resize xterm can only flush as a full re-render of a 10k-line scrollback the
+ * moment that tab is shown. TerminalView refits on show instead.
+ */
+function fitIfVisible(terminalId: string, entry: TerminalEntry): void {
+  if (!visibleTerminals.has(terminalId) || !isTerminalRendered(entry)) return
+  try {
+    entry.fitAddon.fit()
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Tabs currently shown by their group, as reported by TerminalView.
+ *
+ * Tracked explicitly rather than sniffed from the DOM: hidden tabs use
+ * `content-visibility: hidden`, which pauses their rendering but *keeps* their
+ * layout box, so geometry can't tell a hidden tab from a shown one.
+ */
+const visibleTerminals = new Set<string>()
+
+// GPU rendering. Attached lazily (on first display) rather than at creation, so
+// restoring a workspace with dozens of tabs doesn't allocate dozens of WebGL
+// contexts up front — see webglRenderer.ts for the LRU/eviction rationale.
+// On-screen terminals are pinned so a background tab can never steal the
+// context out from under a visible split pane.
+const webglPool = new WebglRendererPool(
+  () => new WebglAddon(),
+  MAX_WEBGL_CONTEXTS,
+  (terminalId) => visibleTerminals.has(terminalId),
+  // A context lost mid-session (GPU reset, driver update) drops the terminal
+  // back to the DOM renderer. If it's still the tab on screen, queue a fresh
+  // one instead of waiting for the user to switch away and back. The pool's
+  // per-terminal loss budget stops this from becoming a retry loop.
+  (terminalId) => webglAttach.schedule(terminalId)
+)
+
+// Only terminals that actually push a lot of output get a GPU context — see
+// terminalRenderLoad.ts for why handing one to every terminal is a net loss.
+const renderLoad = new RenderLoadTracker()
+
+/**
+ * Defers and rate-limits GPU-context creation — see webglAttachScheduler.ts for
+ * why an unmanaged attach is felt as a freeze.
+ */
+const webglAttach = new WebglAttachScheduler({
+  canAttach: (terminalId) => {
+    if (webglPool.isUnavailable || webglPool.hasContext(terminalId)) return false
+    if (!visibleTerminals.has(terminalId)) return false
+    const entry = registry.get(terminalId)
+    return Boolean(entry && isTerminalRendered(entry))
+  },
+  attach: (terminalId) => {
+    const entry = registry.get(terminalId)
+    if (!entry) return
+    webglPool.attach(terminalId, (addon) => entry.term.loadAddon(addon))
+  }
+})
+
+/**
+ * Tell the registry whether a terminal is the tab currently on screen.
+ *
+ * Only visible terminals may claim a GPU context: several sessions resuming at
+ * once all flood output and all earn one, but the user is looking at exactly
+ * one of them. Hidden terminals are also skipped when fitting, since xterm has
+ * paused them and TerminalView refits on show anyway.
+ */
+export function setTerminalVisible(terminalId: string, visible: boolean): void {
+  if (visible) {
+    visibleTerminals.add(terminalId)
+    return
+  }
+  visibleTerminals.delete(terminalId)
+  webglAttach.cancel(terminalId)
+}
+
+/**
+ * Move a terminal onto the WebGL renderer if it has earned one. Call when it
+ * becomes visible; it is cheap and idempotent. Terminals that have never pushed
+ * a heavy render load stay on xterm's DOM renderer, which is already smooth for
+ * them and costs nothing to set up.
+ */
+export function enableWebglRenderer(terminalId: string): void {
+  if (!renderLoad.isBusy(terminalId)) return
+  webglAttach.schedule(terminalId)
+}
+
+/**
+ * Account for PTY output that reached a terminal outside the central dispatcher
+ * — currently the early-buffer flush in `useTerminal`, which replays bytes that
+ * arrived before `pty.create()` resolved. An AI CLI's first full-screen paint
+ * often lands there, and it's exactly the kind of load that should promote a
+ * terminal to the GPU renderer.
+ */
+export function recordTerminalRenderLoad(terminalId: string, bytes: number): void {
+  if (renderLoad.record(terminalId, bytes)) webglAttach.schedule(terminalId)
+}
 
 // ── Centralized PTY Data Dispatcher ─────────────────────────────────────
 // Single global IPC listener routes data to the correct terminal via O(1)
@@ -107,6 +234,12 @@ function ensureGlobalListeners(): void {
     if (!handler) return
 
     handler.flowController.write(handler.entry.truecolorNormalizer.write(data))
+
+    // A terminal that starts flooding output is one the DOM renderer can't keep
+    // up with — promote it to the GPU renderer (during idle, off this frame).
+    if (renderLoad.record(handler.terminalId, data.length)) {
+      webglAttach.schedule(handler.terminalId)
+    }
 
     if (!handler.entry.ready) {
       handler.entry.ready = true
@@ -408,6 +541,12 @@ export function destroyTerminal(terminalId: string): void {
   if (entry.cleanupIpc) entry.cleanupIpc()
   if (entry.disposeExtras) entry.disposeExtras()
   if (entry.ptyId) window.dplex.pty.destroy(entry.ptyId)
+  // Free the GPU context before disposing the terminal, so it's returned to the
+  // pool for another tab rather than leaked until the browser reclaims it.
+  webglAttach.cancel(terminalId)
+  visibleTerminals.delete(terminalId)
+  webglPool.forget(terminalId)
+  renderLoad.forget(terminalId)
   entry.term.dispose()
   entry.wrapperEl.remove()
   registry.delete(terminalId)
@@ -427,11 +566,7 @@ export function isTerminalRegistered(terminalId: string): boolean {
 export function fitTerminal(terminalId: string): void {
   const entry = registry.get(terminalId)
   if (!entry) return
-  try {
-    entry.fitAddon.fit()
-  } catch {
-    // ignore
-  }
+  fitIfVisible(terminalId, entry)
 }
 
 export function updateTerminalFont(terminalId: string, fontSize: number, fontFamily: string): void {
@@ -439,11 +574,7 @@ export function updateTerminalFont(terminalId: string, fontSize: number, fontFam
   if (!entry) return
   entry.term.options.fontSize = fontSize
   entry.term.options.fontFamily = fontFamily
-  try {
-    entry.fitAddon.fit()
-  } catch {
-    // ignore
-  }
+  fitIfVisible(terminalId, entry)
 }
 
 export function updateTerminalMacOptionIsMeta(terminalId: string, macOptionIsMeta: boolean): void {
@@ -452,10 +583,21 @@ export function updateTerminalMacOptionIsMeta(terminalId: string, macOptionIsMet
   entry.term.options.macOptionIsMeta = macOptionIsMeta
 }
 
-export function applyThemeToAll(themeId: string): void {
+function applyThemeToAll(themeId: string): void {
   const appTheme = getTheme(themeId)
   for (const [, entry] of registry) {
     entry.term.options.theme = appTheme.terminal
     entry.wrapperEl.style.backgroundColor = appTheme.terminal.background || '#000'
   }
 }
+
+// Keep every registered terminal's palette in sync with the app theme from a
+// single subscription. Each mounted terminal used to run its own effect calling
+// applyThemeToAll, which iterates the whole registry — O(N²) work per theme
+// change in a many-tab workspace. Living here also covers terminals whose hook
+// isn't mounted (tabs parked in a background Space).
+useSettingsStore.subscribe((state, prev) => {
+  if (state.settings.theme !== prev.settings.theme) {
+    applyThemeToAll(state.settings.theme)
+  }
+})

--- a/src/renderer/src/services/terminalRenderLoad.ts
+++ b/src/renderer/src/services/terminalRenderLoad.ts
@@ -1,0 +1,90 @@
+/**
+ * Decides *which* terminals deserve a GPU renderer, based on how much output
+ * they actually push.
+ *
+ * Attaching xterm's WebGL renderer is not free: creating the context involves a
+ * GPU-process handshake, shader compilation and building a glyph atlas. That
+ * work is native, synchronous and unattributable to JS — measured at ~300ms for
+ * the first context in a renderer process. Paying it for every terminal on sight
+ * makes startup and tab switches janky, which is exactly the symptom the GPU
+ * renderer was meant to cure.
+ *
+ * The DOM renderer's cost, by contrast, scales with how much is actually drawn:
+ * a shell sitting at a prompt costs nothing. So only terminals that demonstrate
+ * a heavy render load — an AI CLI repainting a full-screen TUI, a big file being
+ * cat'd — are promoted to the GPU. Everything else stays on the DOM renderer,
+ * where it was already fast.
+ *
+ * "Busy" latches: once a terminal has proven it can flood, it keeps its claim to
+ * a context across hide/show cycles instead of having to re-prove it each time.
+ */
+
+/** Bytes within one window that mark a terminal as render-heavy. A full-screen
+ *  TUI repaint with SGR sequences is ~10-20KB, so this is a handful of repaints
+ *  per second — well above shell prompts and short command output. */
+export const BUSY_BYTES_THRESHOLD = 64 * 1024
+
+/**
+ * Length of the throughput window.
+ *
+ * Windows are tumbling, not sliding: the counter resets once a window expires
+ * rather than tracking per-chunk timestamps. A burst that straddles a boundary
+ * can therefore need a second window to promote. That's deliberate — this runs
+ * on the hottest path in the renderer (every PTY chunk of every terminal), and
+ * the cost of a false negative is only that a heavy terminal waits up to one
+ * extra second for its GPU context. Terminals heavy enough to matter keep
+ * producing output, so they promote on the following window regardless.
+ */
+export const BUSY_WINDOW_MS = 1000
+
+export class RenderLoadTracker {
+  private readonly windows = new Map<string, { bytes: number; startedAt: number }>()
+  private readonly busy = new Set<string>()
+
+  constructor(private readonly now: () => number = () => performance.now()) {}
+
+  /**
+   * Record PTY output for a terminal.
+   *
+   * @returns `true` only on the transition into "busy", so callers can schedule
+   *   the (expensive) GPU attach exactly once instead of on every chunk.
+   */
+  record(terminalId: string, bytes: number): boolean {
+    if (this.busy.has(terminalId)) return false
+
+    const at = this.now()
+    const window = this.windows.get(terminalId)
+    if (!window || at - window.startedAt >= BUSY_WINDOW_MS) {
+      this.windows.set(terminalId, { bytes, startedAt: at })
+      // A single chunk can exceed the threshold on its own (a large paste or a
+      // burst flushed by flow control), which is just as much a reason to
+      // promote as a sustained stream.
+      if (bytes < BUSY_BYTES_THRESHOLD) return false
+    } else {
+      window.bytes += bytes
+      if (window.bytes < BUSY_BYTES_THRESHOLD) return false
+    }
+
+    this.busy.add(terminalId)
+    this.windows.delete(terminalId)
+    return true
+  }
+
+  /** Whether this terminal has ever proven itself render-heavy. */
+  isBusy(terminalId: string): boolean {
+    return this.busy.has(terminalId)
+  }
+
+  /** Promote a terminal without waiting for it to hit the threshold. Used for
+   *  panes we know will be heavy (an AI CLI) the moment they're shown. */
+  markBusy(terminalId: string): void {
+    this.busy.add(terminalId)
+    this.windows.delete(terminalId)
+  }
+
+  /** Drop all state for a destroyed terminal. */
+  forget(terminalId: string): void {
+    this.busy.delete(terminalId)
+    this.windows.delete(terminalId)
+  }
+}

--- a/src/renderer/src/services/webglAttachScheduler.ts
+++ b/src/renderer/src/services/webglAttachScheduler.ts
@@ -1,0 +1,107 @@
+/**
+ * Decides *when* a terminal that has earned a GPU renderer actually gets one.
+ *
+ * Creating a WebGL context is a few hundred milliseconds of synchronous native
+ * work — GPU-process handshake, shader compilation, glyph atlas. Left
+ * unmanaged, that cost lands at the worst possible moments:
+ *
+ *  - inline during startup or the frame after a tab switch, dropping frames;
+ *  - on every terminal a user flicks past while switching tabs;
+ *  - on several sessions at once (a window full of resuming AI CLIs all cross
+ *    the busy threshold together), stacking into a single long freeze.
+ *
+ * So attaches are deferred to idle time, re-checked against `canAttach` when
+ * they finally run (the caller folds "still alive and still on screen" into
+ * that), and spaced apart from one another.
+ */
+
+/** Longest we'll wait for an idle slot before attaching anyway. Long enough to
+ *  clear a startup burst or a tab switch, short enough that a terminal that
+ *  starts hot on a permanently busy main thread still gets the GPU promptly. */
+export const WEBGL_ATTACH_IDLE_TIMEOUT_MS = 2000
+
+/** Minimum spacing between two context creations, so simultaneous promotions
+ *  are felt as separate blips rather than one stall. */
+export const WEBGL_ATTACH_MIN_GAP_MS = 500
+
+interface WebglAttachSchedulerOptions {
+  /** Perform the attach. */
+  attach: (terminalId: string) => void
+  /**
+   * Whether an attach is still worth doing — terminal alive, on screen, no
+   * context yet. Checked when queueing *and* again when the deferred callback
+   * runs, since anything can change while it waits for an idle slot.
+   */
+  canAttach: (terminalId: string) => boolean
+  now?: () => number
+}
+
+export class WebglAttachScheduler {
+  /** Cancellers for attaches waiting on an idle slot, keyed by terminal. */
+  private readonly pending = new Map<string, () => void>()
+  private lastAttachAt = -Infinity
+
+  private readonly attach: (terminalId: string) => void
+  private readonly canAttach: (terminalId: string) => boolean
+  private readonly now: () => number
+
+  constructor(options: WebglAttachSchedulerOptions) {
+    this.attach = options.attach
+    this.canAttach = options.canAttach
+    this.now = options.now ?? ((): number => performance.now())
+  }
+
+  /** Queue an attach for the next idle slot. Idempotent. */
+  schedule(terminalId: string): void {
+    if (this.pending.has(terminalId)) return
+    if (!this.canAttach(terminalId)) return
+    this.pending.set(
+      terminalId,
+      this.whenIdle(() => this.run(terminalId))
+    )
+  }
+
+  /**
+   * Drop a queued attach.
+   *
+   * Called when a tab is hidden or destroyed, so flicking through busy sessions
+   * doesn't queue a context creation for every one passed through. An
+   * already-attached renderer is deliberately untouched — rebuilding it on the
+   * next switch is the very cost being avoided.
+   */
+  cancel(terminalId: string): void {
+    const cancel = this.pending.get(terminalId)
+    if (!cancel) return
+    this.pending.delete(terminalId)
+    cancel()
+  }
+
+  /** Whether an attach is queued for this terminal. */
+  isPending(terminalId: string): boolean {
+    return this.pending.has(terminalId)
+  }
+
+  private run(terminalId: string): void {
+    this.pending.delete(terminalId)
+    if (!this.canAttach(terminalId)) return
+
+    const sinceLast = this.now() - this.lastAttachAt
+    if (sinceLast < WEBGL_ATTACH_MIN_GAP_MS) {
+      const handle = setTimeout(() => this.run(terminalId), WEBGL_ATTACH_MIN_GAP_MS - sinceLast)
+      this.pending.set(terminalId, () => clearTimeout(handle))
+      return
+    }
+
+    this.lastAttachAt = this.now()
+    this.attach(terminalId)
+  }
+
+  private whenIdle(run: () => void): () => void {
+    if (typeof requestIdleCallback === 'function') {
+      const handle = requestIdleCallback(run, { timeout: WEBGL_ATTACH_IDLE_TIMEOUT_MS })
+      return () => cancelIdleCallback(handle)
+    }
+    const handle = setTimeout(run, 0)
+    return () => clearTimeout(handle)
+  }
+}

--- a/src/renderer/src/services/webglRenderer.ts
+++ b/src/renderer/src/services/webglRenderer.ts
@@ -1,0 +1,198 @@
+/**
+ * WebGL renderer management for xterm.js terminals.
+ *
+ * Without a GPU renderer xterm falls back to its DOM renderer, which rebuilds a
+ * `<span>` per style-run per row on every frame. AI CLIs (Copilot/Claude)
+ * repaint a full-screen TUI many times a second, so the DOM renderer saturates
+ * the main thread and freezes the whole app — React, the sidebar, tab switching
+ * and all. The WebGL renderer moves that work to the GPU.
+ *
+ * WebGL contexts are a scarce, browser-wide resource (Chromium keeps roughly a
+ * dozen alive and silently kills the oldest beyond that). DPlex is a
+ * multiplexer, so a user can easily have more terminals than that. Rather than
+ * let the browser evict contexts behind our back — which surfaces as a
+ * terminal that suddenly renders through the slow path again — the pool caps
+ * the number of live contexts itself and evicts the least-recently-shown
+ * terminal. Hidden terminals don't need a GPU context: their render loop is
+ * paused (they're `content-visibility: hidden`, which xterm's
+ * IntersectionObserver reports as not intersecting, while still preserving the
+ * subtree's layout and paint state so showing them again is cheap), and they
+ * re-acquire a context when shown.
+ */
+
+/** Maximum number of simultaneously attached WebGL contexts. Comfortably below
+ *  Chromium's per-process limit while covering any realistic split layout. */
+export const MAX_WEBGL_CONTEXTS = 8
+
+/** After this many context losses, a terminal stays on the DOM renderer. Guards
+ *  against a loss/reattach loop on flaky drivers. */
+export const MAX_CONTEXT_LOSSES = 2
+
+/** After this many failed attachments across all terminals, WebGL is treated as
+ *  unavailable for the session. High enough that a transient failure (e.g. the
+ *  element detached mid-Space-switch) doesn't permanently downgrade rendering,
+ *  low enough that an environment without WebGL2 stops retrying quickly. */
+export const MAX_ATTACH_FAILURES = 3
+
+export interface Disposable {
+  dispose(): void
+}
+
+/** Structural view of `@xterm/addon-webgl`'s `WebglAddon`, so the pool can be
+ *  unit-tested without a real WebGL2 context. */
+export interface WebglAddonLike extends Disposable {
+  onContextLoss(listener: () => void): Disposable
+}
+
+interface AttachedContext {
+  addon: WebglAddonLike
+  lossSubscription: Disposable
+}
+
+export class WebglRendererPool<T extends WebglAddonLike = WebglAddonLike> {
+  /** Insertion order doubles as LRU recency — re-attaching moves an entry to
+   *  the end, and eviction takes from the front. */
+  private readonly attached = new Map<string, AttachedContext>()
+  /** Per-terminal count of context losses AND failed attachments. Both mean
+   *  "this terminal couldn't hold a GPU context", so they share a budget. */
+  private readonly failures = new Map<string, number>()
+  private attachFailures = 0
+  private unavailable = false
+
+  /**
+   * @param createAddon Builds a fresh renderer addon.
+   * @param maxContexts Cap on simultaneously live contexts.
+   * @param isPinned Optional predicate marking terminals that must not be
+   *   evicted — normally "currently on screen". Eviction prefers unpinned
+   *   terminals and only falls back to pinned ones when the cap can't otherwise
+   *   be met (more visible panes than contexts), so a wide split layout never
+   *   has a visible pane silently demoted to the DOM renderer while a hidden
+   *   background tab keeps its context.
+   * @param onContextLost Optional notification that a terminal lost its context
+   *   and has fallen back to the DOM renderer, so the caller can re-queue an
+   *   attach if that terminal is still on screen. Not called for evictions,
+   *   which are deliberate.
+   */
+  constructor(
+    private readonly createAddon: () => T,
+    private readonly maxContexts: number = MAX_WEBGL_CONTEXTS,
+    private readonly isPinned: (terminalId: string) => boolean = () => false,
+    private readonly onContextLost: (terminalId: string) => void = () => {}
+  ) {}
+
+  /**
+   * Ensure `terminalId` is rendering through WebGL. Safe to call on every
+   * activation — it's a no-op when already attached (beyond refreshing LRU
+   * recency). Returns whether the terminal ended up on the WebGL renderer.
+   */
+  attach(terminalId: string, load: (addon: T) => void): boolean {
+    if (this.unavailable) return false
+
+    const existing = this.attached.get(terminalId)
+    if (existing) {
+      this.attached.delete(terminalId)
+      this.attached.set(terminalId, existing)
+      return true
+    }
+
+    if ((this.failures.get(terminalId) ?? 0) >= MAX_CONTEXT_LOSSES) return false
+
+    let addon: T | null = null
+    try {
+      addon = this.createAddon()
+      // Throws in environments without WebGL2 — xterm's DOM renderer stands in.
+      load(addon)
+    } catch {
+      if (addon) {
+        try {
+          addon.dispose()
+        } catch {
+          /* addon may already be half-disposed */
+        }
+      }
+      this.recordFailure(terminalId)
+      return false
+    }
+
+    const boundAddon = addon
+    const lossSubscription = boundAddon.onContextLoss(() => {
+      this.recordFailure(terminalId, false)
+      // A lost context can't be revived — drop the addon so xterm falls back to
+      // the DOM renderer, then let the owner decide whether to queue a fresh
+      // one (it will, if this terminal is still the tab on screen). The
+      // per-terminal loss budget above stops that becoming a retry loop.
+      this.release(terminalId)
+      this.onContextLost(terminalId)
+    })
+
+    this.attached.set(terminalId, { addon: boundAddon, lossSubscription })
+    // A successful attach proves WebGL2 works here, so any earlier failures were
+    // transient — don't let them accumulate toward writing WebGL off entirely.
+    this.attachFailures = 0
+    this.evictOverflow(terminalId)
+    return this.attached.has(terminalId)
+  }
+
+  /** Drop a terminal's WebGL context (it reverts to the DOM renderer). */
+  release(terminalId: string): void {
+    const ctx = this.attached.get(terminalId)
+    if (!ctx) return
+    this.attached.delete(terminalId)
+    try {
+      ctx.lossSubscription.dispose()
+    } catch {
+      /* isolate teardown errors */
+    }
+    try {
+      ctx.addon.dispose()
+    } catch {
+      /* isolate teardown errors */
+    }
+  }
+
+  /** Release and forget all state for a destroyed terminal. */
+  forget(terminalId: string): void {
+    this.release(terminalId)
+    this.failures.delete(terminalId)
+  }
+
+  hasContext(terminalId: string): boolean {
+    return this.attached.has(terminalId)
+  }
+
+  /** True once WebGL has been written off for this session. */
+  get isUnavailable(): boolean {
+    return this.unavailable
+  }
+
+  get size(): number {
+    return this.attached.size
+  }
+
+  private recordFailure(terminalId: string, countsTowardGlobal = true): void {
+    this.failures.set(terminalId, (this.failures.get(terminalId) ?? 0) + 1)
+    // Context *losses* are normal (driver resets, GPU pressure) and must not
+    // disable WebGL globally; failed *attachments* usually mean no WebGL2.
+    if (!countsTowardGlobal) return
+    this.attachFailures++
+    if (this.attachFailures >= MAX_ATTACH_FAILURES) this.unavailable = true
+  }
+
+  private evictOverflow(keep: string): void {
+    if (this.attached.size <= this.maxContexts) return
+    // Two passes: shed hidden terminals first — their render loop is paused, so
+    // losing the context costs them nothing — and only fall back to evicting a
+    // visible pane if that wasn't enough to get under the cap.
+    this.evictPass(keep, true)
+    this.evictPass(keep, false)
+  }
+
+  private evictPass(keep: string, skipPinned: boolean): void {
+    for (const id of this.attached.keys()) {
+      if (this.attached.size <= this.maxContexts) return
+      if (id === keep) continue
+      if (skipPinned && this.isPinned(id)) continue
+      this.release(id)
+    }
+  }
+}

--- a/tests/e2e/gpu-renderer.e2e.spec.ts
+++ b/tests/e2e/gpu-renderer.e2e.spec.ts
@@ -1,0 +1,89 @@
+import { test, expect, type ElectronApplication, type Page } from '@playwright/test'
+import { closeApp, launchApp } from './support/electronApp'
+
+// Regression guard for app-wide jank. Creating a WebGL context costs a few
+// hundred milliseconds of synchronous native work (GPU-process handshake,
+// shader compilation, glyph atlas), so a terminal that isn't rendering heavily
+// must stay on xterm's DOM renderer. Attaching the GPU renderer to every
+// terminal on sight made app startup and tab switches visibly stall.
+test.describe('DPlex GPU renderer policy', () => {
+  let app: ElectronApplication | undefined
+  let window: Page | undefined
+  let userDataDir: string | undefined
+
+  test.beforeEach(async () => {
+    const launched = await launchApp()
+    app = launched.app
+    window = launched.window
+    userDataDir = launched.userDataDir
+  })
+
+  test.afterEach(async () => {
+    await closeApp(app, userDataDir)
+  })
+
+  test('an idle terminal does not allocate a WebGL context', async () => {
+    if (!window) throw new Error('Window not available')
+    await window.waitForSelector('.xterm-screen', { timeout: 20_000 })
+
+    const longTasks = await window.evaluate(async () => {
+      const seen: number[] = []
+      new PerformanceObserver((list) => {
+        for (const e of list.getEntries()) seen.push(e.duration)
+      }).observe({ entryTypes: ['longtask'] })
+      await new Promise((resolve) => setTimeout(resolve, 4_000))
+      return seen
+    })
+
+    // xterm only renders into a <canvas> under the WebGL renderer; the DOM
+    // renderer emits rows of <span>.
+    const canvases = await window.evaluate(
+      () => document.querySelectorAll('.xterm-screen canvas').length
+    )
+    expect(canvases).toBe(0)
+
+    // And nothing should have blocked the main thread long enough to be felt.
+    expect(longTasks.filter((duration) => duration > 100)).toEqual([])
+  })
+
+  test('rapid switching between busy terminals does not freeze the UI', async () => {
+    if (!window) throw new Error('Window not available')
+    await window.waitForSelector('.xterm-screen', { timeout: 20_000 })
+    await window.getByTitle('New terminal (default shell)').click()
+    await window.waitForTimeout(2_000)
+
+    // Fill both terminals deeply, the way a resumed AI session replays output.
+    // This also pushes them past the render-load threshold, so the GPU-context
+    // policy is exercised rather than bypassed.
+    const blob = ('x'.repeat(78) + '\n').repeat(120)
+    for (const key of ['Meta+1', 'Meta+2']) {
+      await window.keyboard.press(key)
+      await window.waitForTimeout(500)
+      for (let i = 0; i < 30; i++) await window.keyboard.insertText(blob)
+      await window.waitForTimeout(1_500)
+    }
+
+    await window.evaluate(() => {
+      const seen: number[] = []
+      ;(window as unknown as { __switchLongTasks: number[] }).__switchLongTasks = seen
+      new PerformanceObserver((list) => {
+        for (const e of list.getEntries()) seen.push(e.duration)
+      }).observe({ entryTypes: ['longtask'] })
+    })
+
+    for (let i = 0; i < 20; i++) {
+      await window.keyboard.press(i % 2 === 0 ? 'Meta+2' : 'Meta+1')
+      await window.waitForTimeout(120)
+    }
+    await window.waitForTimeout(500)
+
+    const longTasks = await window.evaluate(
+      () => (window as unknown as { __switchLongTasks: number[] }).__switchLongTasks
+    )
+
+    // Flicking between two heavy sessions must not queue a GPU-context
+    // creation for each tab passed through — each one is a few hundred
+    // milliseconds of synchronous native work, i.e. a visible freeze.
+    expect(longTasks.filter((duration) => duration > 200)).toEqual([])
+  })
+})

--- a/tests/unit/terminal-render-load.test.ts
+++ b/tests/unit/terminal-render-load.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BUSY_BYTES_THRESHOLD,
+  BUSY_WINDOW_MS,
+  RenderLoadTracker
+} from '../../src/renderer/src/services/terminalRenderLoad'
+
+// Creating a WebGL context costs a few hundred milliseconds of synchronous
+// native work, so only terminals that genuinely flood output should get one.
+// These cover the promotion policy that keeps quiet terminals on xterm's DOM
+// renderer — which is what stops app startup and tab switches from stalling.
+function makeTracker(): { tracker: RenderLoadTracker; advance: (ms: number) => void } {
+  let clock = 0
+  const tracker = new RenderLoadTracker(() => clock)
+  return { tracker, advance: (ms: number) => (clock += ms) }
+}
+
+describe('RenderLoadTracker', () => {
+  it('leaves a quiet terminal on the DOM renderer', () => {
+    const { tracker, advance } = makeTracker()
+    for (let i = 0; i < 50; i++) {
+      expect(tracker.record('t1', 200)).toBe(false)
+      advance(100)
+    }
+    expect(tracker.isBusy('t1')).toBe(false)
+  })
+
+  it('promotes a terminal that crosses the threshold within one window', () => {
+    const { tracker, advance } = makeTracker()
+    const chunk = BUSY_BYTES_THRESHOLD / 4
+
+    expect(tracker.record('t1', chunk)).toBe(false)
+    advance(100)
+    expect(tracker.record('t1', chunk)).toBe(false)
+    advance(100)
+    expect(tracker.record('t1', chunk)).toBe(false)
+    advance(100)
+    // Crossing the threshold reports the transition exactly once.
+    expect(tracker.record('t1', chunk)).toBe(true)
+    expect(tracker.isBusy('t1')).toBe(true)
+  })
+
+  it('reports the busy transition only once, so the GPU attach is scheduled once', () => {
+    const { tracker } = makeTracker()
+    expect(tracker.record('t1', BUSY_BYTES_THRESHOLD)).toBe(true)
+    expect(tracker.record('t1', BUSY_BYTES_THRESHOLD)).toBe(false)
+    expect(tracker.record('t1', BUSY_BYTES_THRESHOLD)).toBe(false)
+  })
+
+  it('promotes on a single oversized chunk (a flow-control burst flush)', () => {
+    const { tracker } = makeTracker()
+    expect(tracker.record('t1', BUSY_BYTES_THRESHOLD + 1)).toBe(true)
+  })
+
+  it('does not accumulate across windows — steady low traffic never promotes', () => {
+    const { tracker, advance } = makeTracker()
+    // Just under the threshold every window: heavy in total, light at any instant.
+    for (let i = 0; i < 20; i++) {
+      expect(tracker.record('t1', BUSY_BYTES_THRESHOLD - 1)).toBe(false)
+      advance(BUSY_WINDOW_MS)
+    }
+    expect(tracker.isBusy('t1')).toBe(false)
+  })
+
+  it('tracks terminals independently', () => {
+    const { tracker } = makeTracker()
+    tracker.record('busy', BUSY_BYTES_THRESHOLD)
+    tracker.record('quiet', 128)
+    expect(tracker.isBusy('busy')).toBe(true)
+    expect(tracker.isBusy('quiet')).toBe(false)
+  })
+
+  it('latches busy so a hidden-then-shown terminal keeps its GPU claim', () => {
+    const { tracker, advance } = makeTracker()
+    tracker.record('t1', BUSY_BYTES_THRESHOLD)
+    advance(BUSY_WINDOW_MS * 100)
+    expect(tracker.isBusy('t1')).toBe(true)
+  })
+
+  it('supports explicit promotion without waiting for the threshold', () => {
+    const { tracker } = makeTracker()
+    expect(tracker.isBusy('t1')).toBe(false)
+    tracker.markBusy('t1')
+    expect(tracker.isBusy('t1')).toBe(true)
+    // Already busy, so no further transition is reported.
+    expect(tracker.record('t1', BUSY_BYTES_THRESHOLD)).toBe(false)
+  })
+
+  it('forgets a destroyed terminal so a recycled id starts fresh', () => {
+    const { tracker } = makeTracker()
+    tracker.record('t1', BUSY_BYTES_THRESHOLD)
+    expect(tracker.isBusy('t1')).toBe(true)
+    tracker.forget('t1')
+    expect(tracker.isBusy('t1')).toBe(false)
+    expect(tracker.record('t1', 128)).toBe(false)
+  })
+
+  it('starts a fresh window after a quiet gap rather than counting stale bytes', () => {
+    const { tracker, advance } = makeTracker()
+    tracker.record('t1', BUSY_BYTES_THRESHOLD - 1)
+    advance(BUSY_WINDOW_MS + 1)
+    // The stale window must be discarded, not topped up into a promotion.
+    expect(tracker.record('t1', 128)).toBe(false)
+    expect(tracker.isBusy('t1')).toBe(false)
+  })
+})

--- a/tests/unit/webgl-attach-scheduler.test.ts
+++ b/tests/unit/webgl-attach-scheduler.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi, beforeEach, afterEach } from 'vitest'
+
+import {
+  WebglAttachScheduler,
+  WEBGL_ATTACH_IDLE_TIMEOUT_MS,
+  WEBGL_ATTACH_MIN_GAP_MS
+} from '../../src/renderer/src/services/webglAttachScheduler'
+
+describe('WebglAttachScheduler', () => {
+  let now = 0
+  let attached: string[]
+  /** Stands in for "alive, on screen and without a context yet". */
+  let eligible: Set<string>
+
+  const makeScheduler = (): WebglAttachScheduler =>
+    new WebglAttachScheduler({
+      attach: (id) => attached.push(id),
+      canAttach: (id) => eligible.has(id),
+      now: () => now
+    })
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    now = 0
+    attached = []
+    eligible = new Set(['a', 'b'])
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('never attaches synchronously', () => {
+    const scheduler = makeScheduler()
+    scheduler.schedule('a')
+    // The whole point: ~300ms of native context creation must not run inline.
+    expect(attached).toEqual([])
+    vi.advanceTimersByTime(1)
+    expect(attached).toEqual(['a'])
+  })
+
+  it('does not queue an attach for an ineligible terminal', () => {
+    const scheduler = makeScheduler()
+    eligible.clear()
+    scheduler.schedule('a')
+    expect(scheduler.isPending('a')).toBe(false)
+    vi.advanceTimersByTime(5000)
+    expect(attached).toEqual([])
+  })
+
+  it('re-checks eligibility when the deferred callback runs', () => {
+    const scheduler = makeScheduler()
+    scheduler.schedule('a')
+    eligible.delete('a')
+    vi.advanceTimersByTime(5000)
+    expect(attached).toEqual([])
+  })
+
+  it('drops a queued attach on cancel', () => {
+    const scheduler = makeScheduler()
+    scheduler.schedule('a')
+    expect(scheduler.isPending('a')).toBe(true)
+    scheduler.cancel('a')
+    expect(scheduler.isPending('a')).toBe(false)
+    vi.advanceTimersByTime(5000)
+    expect(attached).toEqual([])
+  })
+
+  it('does not queue an attach for every tab flicked past', () => {
+    const scheduler = makeScheduler()
+    // Two busy sessions switched between rapidly: each is scheduled as it comes
+    // on screen, then cancelled as it's hidden before the idle slot arrives.
+    for (let i = 0; i < 5; i++) {
+      scheduler.schedule('a')
+      scheduler.cancel('a')
+      scheduler.schedule('b')
+      scheduler.cancel('b')
+    }
+    vi.advanceTimersByTime(5000)
+    expect(attached).toEqual([])
+  })
+
+  it('spaces simultaneous promotions apart instead of stacking them', () => {
+    const scheduler = makeScheduler()
+    scheduler.schedule('a')
+    scheduler.schedule('b')
+
+    vi.advanceTimersByTime(1)
+    expect(attached).toEqual(['a'])
+
+    now += WEBGL_ATTACH_MIN_GAP_MS - 1
+    vi.advanceTimersByTime(WEBGL_ATTACH_MIN_GAP_MS - 1)
+    expect(attached).toEqual(['a'])
+
+    now += 2
+    vi.advanceTimersByTime(2)
+    expect(attached).toEqual(['a', 'b'])
+  })
+
+  it('is idempotent while an attach is already pending', () => {
+    const scheduler = makeScheduler()
+    scheduler.schedule('a')
+    scheduler.schedule('a')
+    scheduler.schedule('a')
+    vi.advanceTimersByTime(5000)
+    expect(attached).toEqual(['a'])
+  })
+
+  it('cancels a gap-delayed retry', () => {
+    const scheduler = makeScheduler()
+    scheduler.schedule('a')
+    scheduler.schedule('b')
+    vi.advanceTimersByTime(1)
+    expect(attached).toEqual(['a'])
+
+    // 'b' is now waiting out the gap rather than sitting in an idle callback.
+    expect(scheduler.isPending('b')).toBe(true)
+    scheduler.cancel('b')
+    now += WEBGL_ATTACH_MIN_GAP_MS * 2
+    vi.advanceTimersByTime(WEBGL_ATTACH_MIN_GAP_MS * 2)
+    expect(attached).toEqual(['a'])
+  })
+
+  it('can be scheduled again after a cancelled attach', () => {
+    const scheduler = makeScheduler()
+    scheduler.schedule('a')
+    scheduler.cancel('a')
+    vi.advanceTimersByTime(5000)
+    expect(attached).toEqual([])
+
+    scheduler.schedule('a')
+    vi.advanceTimersByTime(1)
+    expect(attached).toEqual(['a'])
+  })
+})
+
+// jsdom has no requestIdleCallback, so the suite above exercises the setTimeout
+// fallback. Production Electron always takes the idle path, and the two branches
+// hand back different cancel closures — so it gets its own tests.
+describe('WebglAttachScheduler on the requestIdleCallback path', () => {
+  let queued: { id: number; run: () => void; timeout?: number }[]
+  let cancelled: number[]
+  let nextHandle: number
+
+  beforeEach(() => {
+    queued = []
+    cancelled = []
+    nextHandle = 1
+    vi.stubGlobal('requestIdleCallback', (run: () => void, options?: { timeout?: number }) => {
+      const id = nextHandle++
+      queued.push({ id, run, timeout: options?.timeout })
+      return id
+    })
+    vi.stubGlobal('cancelIdleCallback', (handle: number) => {
+      cancelled.push(handle)
+      queued = queued.filter((q) => q.id !== handle)
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('defers through requestIdleCallback with a bounded timeout', () => {
+    const attached: string[] = []
+    const scheduler = new WebglAttachScheduler({
+      attach: (id) => attached.push(id),
+      canAttach: () => true
+    })
+
+    scheduler.schedule('a')
+    expect(queued).toHaveLength(1)
+    expect(queued[0].timeout).toBe(WEBGL_ATTACH_IDLE_TIMEOUT_MS)
+    expect(attached).toEqual([])
+
+    queued[0].run()
+    expect(attached).toEqual(['a'])
+  })
+
+  it('cancels through cancelIdleCallback, not clearTimeout', () => {
+    const attached: string[] = []
+    const scheduler = new WebglAttachScheduler({
+      attach: (id) => attached.push(id),
+      canAttach: () => true
+    })
+
+    scheduler.schedule('a')
+    const handle = queued[0].id
+    scheduler.cancel('a')
+
+    expect(cancelled).toEqual([handle])
+    expect(queued).toHaveLength(0)
+    expect(scheduler.isPending('a')).toBe(false)
+    expect(attached).toEqual([])
+  })
+})

--- a/tests/unit/webgl-renderer-pool.test.ts
+++ b/tests/unit/webgl-renderer-pool.test.ts
@@ -1,0 +1,379 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  MAX_ATTACH_FAILURES,
+  MAX_CONTEXT_LOSSES,
+  WebglRendererPool,
+  type WebglAddonLike
+} from '../../src/renderer/src/services/webglRenderer'
+
+// A stand-in for @xterm/addon-webgl's WebglAddon. Real WebGL2 contexts aren't
+// available under jsdom, and the pool's contract (LRU capping, context-loss
+// fallback, give-up budgets) is what actually needs covering.
+class FakeAddon implements WebglAddonLike {
+  disposed = false
+  lossListener: (() => void) | null = null
+  lossSubscriptionDisposed = false
+
+  dispose(): void {
+    this.disposed = true
+  }
+
+  onContextLoss(listener: () => void): { dispose(): void } {
+    this.lossListener = listener
+    return {
+      dispose: () => {
+        this.lossSubscriptionDisposed = true
+      }
+    }
+  }
+
+  /** Simulate the GPU dropping this addon's context. */
+  loseContext(): void {
+    this.lossListener?.()
+  }
+}
+
+function makePool(
+  maxContexts = 3,
+  isPinned?: (terminalId: string) => boolean,
+  onContextLost?: (terminalId: string) => void
+): {
+  pool: WebglRendererPool<FakeAddon>
+  created: FakeAddon[]
+  loaded: FakeAddon[]
+} {
+  const created: FakeAddon[] = []
+  const loaded: FakeAddon[] = []
+  const pool = new WebglRendererPool<FakeAddon>(
+    () => {
+      const addon = new FakeAddon()
+      created.push(addon)
+      return addon
+    },
+    maxContexts,
+    isPinned,
+    onContextLost
+  )
+  return { pool, created, loaded }
+}
+
+const load =
+  (loaded: FakeAddon[]) =>
+  (addon: FakeAddon): void => {
+    loaded.push(addon)
+  }
+
+describe('WebglRendererPool attachment', () => {
+  it('creates and loads an addon on first attach', () => {
+    const { pool, created, loaded } = makePool()
+    expect(pool.attach('t1', load(loaded))).toBe(true)
+    expect(created).toHaveLength(1)
+    expect(loaded).toEqual(created)
+    expect(pool.hasContext('t1')).toBe(true)
+  })
+
+  it('is idempotent — re-attaching does not create a second context', () => {
+    const { pool, created, loaded } = makePool()
+    pool.attach('t1', load(loaded))
+    pool.attach('t1', load(loaded))
+    pool.attach('t1', load(loaded))
+    expect(created).toHaveLength(1)
+    expect(pool.size).toBe(1)
+  })
+
+  it('reports the number of live contexts', () => {
+    const { pool, loaded } = makePool()
+    pool.attach('a', load(loaded))
+    pool.attach('b', load(loaded))
+    expect(pool.size).toBe(2)
+  })
+})
+
+// WebGL contexts are a scarce browser-wide resource and DPlex can have far more
+// terminals than the browser will keep alive. The pool caps them itself so the
+// browser never silently kills one behind our back.
+describe('WebglRendererPool LRU capping', () => {
+  it('never exceeds the context cap', () => {
+    const { pool, loaded } = makePool(3)
+    for (const id of ['a', 'b', 'c', 'd', 'e']) pool.attach(id, load(loaded))
+    expect(pool.size).toBe(3)
+  })
+
+  it('evicts the least-recently-attached terminal and disposes its addon', () => {
+    const { pool, created, loaded } = makePool(2)
+    pool.attach('a', load(loaded))
+    pool.attach('b', load(loaded))
+    pool.attach('c', load(loaded))
+
+    expect(pool.hasContext('a')).toBe(false)
+    expect(pool.hasContext('b')).toBe(true)
+    expect(pool.hasContext('c')).toBe(true)
+    expect(created[0].disposed).toBe(true)
+    expect(created[0].lossSubscriptionDisposed).toBe(true)
+  })
+
+  it('re-attaching refreshes recency so an in-use terminal is not evicted', () => {
+    const { pool, loaded } = makePool(2)
+    pool.attach('a', load(loaded))
+    pool.attach('b', load(loaded))
+    // Showing 'a' again makes 'b' the least recently used.
+    pool.attach('a', load(loaded))
+    pool.attach('c', load(loaded))
+
+    expect(pool.hasContext('a')).toBe(true)
+    expect(pool.hasContext('b')).toBe(false)
+    expect(pool.hasContext('c')).toBe(true)
+  })
+
+  it('never evicts the terminal that was just attached', () => {
+    const { pool, loaded } = makePool(1)
+    pool.attach('a', load(loaded))
+    pool.attach('b', load(loaded))
+    expect(pool.hasContext('b')).toBe(true)
+    expect(pool.size).toBe(1)
+  })
+})
+
+// A lost context can't be revived — the addon must be dropped so xterm falls
+// back to its DOM renderer, and the terminal re-acquires one when next shown.
+describe('WebglRendererPool context loss', () => {
+  it('drops the addon when the context is lost', () => {
+    const { pool, created, loaded } = makePool()
+    pool.attach('t1', load(loaded))
+    created[0].loseContext()
+
+    expect(pool.hasContext('t1')).toBe(false)
+    expect(created[0].disposed).toBe(true)
+  })
+
+  it('re-acquires a fresh context on the next attach', () => {
+    const { pool, created, loaded } = makePool()
+    pool.attach('t1', load(loaded))
+    created[0].loseContext()
+    expect(pool.attach('t1', load(loaded))).toBe(true)
+    expect(created).toHaveLength(2)
+  })
+
+  it('gives up on a terminal after repeated losses', () => {
+    const { pool, created, loaded } = makePool()
+    for (let i = 0; i < MAX_CONTEXT_LOSSES; i++) {
+      pool.attach('t1', load(loaded))
+      created[created.length - 1].loseContext()
+    }
+    expect(pool.attach('t1', load(loaded))).toBe(false)
+    expect(created).toHaveLength(MAX_CONTEXT_LOSSES)
+  })
+
+  it('does not disable WebGL globally — losses are normal driver behavior', () => {
+    const { pool, created, loaded } = makePool()
+    for (let i = 0; i < MAX_CONTEXT_LOSSES; i++) {
+      pool.attach('t1', load(loaded))
+      created[created.length - 1].loseContext()
+    }
+    expect(pool.isUnavailable).toBe(false)
+    expect(pool.attach('other', load(loaded))).toBe(true)
+  })
+})
+
+describe('WebglRendererPool attach failures', () => {
+  it('returns false and disposes the addon when loading throws', () => {
+    const created: FakeAddon[] = []
+    const pool = new WebglRendererPool<FakeAddon>(() => {
+      const addon = new FakeAddon()
+      created.push(addon)
+      return addon
+    })
+    const boom = (): void => {
+      throw new Error('WebGL2 not supported')
+    }
+    expect(pool.attach('t1', boom)).toBe(false)
+    expect(created[0].disposed).toBe(true)
+    expect(pool.hasContext('t1')).toBe(false)
+  })
+
+  it('tolerates a transient failure without writing off WebGL', () => {
+    const { pool, loaded } = makePool()
+    const boom = (): void => {
+      throw new Error('element detached')
+    }
+    pool.attach('t1', boom)
+    expect(pool.isUnavailable).toBe(false)
+    expect(pool.attach('t2', load(loaded))).toBe(true)
+  })
+
+  it('stops retrying once failures indicate WebGL is unavailable', () => {
+    const { pool, loaded } = makePool()
+    const boom = (): void => {
+      throw new Error('WebGL2 not supported')
+    }
+    for (let i = 0; i < MAX_ATTACH_FAILURES; i++) pool.attach(`t${i}`, boom)
+    expect(pool.isUnavailable).toBe(true)
+    expect(pool.attach('fresh', load(loaded))).toBe(false)
+  })
+
+  it('survives a throwing addon factory', () => {
+    const pool = new WebglRendererPool<FakeAddon>(() => {
+      throw new Error('no constructor')
+    })
+    expect(() => pool.attach('t1', vi.fn())).not.toThrow()
+    expect(pool.attach('t1', vi.fn())).toBe(false)
+  })
+})
+
+describe('WebglRendererPool release and forget', () => {
+  it('release disposes both the addon and its loss subscription', () => {
+    const { pool, created, loaded } = makePool()
+    pool.attach('t1', load(loaded))
+    pool.release('t1')
+    expect(created[0].disposed).toBe(true)
+    expect(created[0].lossSubscriptionDisposed).toBe(true)
+    expect(pool.size).toBe(0)
+  })
+
+  it('release is safe for an unknown terminal', () => {
+    const { pool } = makePool()
+    expect(() => pool.release('nope')).not.toThrow()
+  })
+
+  it('isolates a throwing dispose so the context is still dropped', () => {
+    const pool = new WebglRendererPool<FakeAddon>(() => {
+      const addon = new FakeAddon()
+      addon.dispose = (): void => {
+        throw new Error('dispose boom')
+      }
+      return addon
+    })
+    pool.attach('t1', vi.fn())
+    expect(() => pool.release('t1')).not.toThrow()
+    expect(pool.hasContext('t1')).toBe(false)
+  })
+
+  it('forget clears the failure budget so a reused id starts fresh', () => {
+    const { pool, created, loaded } = makePool()
+    for (let i = 0; i < MAX_CONTEXT_LOSSES; i++) {
+      pool.attach('t1', load(loaded))
+      created[created.length - 1].loseContext()
+    }
+    expect(pool.attach('t1', load(loaded))).toBe(false)
+    pool.forget('t1')
+    expect(pool.attach('t1', load(loaded))).toBe(true)
+  })
+
+  it('forget releases a live context', () => {
+    const { pool, created, loaded } = makePool()
+    pool.attach('t1', load(loaded))
+    pool.forget('t1')
+    expect(created[0].disposed).toBe(true)
+    expect(pool.size).toBe(0)
+  })
+})
+
+describe('WebglRendererPool pinned terminals', () => {
+  it('evicts unpinned terminals before pinned ones, even if the pinned one is older', () => {
+    const pinned = new Set(['t1'])
+    const { pool, created, loaded } = makePool(2, (id) => pinned.has(id))
+
+    pool.attach('t1', load(loaded)) // pinned, oldest
+    pool.attach('t2', load(loaded)) // unpinned
+    pool.attach('t3', load(loaded)) // overflows the cap of 2
+
+    // Plain LRU would drop t1; the pin predicate must spare it and drop t2.
+    expect(pool.hasContext('t1')).toBe(true)
+    expect(pool.hasContext('t2')).toBe(false)
+    expect(pool.hasContext('t3')).toBe(true)
+    expect(created[1]?.disposed).toBe(true)
+  })
+
+  it('falls back to evicting pinned terminals when every candidate is pinned', () => {
+    const { pool, created, loaded } = makePool(2, () => true)
+
+    pool.attach('t1', load(loaded))
+    pool.attach('t2', load(loaded))
+    pool.attach('t3', load(loaded))
+
+    // The cap is a hard limit — with nothing unpinned to give up, the least
+    // recently used pinned context goes rather than exceeding the browser's
+    // WebGL context budget.
+    expect(pool.size).toBe(2)
+    expect(pool.hasContext('t1')).toBe(false)
+    expect(created[0]?.disposed).toBe(true)
+    expect(pool.hasContext('t2')).toBe(true)
+    expect(pool.hasContext('t3')).toBe(true)
+  })
+
+  it('treats a re-attach as recent use when choosing an unpinned victim', () => {
+    const pinned = new Set<string>()
+    const { pool, loaded } = makePool(2, (id) => pinned.has(id))
+
+    pool.attach('t1', load(loaded))
+    pool.attach('t2', load(loaded))
+    pool.attach('t1', load(loaded)) // refresh recency of t1
+    pool.attach('t3', load(loaded))
+
+    expect(pool.hasContext('t2')).toBe(false)
+    expect(pool.hasContext('t1')).toBe(true)
+    expect(pool.hasContext('t3')).toBe(true)
+  })
+})
+
+describe('WebglRendererPool attach-failure budget', () => {
+  it('resets the failure count after a successful attach so transient errors do not latch', () => {
+    const { pool } = makePool()
+    const boom = (): void => {
+      throw new Error('transient WebGL failure')
+    }
+    const ok = (): void => {}
+
+    // Fail just short of the global give-up threshold...
+    for (let i = 0; i < MAX_ATTACH_FAILURES - 1; i++) {
+      expect(pool.attach(`bad${i}`, boom)).toBe(false)
+    }
+    expect(pool.isUnavailable).toBe(false)
+
+    // ...then succeed, which should clear the tally.
+    expect(pool.attach('good', ok)).toBe(true)
+
+    // A fresh run of failures must now be needed to disable WebGL globally.
+    for (let i = 0; i < MAX_ATTACH_FAILURES - 1; i++) {
+      expect(pool.attach(`later${i}`, boom)).toBe(false)
+      expect(pool.isUnavailable).toBe(false)
+    }
+    expect(pool.attach('final', boom)).toBe(false)
+    expect(pool.isUnavailable).toBe(true)
+  })
+})
+
+describe('WebglRendererPool context-loss notification', () => {
+  it('tells the owner when a terminal falls back to the DOM renderer', () => {
+    const lost: string[] = []
+    const { pool, created, loaded } = makePool(3, undefined, (id) => lost.push(id))
+    pool.attach('a', load(loaded))
+    expect(lost).toEqual([])
+
+    created[0].loseContext()
+
+    // Without this the terminal stays on the slow DOM renderer until the user
+    // happens to switch away and back — on the very pane they're watching.
+    expect(lost).toEqual(['a'])
+    expect(pool.hasContext('a')).toBe(false)
+  })
+
+  it('does not report deliberate evictions as context loss', () => {
+    const lost: string[] = []
+    const { pool, loaded } = makePool(1, undefined, (id) => lost.push(id))
+    pool.attach('a', load(loaded))
+    pool.attach('b', load(loaded))
+
+    expect(pool.hasContext('a')).toBe(false)
+    expect(lost).toEqual([])
+  })
+
+  it('does not report an explicit release as context loss', () => {
+    const lost: string[] = []
+    const { pool, loaded } = makePool(3, undefined, (id) => lost.push(id))
+    pool.attach('a', load(loaded))
+    pool.forget('a')
+    expect(lost).toEqual([])
+  })
+})


### PR DESCRIPTION
Heavy AI sessions could freeze the whole UI — especially when switching away from and back to a busy tab, or when two Copilot CLI sessions were resuming at once.

## Root causes

1. **`@xterm/addon-webgl` was a declared dependency but never imported.** `git log -S"WebglAddon" --all` confirms it was never used, despite the README claiming otherwise. Every terminal used xterm's DOM renderer — a `<span>` per style-run per row, every frame — on the same thread React renders on.
2. **Inactive tabs were hidden with `visibility: hidden`.** xterm pauses its render loop via an `IntersectionObserver`, and `visibility: hidden` elements still intersect the viewport. Background sessions never stopped rendering.
3. **Re-show flushed a deferred resize plus a full refresh** against a 10k-line scrollback in one synchronous task.

## Changes

- **`WebglRendererPool`** — LRU-capped GPU contexts (browsers cap live WebGL contexts), two-pass eviction that never evicts a visible terminal, a context-loss budget with DOM fallback, and re-scheduling on loss.
- **`RenderLoadTracker`** — only promote a terminal to the GPU once it exceeds 64KB in a 1s window.
- **`WebglAttachScheduler`** — defers attach to `requestIdleCallback` (2s timeout), re-checks eligibility on run, and spaces attaches ≥500ms apart.
- **`content-visibility: hidden`** for inactive tabs instead of `visibility: hidden`.
- **Split `isActive` into `isVisible` / `isFocused`.**
- **Guard fits** behind `isTerminalRendered()` / `fitIfVisible()`.
- **Coalesce ResizeObserver fits** into a single rAF.
- **Theme fan-out** moved to one store subscription instead of per-terminal (was O(N²)).

## Why not eager WebGL, and why not `display: none`

Both were tried and measured, and both made things worse:

- **Eager WebGL attach caused a *startup* stall.** A production build showed 330ms + 302ms long tasks, but CPU profiling found only 15ms of JS across 8 seconds — the cost is ~300ms of synchronous *native* work per context (GPU handshake, shader compile, glyph atlas). A/B against a stashed baseline confirmed the regression was self-inflicted. Hence the throughput gate + idle deferral + rate limit. Re-measured: zero long tasks.
- **`display: none` breaks `FitAddon`.** It measures via `getComputedStyle(parentElement)`, not `getBoundingClientRect`. On a `display: none` element Chromium returns the *unresolved* value, so `height: 100%` comes back as the string `"100%"` → `parseInt` → `100`. Fitting a hidden terminal yields ~10×5 cells and forwards that to the PTY, wrecking the AI CLI's layout.

`content-visibility: hidden` was verified in the real app to give both properties: descendants report `isIntersecting: false` (so xterm pauses) while keeping `getClientRects()`, a non-null `offsetParent`, and correctly-resolved pixel dimensions. The trade-off is that geometry can no longer distinguish hidden from shown, so visibility is tracked explicitly via a `visibleTerminals` set.

## Testing

- `tests/unit/webgl-renderer-pool.test.ts`, `terminal-render-load.test.ts`, `webgl-attach-scheduler.test.ts`
- `tests/e2e/gpu-renderer.e2e.spec.ts` — two regression guards: an idle terminal allocates no WebGL context and produces no >100ms long task; and 20 rapid switches between two flooded terminals produce no >200ms long task.
- Typecheck clean; lint clean on all new/changed files (`useTerminal.ts` has one pre-existing error + warning, byte-identical to baseline); 866/867 unit tests pass (the one failure is a pre-existing parallel-load flake in `claude-pidfile-registry.test.ts`, which passes in isolation); 42 e2e pass.

Three rounds of dual-model code review were run; all valid findings were fixed.

## Follow-ups (not in this PR)

A survey of comparable tools (VS Code, `coder/mux`, tmax, Hyper, Tabby, Ghostty, tmux-based agent managers) surfaced further work:

- **Re-slice chunks to ~4–16KB before `term.write()`.** `DataBatcher` is modelled after Hyper's and inherits its `BATCH_MAX_SIZE = 200 * 1024`. xterm's 12ms yield is checked *between* chunks, never inside one, so a 200KB batch is a single uninterruptible parse.
- **Headless VT in the main process** (`@xterm/headless` + `SerializeAddon`) so re-showing a tab replays a ~4KB screen snapshot instead of raw scrollback.
- **Subscribe-on-visible / abort-on-hide** so hidden tabs cost zero renderer bytes (they still parse today).
- **`app.commandLine.appendSwitch('max-active-webgl-contexts', '32')`**, as VS Code ships, which would let the pool cap rise above 8.

